### PR TITLE
Intermediate Language inspection

### DIFF
--- a/Drill4dotNet/Drill4dotNet/CProfilerCallback.cpp
+++ b/Drill4dotNet/Drill4dotNet/CProfilerCallback.cpp
@@ -1,4 +1,6 @@
 #include "pch.h"
+
+#include "OutputUtils.h"
 #include "CProfilerCallback.h"
 #include "ProClient.h"
 
@@ -24,21 +26,21 @@ namespace Drill4dotNet
         {
             if (!g_cb) return;
 
-            g_cb->GetClient().Log() << L"Enter function: " << funcId;
+            g_cb->GetClient().Log() << L"Enter function: " << HexOutput(funcId);
         }
 
         static void __stdcall fn_functionLeave2(FunctionID funcId, UINT_PTR clientData, COR_PRF_FRAME_INFO func, COR_PRF_FUNCTION_ARGUMENT_RANGE* retvalRange)
         {
             if (!g_cb) return;
 
-            g_cb->GetClient().Log() << L"Leave function: " << funcId;
+            g_cb->GetClient().Log() << L"Leave function: " << HexOutput(funcId);
         }
 
         static void __stdcall fn_functionTailcall2(FunctionID funcId, UINT_PTR clientData, COR_PRF_FRAME_INFO func)
         {
             if (!g_cb) return;
 
-            g_cb->GetClient().Log() << L"Tailcall at function: " << funcId;
+            g_cb->GetClient().Log() << L"Tailcall at function: " << HexOutput(funcId);
         }
     } // anonymous namespace
 
@@ -88,7 +90,7 @@ namespace Drill4dotNet
         HRESULT hr = pICorProfilerInfoUnk->QueryInterface(IID_ICorProfilerInfo2, (LPVOID*)&m_corProfilerInfo2);
         if (FAILED(hr))
         {
-            m_pImplClient.Log() << L"Error: " << hr;
+            m_pImplClient.Log() << L"Error: " << HexOutput(hr);
             return hr;
         }
 
@@ -96,7 +98,7 @@ namespace Drill4dotNet
         hr = m_corProfilerInfo2->SetEventMask(eventMask);
         if (FAILED(hr))
         {
-            m_pImplClient.Log() << L"Error: " << hr;
+            m_pImplClient.Log() << L"Error: " << HexOutput(hr);
             return hr;
         }
 
@@ -107,7 +109,7 @@ namespace Drill4dotNet
         if (FAILED(hr))
         {
             g_cb = nullptr;
-            m_pImplClient.Log() << L"Error: " << hr;
+            m_pImplClient.Log() << L"Error: " << HexOutput(hr);
             return hr;
         }
 

