### PR TITLE
Preparing to switch to a newer version of interface

### DIFF
--- a/Drill4dotNet/Drill4dotNet/CProfilerCallback.h
+++ b/Drill4dotNet/Drill4dotNet/CProfilerCallback.h
@@ -4,14 +4,14 @@
 #include <type_traits>
 
 #include "LogBuffer.h"
-#include "CorProfilerInfo2.h"
+#include "CorProfilerInfo.h"
 
 namespace Drill4dotNet
 {
     class ProClient;
 
     // Wraps ProClient to make its logging interface
-    // compatible with CorProfilerInfo2.
+    // compatible with CorProfilerInfo.
     class LogToProClient
     {
     private:
@@ -38,7 +38,7 @@ namespace Drill4dotNet
     protected:
         ProClient& m_pImplClient;
         volatile ULONG m_lRef = 0;
-        std::optional<CorProfilerInfo2<LogToProClient>> m_corProfilerInfo2{};
+        std::optional<CorProfilerInfo<LogToProClient>> m_corProfilerInfo{};
     public:
         CProfilerCallback(ProClient& client);
         ProClient& GetClient();

--- a/Drill4dotNet/Drill4dotNet/CorProfilerInfo.h
+++ b/Drill4dotNet/Drill4dotNet/CorProfilerInfo.h
@@ -7,7 +7,7 @@
 #include "OutputUtils.h"
 #include "FunctionInfo.h"
 #include "ComWrapperBase.h"
-#include "MetaDataImport2.h"
+#include "MetaDataImport.h"
 
 namespace Drill4dotNet
 {
@@ -17,19 +17,19 @@ namespace Drill4dotNet
     //     object allowing to output data with << in the
     //     same manner as standard output streams do.
     template <typename TLogger>
-    class CorProfilerInfo2 : protected ComWrapperBase<TLogger>
+    class CorProfilerInfo : protected ComWrapperBase<TLogger>
     {
     private:
-        ATL::CComQIPtr<ICorProfilerInfo2> m_corProfilerInfo2{};
+        ATL::CComQIPtr<ICorProfilerInfo2> m_corProfilerInfo{};
 
-        CorProfilerInfo2(const TLogger logger) : ComWrapperBase(logger)
+        CorProfilerInfo(const TLogger logger) : ComWrapperBase(logger)
         {
         }
 
-        // Updates m_corProfilerInfo2 with the extracted interface.
+        // Updates m_corProfilerInfo with the extracted interface.
         auto InitCallable(IUnknown* pICorProfilerInfoUnk)
         {
-            return [&info = m_corProfilerInfo2, pICorProfilerInfoUnk]()
+            return [&info = m_corProfilerInfo, pICorProfilerInfoUnk]()
             {
                 return pICorProfilerInfoUnk->QueryInterface(
                     IID_ICorProfilerInfo2,
@@ -37,15 +37,15 @@ namespace Drill4dotNet
             };
         }
 
-        inline static const wchar_t s_InitError[] { L"Failed to initialize CorProfilerInfo2." };
+        inline static const wchar_t s_InitError[] { L"Failed to initialize CorProfilerInfo." };
 
-        // Fills m_corProfilerInfo2. Returns false in case of error.
+        // Fills m_corProfilerInfo. Returns false in case of error.
         bool TryInit(IUnknown* pICorProfilerInfoUnk)
         {
             return this->TryCallCom(InitCallable(pICorProfilerInfoUnk), s_InitError);
         }
 
-        // Fills m_corProfilerInfo2. Throws in case of error.
+        // Fills m_corProfilerInfo. Throws in case of error.
         void Init(IUnknown* pICorProfilerInfoUnk)
         {
             this->CallComOrThrow(InitCallable(pICorProfilerInfoUnk), s_InitError);
@@ -56,19 +56,19 @@ namespace Drill4dotNet
         {
             return [this, eventMask]()
             {
-                return m_corProfilerInfo2->SetEventMask(eventMask);
+                return m_corProfilerInfo->SetEventMask(eventMask);
             };
         }
 
         // Wraps ICorProfilerInfo2::SetEnterLeaveFunctionHooks2.
-        auto SetEnterLeaveFunctionHooks2Callable(
+        auto SetEnterLeaveFunctionHooksCallable(
             FunctionEnter2* pFuncEnter,
             FunctionLeave2* pFuncLeave,
             FunctionTailcall2* pFuncTailcall)
         {
             return [this, pFuncEnter, pFuncLeave, pFuncTailcall]()
             {
-                return m_corProfilerInfo2->SetEnterLeaveFunctionHooks2(
+                return m_corProfilerInfo->SetEnterLeaveFunctionHooks2(
                     pFuncEnter,
                     pFuncLeave,
                     pFuncTailcall);
@@ -80,7 +80,7 @@ namespace Drill4dotNet
         {
             return [this, functionId, &result]()
             {
-                return m_corProfilerInfo2->GetFunctionInfo(
+                return m_corProfilerInfo->GetFunctionInfo(
                     functionId,
                     &result.classId,
                     &result.moduleId,
@@ -95,7 +95,7 @@ namespace Drill4dotNet
         {
             return [this, moduleId, &result]()
             {
-                return m_corProfilerInfo2->GetModuleMetaData(
+                return m_corProfilerInfo->GetModuleMetaData(
                     moduleId,
                     CorOpenFlags::ofRead,
                     IID_IMetaDataImport2,
@@ -111,7 +111,7 @@ namespace Drill4dotNet
         {
             return [this, functionInfo, &methodHeader, &methodSize]()
             {
-                return m_corProfilerInfo2->GetILFunctionBody(
+                return m_corProfilerInfo->GetILFunctionBody(
                     functionInfo.moduleId,
                     functionInfo.token,
                     &methodHeader,
@@ -132,8 +132,8 @@ namespace Drill4dotNet
         // Throws _com_error in case of an error.
         // pICorProfilerInfoUnk : should provide ICorProfilerInfo2.
         // logger : tool to log the exceptions.
-        CorProfilerInfo2(IUnknown* pICorProfilerInfoUnk, const TLogger logger)
-            : CorProfilerInfo2(logger)
+        CorProfilerInfo(IUnknown* pICorProfilerInfoUnk, const TLogger logger)
+            : CorProfilerInfo(logger)
         {
             Init(pICorProfilerInfoUnk);
         }
@@ -142,9 +142,9 @@ namespace Drill4dotNet
         // Returns an empty optional in case of an error.
         // pICorProfilerInfoUnk : should provide ICorProfilerInfo2.
         // logger : tool to log the exceptions.
-        static std::optional<CorProfilerInfo2<TLogger>> TryCreate(IUnknown* pICorProfilerInfoUnk, const TLogger logger)
+        static std::optional<CorProfilerInfo<TLogger>> TryCreate(IUnknown* pICorProfilerInfoUnk, const TLogger logger)
         {
-            if (CorProfilerInfo2<TLogger> result(logger)
+            if (CorProfilerInfo<TLogger> result(logger)
                 ; result.TryInit(pICorProfilerInfoUnk))
             {
                 return result;
@@ -160,7 +160,7 @@ namespace Drill4dotNet
             FunctionInfo result;
             this->CallComOrThrow(
                 GetFunctionInfoCallable(functionId, result),
-                L"Failed to call CorProfilerInfo2::GetFunctionInfo.");
+                L"Failed to call CorProfilerInfo::GetFunctionInfo.");
             return result;
         }
 
@@ -171,7 +171,7 @@ namespace Drill4dotNet
             if (FunctionInfo result
                 ; this->TryCallCom(
                     GetFunctionInfoCallable(functionId, result),
-                    L"Failed to call CorProfilerInfo2::TryGetFunctionInfo."))
+                    L"Failed to call CorProfilerInfo::TryGetFunctionInfo."))
             {
                 return result;
             }
@@ -180,40 +180,40 @@ namespace Drill4dotNet
         }
 
         // Calls ICorProfilerInfo2::GetModuleMetadata and creates
-        // a MetadataImport2 wrapper around it.
+        // a MetadataImport wrapper around it.
         // The resulting object will become independent, and because
         // some logging context is required to create it, user of this
         // function must provide loggerForMetadata.
         // Throws _com_error in case of an error.
         template <typename TMetaDataLogger = TLogger>
-        MetaDataImport2<TMetaDataLogger> GetModuleMetadata(
+        MetaDataImport<TMetaDataLogger> GetModuleMetadata(
             const ModuleID moduleId,
             const TMetaDataLogger loggerForMetadata) const
         {
-            ATL::CComQIPtr<IMetaDataImport2, &IID_IMetaDataImport2> metaDataImport2{};
+            ATL::CComQIPtr<IMetaDataImport2, &IID_IMetaDataImport2> metaDataImport{};
             CallComOrThrow(
-                GetModuleMetadataCallable(moduleId, metaDataImport2),
-                L"Failed to call CorProfilerInfo2::GetModuleMetadata.");
-            return MetaDataImport2<TMetaDataLogger>(metaDataImport2, loggerForMetadata);
+                GetModuleMetadataCallable(moduleId, metaDataImport),
+                L"Failed to call CorProfilerInfo::GetModuleMetadata.");
+            return MetaDataImport<TMetaDataLogger>(metaDataImport, loggerForMetadata);
         }
 
         // Calls ICorProfilerInfo2::GetModuleMetadata and creates
-        // a MetadataImport2 wrapper around it.
+        // a MetadataImport wrapper around it.
         // The resulting object will become independent, and because
         // some logging context is required to create it, user of this
         // function must provide loggerForMetadata.
         // Returns an empty optional in case of an error.
         template <typename TMetaDataLogger = TLogger>
-        std::optional<MetaDataImport2<TMetaDataLogger>> TryGetModuleMetadata(
+        std::optional<MetaDataImport<TMetaDataLogger>> TryGetModuleMetadata(
             const ModuleID moduleId,
             const TMetaDataLogger loggerForMetadata) const
         {
-            if (ATL::CComQIPtr<IMetaDataImport2, &IID_IMetaDataImport2> metaDataImport2{}
+            if (ATL::CComQIPtr<IMetaDataImport2, &IID_IMetaDataImport2> metaDataImport{}
                 ; TryCallCom(
-                    GetModuleMetadataCallable(moduleId, metaDataImport2),
-                    L"Failed to call CorProfilerInfo2::TryGetModuleMetadata."))
+                    GetModuleMetadataCallable(moduleId, metaDataImport),
+                    L"Failed to call CorProfilerInfo::TryGetModuleMetadata."))
             {
-                return MetaDataImport2<TMetaDataLogger>(metaDataImport2, loggerForMetadata);
+                return MetaDataImport<TMetaDataLogger>(metaDataImport, loggerForMetadata);
             }
 
             return std::nullopt;
@@ -231,7 +231,7 @@ namespace Drill4dotNet
             }
             catch (const _com_error&)
             {
-                m_logger.Log() << L"CorProfilerInfo2::GetFunctionName failed.";
+                m_logger.Log() << L"CorProfilerInfo::GetFunctionName failed.";
                 throw;
             }
         }
@@ -249,7 +249,7 @@ namespace Drill4dotNet
                     functionInfo,
                     methodHeader,
                     methodSize),
-                L"Failed to call CorProfilerInfo2::GetMethodIntermediateLanguageBody.");
+                L"Failed to call CorProfilerInfo::GetMethodIntermediateLanguageBody.");
 
             return CopyBody(methodHeader, methodSize);
         }
@@ -267,7 +267,7 @@ namespace Drill4dotNet
                     functionInfo,
                     methodHeader,
                     methodSize),
-                L"Failed to call CorProfilerInfo2::TryGetMethodIntermediateLanguageBody."))
+                L"Failed to call CorProfilerInfo::TryGetMethodIntermediateLanguageBody."))
             {
                 return CopyBody(methodHeader, methodSize);
             }
@@ -279,44 +279,44 @@ namespace Drill4dotNet
         // Throws _com_error in case of an error.
         void SetEventMask(DWORD eventMask)
         {
-            this->CallComOrThrow(SetEventMaskCallable(eventMask), L"Failed to call CorProfilerInfo2::SetEventMask.");
+            this->CallComOrThrow(SetEventMaskCallable(eventMask), L"Failed to call CorProfilerInfo::SetEventMask.");
         }
 
         // Calls ICorProfilerInfo2::SetEventMask with the given mask.
         // Returns false in case of an error.
         bool TrySetEventMask(DWORD eventMask)
         {
-            return this->TryCallCom(SetEventMaskCallable(eventMask) , L"Failed to call CorProfilerInfo2::TrySetEventMask.");
+            return this->TryCallCom(SetEventMaskCallable(eventMask) , L"Failed to call CorProfilerInfo::TrySetEventMask.");
         }
 
         // Calls ICorProfilerInfo2::SetEnterLeaveFunctionHooks2 with the given parameters.
         // Throws _com_error in case of an error.
-        void SetEnterLeaveFunctionHooks2(
+        void SetEnterLeaveFunctionHooks(
             FunctionEnter2* pFuncEnter,
             FunctionLeave2* pFuncLeave,
             FunctionTailcall2* pFuncTailcall)
         {
             this->CallComOrThrow(
-                SetEnterLeaveFunctionHooks2Callable(
+                SetEnterLeaveFunctionHooksCallable(
                     pFuncEnter,
                     pFuncLeave,
                     pFuncTailcall),
-                L"Failed to call CorProfilerInfo2::SetEnterLeaveFunctionHooks2.");
+                L"Failed to call CorProfilerInfo::SetEnterLeaveFunctionHooks.");
         }
 
         // Calls ICorProfilerInfo2::SetEnterLeaveFunctionHooks2 with the given parameters.
         // Returns false in case of an error.
-        bool TrySetEnterLeaveFunctionHooks2(
+        bool TrySetEnterLeaveFunctionHooks(
             FunctionEnter2* pFuncEnter,
             FunctionLeave2* pFuncLeave,
             FunctionTailcall2* pFuncTailcall)
         {
             return this->TryCallCom(
-                SetEnterLeaveFunctionHooks2Callable(
+                SetEnterLeaveFunctionHooksCallable(
                     pFuncEnter,
                     pFuncLeave,
                     pFuncTailcall),
-                L"Failed to call CorProfilerInfo2::TrySetEnterLeaveFunctionHooks2.");
+                L"Failed to call CorProfilerInfo::TrySetEnterLeaveFunctionHooks.");
         }
     };
 }

--- a/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj
+++ b/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj
@@ -236,14 +236,14 @@
   <ItemGroup>
     <ClInclude Include="CDrillProfiler.h" />
     <ClInclude Include="ComWrapperBase.h" />
-    <ClInclude Include="CorProfilerInfo2.h" />
+    <ClInclude Include="CorProfilerInfo.h" />
     <ClInclude Include="CProfilerCallback.h" />
     <ClInclude Include="dllmain.h" />
     <ClInclude Include="Drill4dotNet_i.h" />
     <ClInclude Include="framework.h" />
     <ClInclude Include="FunctionInfo.h" />
     <ClInclude Include="LogBuffer.h" />
-    <ClInclude Include="MetaDataImport2.h" />
+    <ClInclude Include="MetaDataImport.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="ProClient.h" />
     <ClInclude Include="Resource.h" />

--- a/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj.filters
+++ b/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj.filters
@@ -52,7 +52,7 @@
     <ClInclude Include="OutputUtils.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="CorProfilerInfo2.h">
+    <ClInclude Include="CorProfilerInfo.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="FunctionInfo.h">
@@ -61,7 +61,7 @@
     <ClInclude Include="ComWrapperBase.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="MetaDataImport2.h">
+    <ClInclude Include="MetaDataImport.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Drill4dotNet/Drill4dotNet/MetaDataImport.h
+++ b/Drill4dotNet/Drill4dotNet/MetaDataImport.h
@@ -13,21 +13,21 @@ namespace Drill4dotNet
     //     object allowing to output data with << in the
     //     same manner as standard output streams do.
     template <typename TLogger>
-    class MetaDataImport2 : protected ComWrapperBase<TLogger>
+    class MetaDataImport : protected ComWrapperBase<TLogger>
     {
     private:
-        ATL::CComQIPtr<IMetaDataImport2, &IID_IMetaDataImport2> m_metaDataImport2{};
+        ATL::CComQIPtr<IMetaDataImport2, &IID_IMetaDataImport2> m_metaDataImport{};
 
     public:
         // Captures IID_IMetaDataImport2 object allowing safe access to its methods.
-        // metaDataImport2: the IID_IMetaDataImport2 object, which allows accessing
+        // metaDataImport: the IID_IMetaDataImport2 object, which allows accessing
         //     information on classes and methods
         // logger: tool to log the exceptions.
-        MetaDataImport2(
-            ATL::CComQIPtr<IMetaDataImport2, &IID_IMetaDataImport2> metaDataImport2,
+        MetaDataImport(
+            ATL::CComQIPtr<IMetaDataImport2, &IID_IMetaDataImport2> metaDataImport,
             TLogger logger)
             : ComWrapperBase(logger),
-            m_metaDataImport2(metaDataImport2)
+            m_metaDataImport(metaDataImport)
         {
         }
 
@@ -41,7 +41,7 @@ namespace Drill4dotNet
                 ULONG actualLength;
                 CallComOrThrow([this, methodMetadataToken, &actualLength]()
                 {
-                    return m_metaDataImport2->GetMethodProps(
+                    return m_metaDataImport->GetMethodProps(
                         methodMetadataToken,
                         nullptr,
                         nullptr,
@@ -52,7 +52,7 @@ namespace Drill4dotNet
                         nullptr,
                         nullptr,
                         nullptr);
-                }, L"MetadataImport2::GetMethodName: Failed to retrieve the length of the method name");
+                }, L"IMetadataImport2::GetMethodName, 1-st call: Failed to retrieve the length of the method name");
 
                 if (actualLength == 0)
                 {
@@ -63,7 +63,7 @@ namespace Drill4dotNet
                 CallComOrThrow([this, methodMetadataToken, &result, actualLength]()
                 {
                     ULONG dummy;
-                    return m_metaDataImport2->GetMethodProps(
+                    return m_metaDataImport->GetMethodProps(
                         methodMetadataToken,
                         nullptr,
                         result.data(),
@@ -74,14 +74,14 @@ namespace Drill4dotNet
                         nullptr,
                         nullptr,
                         nullptr);
-                }, L"MetadataImport2::GetMethodName: Failed to retrieve the characters of the method name");
+                }, L"IMetadataImport2::GetMethodName, 2-nd call: Failed to retrieve the characters of the method name");
 
                 TrimTrailingNull(result);
                 return result;
             }
             catch (const _com_error&)
             {
-                m_logger.Log() << L"MetadataImport2::GetMethodName failed";
+                m_logger.Log() << L"MetadataImport::GetMethodName failed";
                 throw;
             }
         }


### PR DESCRIPTION
Preparing to switch to a newer version of interface: renamed own classes, objects, and methods without mentioning specific version of interfaces behind. It would minimize changes in future.
