### PR TITLE
Provide .gitattributes file to prevent line endings mix

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
This forces git to store files internally with normalized line endings. When checking out to the working directory, the line endings will be converted according to the local machine settings. On commit, the endings will be normalized in the git's internal storage.