--- a/Drill4dotNet/Drill4dotNet/ComWrapperBase.h
+++ b/Drill4dotNet/Drill4dotNet/ComWrapperBase.h
@@ -1,0 +1,137 @@
+#pragma once
+
+#include <winerror.h>
+#include <winnt.h>
+#include <comdef.h>
+
+#include "OutputUtils.h"
+
+namespace Drill4dotNet
+{
+    // Provides error checking for a single COM call.
+    // Returns false in case of an error.
+    // callable : parameterless lambda returning HRESULT.
+    // errorHandler : lambda accepting _com_error.
+    template <typename TCallable, typename TErrorHandler>
+    bool TryCallCom(TCallable callable, const TErrorHandler& errorHandler)
+    {
+        HRESULT result;
+        if (SUCCEEDED(result = callable()))
+        {
+            return true;
+        }
+
+        errorHandler(_com_error(result));
+        return false;
+    }
+
+    // Provides error handling for a single COM call.
+    // Throws _com_error in case of an error.
+    // callable : parameterless lambda returning HRESULT.
+    template <typename TCallable>
+    void CallCom(TCallable callable)
+    {
+        TryCallCom(callable, [](const _com_error error) { throw error; });
+    }
+
+    // Provides error handling and logging capabilities
+    // to classes wrapping COM objects. Derived classes get
+    // per-instance logging context. Their user must provide
+    // the logging object upon construction of such objects.
+    // TLogger: class with methods bool IsLogEnabled()
+    //     and Log(). The second one should provide some
+    //     object allowing to output data with << in the
+    //     same manner as standard output streams do.
+    template <typename TLogger>
+    class ComWrapperBase
+    {
+    private:
+        template <typename TChar>
+        void LogComError(const _com_error& exception, const TChar* detailsFromCaller) const
+        {
+            if (m_logger.IsLogEnabled())
+            {
+                m_logger.Log()
+                    << detailsFromCaller
+                    << " Exception from HRESULT: "
+                    << HexOutput(exception.Error())
+                    << " (" << exception.ErrorMessage() << ")";
+            }
+        }
+
+    protected:
+        // Logger for this instance, each instance has
+        // its own logger, allowing to have per-object context.
+        TLogger m_logger;
+
+        ComWrapperBase(const TLogger logger)
+            : m_logger(logger)
+        {
+        }
+
+        // Makes an error handler for the TrycallCom method.
+        // The handler logs the COM error and throws _com_error.
+        template <typename TChar, size_t length>
+        auto LogAndThrowHandler(const TChar(&detailsFromCaller)[length]) const
+        {
+            return [this, detailsFromCaller](const _com_error exception)
+            {
+                LogComError(exception, detailsFromCaller);
+                throw exception;
+            };
+        }
+
+        // Makes an error handler for the TrycallCom method.
+        // The handler logs the COM error.
+        template <typename TChar, size_t length>
+        auto LogHandler(const TChar(&detailsFromCaller)[length]) const
+        {
+            return [this, detailsFromCaller](const _com_error& exception)
+            {
+                LogComError(exception, detailsFromCaller);
+            };
+        }
+
+        // Provides error handling for a single COM call.
+        // In case of error, logs it and throws _com_error.
+        // callable: lambda without parameters, returning HRESULT.
+        // detailsFromCaller: added to message logged in case of an error.
+        template <typename TCallable, typename TChar, size_t length>
+        void CallComOrThrow(TCallable callable, const TChar(&detailsFromCaller)[length])
+        {
+            Drill4dotNet::TryCallCom(callable, LogAndThrowHandler(detailsFromCaller));
+        }
+
+        // Provides error handling for a single COM call.
+        // In case of error, logs it and throws _com_error.
+        // callable: lambda without parameters, returning HRESULT.
+        // detailsFromCaller: added to message logged in case of an error.
+        template <typename TCallable, typename TChar, size_t length>
+        void CallComOrThrow(TCallable callable, const TChar(&detailsFromCaller)[length]) const
+        {
+            Drill4dotNet::TryCallCom(callable, LogAndThrowHandler(detailsFromCaller));
+        }
+
+        // Provides error handling for a single COM call.
+        // If the call is successful, returns true.
+        // In case of error, logs it and returns false.
+        // callable: lambda without parameters, returning HRESULT.
+        // detailsFromCaller: added to message logged in case of an error.
+        template <typename TCallable, typename TChar, size_t length>
+        bool TryCallCom(TCallable callable, const TChar(&detailsFromCaller)[length])
+        {
+            return Drill4dotNet::TryCallCom(callable, LogHandler(detailsFromCaller));
+        }
+
+        // Provides error handling for a single COM call.
+        // If the call is successful, returns true.
+        // In case of error, logs it and returns false.
+        // callable: lambda without parameters, returning HRESULT.
+        // detailsFromCaller: added to message logged in case of an error.
+        template <typename TCallable, typename TChar, size_t length>
+        bool TryCallCom(TCallable callable, const TChar(&detailsFromCaller)[length]) const
+        {
+            return Drill4dotNet::TryCallCom(callable, LogHandler(detailsFromCaller));
+        }
+    };
+}

