### PR TITLE
Fix Access Violation in CorProfilerCallback2::InitCallable lambda

### DIFF
--- a/Drill4dotNet/Drill4dotNet/CorProfilerInfo2.h
+++ b/Drill4dotNet/Drill4dotNet/CorProfilerInfo2.h
@@ -29,7 +29,7 @@ namespace Drill4dotNet
         // Updates m_corProfilerInfo2 with the extracted interface.
         auto InitCallable(IUnknown* pICorProfilerInfoUnk)
         {
-            return [&info = m_corProfilerInfo2, &pICorProfilerInfoUnk]()
+            return [&info = m_corProfilerInfo2, pICorProfilerInfoUnk]()
             {
                 return pICorProfilerInfoUnk->QueryInterface(
                     IID_ICorProfilerInfo2,
@@ -109,7 +109,7 @@ namespace Drill4dotNet
             LPCBYTE& methodHeader,
             ULONG& methodSize) const
         {
-            return [this, &functionInfo, &methodHeader, &methodSize]()
+            return [this, functionInfo, &methodHeader, &methodSize]()
             {
                 return m_corProfilerInfo2->GetILFunctionBody(
                     functionInfo.moduleId,


### PR DESCRIPTION
Due to wrong mode of closure, the lambda was trying to access a pointer to a destroyed stack frame.
This not appeared on Release, because due to aggressive inlining a stack frame was not created and the final destination was used directly.
If Debug, it started appearing.