--- a/Drill4dotNet/Drill4dotNet/CorProfilerInfo2.h
+++ b/Drill4dotNet/Drill4dotNet/CorProfilerInfo2.h
@@ -1,0 +1,144 @@
+#pragma once
+
+
+#include "framework.h"
+#include "OutputUtils.h"
+#include "ComWrapperBase.h"
+
+namespace Drill4dotNet
+{
+    // Provides logging and error handling capabilities for ICorProfilerInfo2.
+    // TLogger: class with methods bool IsLogEnabled()
+    //     and Log(). The second one should provide some
+    //     object allowing to output data with << in the
+    //     same manner as standard output streams do.
+    template <typename TLogger>
+    class CorProfilerInfo2 : protected ComWrapperBase<TLogger>
+    {
+    private:
+        ATL::CComQIPtr<ICorProfilerInfo2> m_corProfilerInfo2{};
+
+        CorProfilerInfo2(const TLogger logger) : ComWrapperBase(logger)
+        {
+        }
+
+        // Updates m_corProfilerInfo2 with the extracted interface.
+        auto InitCallable(IUnknown* pICorProfilerInfoUnk)
+        {
+            return [&info = m_corProfilerInfo2, &pICorProfilerInfoUnk]()
+            {
+                return pICorProfilerInfoUnk->QueryInterface(
+                    IID_ICorProfilerInfo2,
+                    (LPVOID*)&info);
+            };
+        }
+
+        inline static const wchar_t s_InitError[] { L"Failed to initialize CorProfilerInfo2." };
+
+        // Fills m_corProfilerInfo2. Returns false in case of error.
+        bool TryInit(IUnknown* pICorProfilerInfoUnk)
+        {
+            return this->TryCallCom(InitCallable(pICorProfilerInfoUnk), s_InitError);
+        }
+
+        // Fills m_corProfilerInfo2. Throws in case of error.
+        void Init(IUnknown* pICorProfilerInfoUnk)
+        {
+            this->CallComOrThrow(InitCallable(pICorProfilerInfoUnk), s_InitError);
+        }
+
+        // Wraps ICorProfilerInfo2::SetEventMask.
+        auto SetEventMaskCallable(DWORD eventMask)
+        {
+            return [this, eventMask]()
+            {
+                return m_corProfilerInfo2->SetEventMask(eventMask);
+            };
+        }
+
+        // Wraps ICorProfilerInfo2::SetEnterLeaveFunctionHooks2.
+        auto SetEnterLeaveFunctionHooks2Callable(
+            FunctionEnter2* pFuncEnter,
+            FunctionLeave2* pFuncLeave,
+            FunctionTailcall2* pFuncTailcall)
+        {
+            return [this, pFuncEnter, pFuncLeave, pFuncTailcall]()
+            {
+                return m_corProfilerInfo2->SetEnterLeaveFunctionHooks2(
+                    pFuncEnter,
+                    pFuncLeave,
+                    pFuncTailcall);
+            };
+        }
+
+    public:
+        // Creates wrapper with logging and error handling capabilities.
+        // Throws _com_error in case of an error.
+        // pICorProfilerInfoUnk : should provide ICorProfilerInfo2.
+        // logger : tool to log the exceptions.
+        CorProfilerInfo2(IUnknown* pICorProfilerInfoUnk, const TLogger logger)
+            : CorProfilerInfo2(logger)
+        {
+            Init(pICorProfilerInfoUnk);
+        }
+
+        // Creates wrapper with logging and error handling capabilities.
+        // Returns an empty optional in case of an error.
+        // pICorProfilerInfoUnk : should provide ICorProfilerInfo2.
+        // logger : tool to log the exceptions.
+        static std::optional<CorProfilerInfo2<TLogger>> TryCreate(IUnknown* pICorProfilerInfoUnk, const TLogger logger)
+        {
+            if (CorProfilerInfo2<TLogger> result(logger)
+                ; result.TryInit(pICorProfilerInfoUnk))
+            {
+                return result;
+            }
+
+            return std::nullopt;
+        }
+
+        // Calls ICorProfilerInfo2::SetEventMask with the given mask.
+        // Throws _com_error in case of an error.
+        void SetEventMask(DWORD eventMask)
+        {
+            this->CallComOrThrow(SetEventMaskCallable(eventMask), L"Failed to call CorProfilerInfo2::SetEventMask.");
+        }
+
+        // Calls ICorProfilerInfo2::SetEventMask with the given mask.
+        // Returns false in case of an error.
+        bool TrySetEventMask(DWORD eventMask)
+        {
+            return this->TryCallCom(SetEventMaskCallable(eventMask) , L"Failed to call CorProfilerInfo2::TrySetEventMask.");
+        }
+
+        // Calls ICorProfilerInfo2::SetEnterLeaveFunctionHooks2 with the given parameters.
+        // Throws _com_error in case of an error.
+        void SetEnterLeaveFunctionHooks2(
+            FunctionEnter2* pFuncEnter,
+            FunctionLeave2* pFuncLeave,
+            FunctionTailcall2* pFuncTailcall)
+        {
+            this->CallComOrThrow(
+                SetEnterLeaveFunctionHooks2Callable(
+                    pFuncEnter,
+                    pFuncLeave,
+                    pFuncTailcall),
+                L"Failed to call CorProfilerInfo2::SetEnterLeaveFunctionHooks2.");
+        }
+
+        // Calls ICorProfilerInfo2::SetEnterLeaveFunctionHooks2 with the given parameters.
+        // Returns false in case of an error.
+        bool TrySetEnterLeaveFunctionHooks2(
+            FunctionEnter2* pFuncEnter,
+            FunctionLeave2* pFuncLeave,
+            FunctionTailcall2* pFuncTailcall)
+        {
+            return this->TryCallCom(
+                SetEnterLeaveFunctionHooks2Callable(
+                    pFuncEnter,
+                    pFuncLeave,
+                    pFuncTailcall),
+                L"Failed to call CorProfilerInfo2::TrySetEnterLeaveFunctionHooks2.");
+        }
+    };
+}

--- a/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj
+++ b/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj
@@ -244,6 +244,7 @@
     <ClInclude Include="ProClient.h" />
     <ClInclude Include="Resource.h" />
     <ClInclude Include="targetver.h" />
+    <ClInclude Include="OutputUtils.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="CDrillProfiler.cpp" />

--- a/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj
+++ b/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj
@@ -241,7 +241,9 @@
     <ClInclude Include="dllmain.h" />
     <ClInclude Include="Drill4dotNet_i.h" />
     <ClInclude Include="framework.h" />
+    <ClInclude Include="FunctionInfo.h" />
     <ClInclude Include="LogBuffer.h" />
+    <ClInclude Include="MetaDataImport2.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="ProClient.h" />
     <ClInclude Include="Resource.h" />

--- a/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj
+++ b/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj
@@ -235,6 +235,8 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="CDrillProfiler.h" />
+    <ClInclude Include="ComWrapperBase.h" />
+    <ClInclude Include="CorProfilerInfo2.h" />
     <ClInclude Include="CProfilerCallback.h" />
     <ClInclude Include="dllmain.h" />
     <ClInclude Include="Drill4dotNet_i.h" />

--- a/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj.filters
+++ b/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj.filters
@@ -52,6 +52,12 @@
     <ClInclude Include="OutputUtils.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="CorProfilerInfo2.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ComWrapperBase.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Drill4dotNet.cpp">

--- a/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj.filters
+++ b/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj.filters
@@ -49,6 +49,9 @@
     <ClInclude Include="LogBuffer.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="OutputUtils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Drill4dotNet.cpp">

--- a/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj.filters
+++ b/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj.filters
@@ -55,7 +55,13 @@
     <ClInclude Include="CorProfilerInfo2.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="FunctionInfo.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="ComWrapperBase.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="MetaDataImport2.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Drill4dotNet/Drill4dotNet/FunctionInfo.h
+++ b/Drill4dotNet/Drill4dotNet/FunctionInfo.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "framework.h"
+
+namespace Drill4dotNet
+{
+    struct FunctionInfo
+    {
+        ClassID classId;
+        ModuleID moduleId;
+        mdToken token;
+    };
+}

--- a/Drill4dotNet/Drill4dotNet/LogBuffer.h
+++ b/Drill4dotNet/Drill4dotNet/LogBuffer.h
@@ -5,13 +5,34 @@
 
 namespace Drill4dotNet
 {
+    // Wrapper for another stream. Adds a line break each time
+    // when a set of << operators is over. All instances are
+    // temporary and forbidden to be stored in variables.
+    // Example:
+    // auto f() { return LogBuffer(std::cout); }
+    //
+    // void main()
+    // {
+    //     f() << "Hello, " << "world";
+    //     // Line break inserted to the output;
+    //     f() << 1 << 2 << 3;
+    //     // Another line break inserted to the output;
+    // }
     template <typename TStream>
     class LogBuffer
     {
     private:
+        // It is safe to have a reference here.
+        // This class is neither copyable not moveable.
+        // An instance cannot live longer than the expression,
+        // which created it, is being executed - because
+        // temporary objects are not deleted in the middle of
+        // an expression.
         TStream& m_output;
         std::wostringstream m_buffer{};
     public:
+        // Creates a new instance.
+        // output : the target stream.
         explicit LogBuffer(TStream& output)
             : m_output(output)
         {
@@ -22,8 +43,11 @@ namespace Drill4dotNet
             m_output << m_buffer.str() << std::endl;
         }
 
-        LogBuffer(LogBuffer&&) = default;
-        LogBuffer& operator=(LogBuffer&&) = default;
+        // This class should not be neither copyable nor moveable.
+        // Otherwise, it is possible to keer the instance after
+        // the expression, which created it, is finished.
+        // In this case it is possible that the m_output reference
+        // to become stale.
         LogBuffer(const LogBuffer&) = delete;
         LogBuffer& operator=(const LogBuffer&) = delete;
 
@@ -35,6 +59,8 @@ namespace Drill4dotNet
         }
     };
 
+    // Makes an output tool, which automatically adds
+    // a line break at the end of series of << operators.
     inline LogBuffer<std::wostream> LogStdout()
     {
         return LogBuffer<std::wostream>(std::wcout);

--- a/Drill4dotNet/Drill4dotNet/MetaDataImport2.h
+++ b/Drill4dotNet/Drill4dotNet/MetaDataImport2.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include "framework.h"
+#include "OutputUtils.h"
+#include "FunctionInfo.h"
+#include "ComWrapperBase.h"
+
+namespace Drill4dotNet
+{
+    // Provides logging and error handling capabilities for IMetaDataImport2.
+    // TLogger: class with methods bool IsLogEnabled()
+    //     and Log(). The second one should provide some
+    //     object allowing to output data with << in the
+    //     same manner as standard output streams do.
+    template <typename TLogger>
+    class MetaDataImport2 : protected ComWrapperBase<TLogger>
+    {
+    private:
+        ATL::CComQIPtr<IMetaDataImport2, &IID_IMetaDataImport2> m_metaDataImport2{};
+
+    public:
+        // Captures IID_IMetaDataImport2 object allowing safe access to its methods.
+        // metaDataImport2: the IID_IMetaDataImport2 object, which allows accessing
+        //     information on classes and methods
+        // logger: tool to log the exceptions.
+        MetaDataImport2(
+            ATL::CComQIPtr<IMetaDataImport2, &IID_IMetaDataImport2> metaDataImport2,
+            TLogger logger)
+            : ComWrapperBase(logger),
+            m_metaDataImport2(metaDataImport2)
+        {
+        }
+
+        // Gets the name of the method with IID_IMetaDataImport2::GetMethodProps.
+        // Throws _com_error in case of error.
+        // methodMetadataToken : points to the method
+        std::wstring GetMethodName(const mdToken methodMetadataToken) const
+        {
+            try
+            {
+                ULONG actualLength;
+                CallComOrThrow([this, methodMetadataToken, &actualLength]()
+                {
+                    return m_metaDataImport2->GetMethodProps(
+                        methodMetadataToken,
+                        nullptr,
+                        nullptr,
+                        0,
+                        &actualLength,
+                        nullptr,
+                        nullptr,
+                        nullptr,
+                        nullptr,
+                        nullptr);
+                }, L"MetadataImport2::GetMethodName: Failed to retrieve the length of the method name");
+
+                if (actualLength == 0)
+                {
+                    return std::wstring{};
+                }
+
+                std::wstring result(actualLength, L'\0');
+                CallComOrThrow([this, methodMetadataToken, &result, actualLength]()
+                {
+                    ULONG dummy;
+                    return m_metaDataImport2->GetMethodProps(
+                        methodMetadataToken,
+                        nullptr,
+                        result.data(),
+                        actualLength,
+                        &dummy,
+                        nullptr,
+                        nullptr,
+                        nullptr,
+                        nullptr,
+                        nullptr);
+                }, L"MetadataImport2::GetMethodName: Failed to retrieve the characters of the method name");
+
+                TrimTrailingNull(result);
+                return result;
+            }
+            catch (const _com_error&)
+            {
+                m_logger.Log() << L"MetadataImport2::GetMethodName failed";
+                throw;
+            }
+        }
+    };
+}

--- a/Drill4dotNet/Drill4dotNet/OutputUtils.h
+++ b/Drill4dotNet/Drill4dotNet/OutputUtils.h
@@ -1,0 +1,140 @@
+#pragma once
+
+#include <ostream>
+#include <ios>
+#include <iomanip>
+#include <optional>
+
+namespace Drill4dotNet
+{
+    // RAII wrapper to save and restore settings
+    // of a stream.
+    // Usage:
+    // void f()
+    // {
+    //     StreamFlagsSaveRestore storedFlags { std::cout }; // settings stored
+    //     std::cout << std::setw(8) << std::setfill('0') << 42; // stream state changed
+    //     // here, storedFlags will restore the settings
+    // }
+    // 
+    // // Will type 00000042 42
+    // void main()
+    // {
+    //     f();
+    //     std::cout << " " << 42;
+    // }
+    template <typename T>
+    class StreamFlagsSaveRestore
+    {
+    private:
+        T& m_stream;
+        std::ios_base::fmtflags m_flags;
+
+    public:
+        // Stores the format setting of the given stream
+        // into the instance being created.
+        // stream : the underlying object should be live
+        //     all the time the new instance will live.
+        StreamFlagsSaveRestore(T& stream)
+            : m_stream(stream), m_flags(stream.flags())
+        {
+        }
+
+        // Restores the target stream status
+        ~StreamFlagsSaveRestore()
+        {
+            m_stream.flags(m_flags);
+        }
+
+        // Copy operations are forbidden because they do
+        // not make any sense.
+        StreamFlagsSaveRestore(const StreamFlagsSaveRestore&) = delete;
+        StreamFlagsSaveRestore& operator=(const StreamFlagsSaveRestore&) = delete;
+    };
+
+    // Tool to put a number in the hex form to a stream.
+    // Pads the value with zeros on the left.
+    // Does not affect the output settings of other values.
+    // Parameters:
+    // width : Number of characters to output, optional
+    // Usage:
+    // void main()
+    // {
+    //     // Types: 0x10 == 16
+    //     std::cout << "0x" << HexOutput(16) << " == " << 16;
+    //
+    //     // Types: 0x0010
+    //     std::cout << "0x" << HexOutput<int, 4>(16);
+    // }
+    template <typename T, size_t width = 2 * sizeof(T)>
+    class HexOutput
+    {
+    private:
+        const T& m_value;
+    public:
+        // Puts a number in the fixed-width hex form to a stream.
+        // Pads the value with zeros on the left, Does not affect
+        // the output settings of other values. Usage:
+        // void main()
+        // {
+        //     // Types: 0x10 == 16
+        //     std::cout << "0x" << HexOutput(16) << " == " << 16;
+        //
+        //     // Types: 0x0010
+        //     std::cout << "0x" << HexOutput<int, 4>(16);
+        // }
+        explicit HexOutput(const T& value) noexcept
+            : m_value(value)
+        {
+        }
+
+        // Temporarily changes the format settings of the target stream,
+        // to output the value in the desired format.
+        template <typename TChar>
+        friend std::basic_ostream<TChar>& operator<<(std::basic_ostream<TChar>& target, const HexOutput& value)
+        {
+            StreamFlagsSaveRestore restoreStreamOnExit { target };
+
+            target
+                << std::hex
+                << std::uppercase
+                << std::setw(width)
+                << std::setfill(L'0')
+                << value.m_value;
+
+            return target;
+        }
+    };
+
+    // Provides support for putting an empty optional<T>
+    // to an output stream.
+    // Writes "std::nullopt".
+    template <typename TChar>
+    std::basic_ostream<TChar>& operator <<(std::basic_ostream<TChar>& target, std::nullopt_t)
+    {
+        // DO NOT "optimize" by removing this function and putting the string to the next operator.
+        // This will cause inconsistency between different usage scenarios.
+
+        target << L"std::nullopt";
+        return target;
+    }
+
+    // Provides support for putting an optional<T>
+    // to an output stream.
+    // Writes the contents of the givan optional.
+    // If the given optional is empty, types a placeholder.
+    template <typename TChar, typename T>
+    std::basic_ostream<TChar>& operator <<(std::basic_ostream<TChar>& target, const std::optional<T>& value)
+    {
+        if (value.has_value())
+        {
+            target << *value;
+        }
+        else
+        {
+            target << std::nullopt;
+        }
+
+        return target;
+    }
+}


### PR DESCRIPTION
Now we have ability to retrieve the Intermediate Language representation of a method being compiled by the CLR machine.
Also includes massive refactoring to make work with COM less painful.