### PR TITLE
Add ability to inject code into method bodies

### DIFF
--- a/Drill4dotNet/Drill4dotNet/DefineOpCodesGeneratorSpecializations.h
+++ b/Drill4dotNet/Drill4dotNet/DefineOpCodesGeneratorSpecializations.h
@@ -1,0 +1,99 @@
+
+// Designed to use together with opcode.def from the .net source.
+// The opcode.def calls OPDEF macro for each Intermediate Language
+// instruction, allowing to generate desired declarations.
+// Unfortunately, the list includes some artificial entries, like CEE_ILLEGAL.
+// This file provides means to exclude such entries.
+// User of this class defines macro OPDEF_REAL_INSTRUCTION the same way as the was
+// defining OPDEF. Then he writes:
+//     #include "DefineOpCodesGeneratorSpecializations.h"
+//     #include <opcode.def>
+//     #include "UnDefineOpCodesGeneratorSpecializations.h"
+// and this will only invoke OPDEF_REAL_INSTRUCTION for real instructions.
+
+#ifndef OPDEF_SPECIALIZATIONS_DEFINED
+
+#define OPDEF_LENGTH_SPECIALIZATION_0(\
+    canonicalName, \
+    stringName, \
+    stackPop, \
+    stackPush, \
+    inlineArgumentType, \
+    operationKind, \
+    codeLength, \
+    byte1, \
+    byte2, \
+    controlBehavior) 
+
+#define OPDEF_LENGTH_SPECIALIZATION_1(\
+    canonicalName, \
+    stringName, \
+    stackPop, \
+    stackPush, \
+    inlineArgumentType, \
+    operationKind, \
+    codeLength, \
+    byte1, \
+    byte2, \
+    controlBehavior) \
+OPDEF_REAL_INSTRUCTION(\
+    canonicalName, \
+    stringName, \
+    stackPop, \
+    stackPush, \
+    inlineArgumentType, \
+    operationKind, \
+    codeLength, \
+    byte1, \
+    byte2, \
+    controlBehavior) 
+
+#define OPDEF_LENGTH_SPECIALIZATION_2(\
+    canonicalName, \
+    stringName, \
+    stackPop, \
+    stackPush, \
+    inlineArgumentType, \
+    operationKind, \
+    codeLength, \
+    byte1, \
+    byte2, \
+    controlBehavior) \
+OPDEF_REAL_INSTRUCTION(\
+    canonicalName, \
+    stringName, \
+    stackPop, \
+    stackPush, \
+    inlineArgumentType, \
+    operationKind, \
+    codeLength, \
+    byte1, \
+    byte2, \
+    controlBehavior) 
+
+#define OPDEF( \
+    canonicalName, \
+    stringName, \
+    stackPop, \
+    stackPush, \
+    inlineArgumentType, \
+    operationKind, \
+    codeLength, \
+    byte1, \
+    byte2, \
+    controlBehavior) \
+OPDEF_LENGTH_SPECIALIZATION_ ## codeLength (\
+    canonicalName, \
+    stringName, \
+    stackPop, \
+    stackPush, \
+    inlineArgumentType, \
+    operationKind, \
+    codeLength, \
+    byte1, \
+    byte2, \
+    controlBehavior)
+
+#define OPDEF_SPECIALIZATIONS_DEFINED
+
+#endif

--- a/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj
+++ b/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj
@@ -234,6 +234,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="MethodBody.h" />
     <ClInclude Include="OpCodes.h" />
     <ClInclude Include="CDrillProfiler.h" />
     <ClInclude Include="ComWrapperBase.h" />
@@ -287,6 +288,7 @@
       </PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="InfoHandler.cpp" />
+    <ClCompile Include="MethodBody.cpp" />
     <ClCompile Include="OpCodes.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>

--- a/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj
+++ b/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj
@@ -235,6 +235,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="MethodBody.h" />
+    <ClInclude Include="MethodMalloc.h" />
     <ClInclude Include="OpCodes.h" />
     <ClInclude Include="CDrillProfiler.h" />
     <ClInclude Include="ComWrapperBase.h" />

--- a/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj
+++ b/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj
@@ -246,11 +246,13 @@
     <ClInclude Include="InfoHandler.h" />
     <ClInclude Include="LogBuffer.h" />
     <ClInclude Include="MetaDataImport.h" />
+    <ClInclude Include="DefineOpCodesGeneratorSpecializations.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="ProClient.h" />
     <ClInclude Include="Resource.h" />
     <ClInclude Include="targetver.h" />
     <ClInclude Include="OutputUtils.h" />
+    <ClInclude Include="UnDefineOpCodesGeneratorSpecializations.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="CDrillProfiler.cpp" />

--- a/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj
+++ b/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj
@@ -234,6 +234,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="OpCodes.h" />
     <ClInclude Include="CDrillProfiler.h" />
     <ClInclude Include="ComWrapperBase.h" />
     <ClInclude Include="CorProfilerInfo.h" />
@@ -284,6 +285,7 @@
       </PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="InfoHandler.cpp" />
+    <ClCompile Include="OpCodes.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>

--- a/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj.filters
+++ b/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj.filters
@@ -76,6 +76,9 @@
     <ClInclude Include="UnDefineOpCodesGeneratorSpecializations.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="MethodBody.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Drill4dotNet.cpp">
@@ -103,6 +106,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="OpCodes.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="MethodBody.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj.filters
+++ b/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj.filters
@@ -79,6 +79,9 @@
     <ClInclude Include="MethodBody.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="MethodMalloc.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Drill4dotNet.cpp">

--- a/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj.filters
+++ b/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj.filters
@@ -67,6 +67,9 @@
     <ClInclude Include="InfoHandler.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="OpCodes.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Drill4dotNet.cpp">
@@ -91,6 +94,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="InfoHandler.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="OpCodes.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj.filters
+++ b/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj.filters
@@ -70,6 +70,12 @@
     <ClInclude Include="OpCodes.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="DefineOpCodesGeneratorSpecializations.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="UnDefineOpCodesGeneratorSpecializations.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Drill4dotNet.cpp">

--- a/Drill4dotNet/Drill4dotNet/MethodBody.cpp
+++ b/Drill4dotNet/Drill4dotNet/MethodBody.cpp
@@ -1,0 +1,233 @@
+#include "pch.h"
+#include "MethodBody.h"
+
+#include <array>
+
+// The TARGET_* defines are only needed for <opinfo.cpp>
+#ifdef _M_AMD64
+#define TARGET_AMD64
+#else
+#define TARGET_X86
+#endif
+
+#include <opinfo.cpp>
+
+#ifdef _M_AMD64
+#undef TARGET_AMD64
+#else
+#undef TARGET_X86
+#endif
+
+#if defined(_DEBUG)
+
+// The <opinfo.cpp> requires this function to be defined, have to add a stub.
+static void DbgAssertDialog(const char* szFile, int iLine, const char* szExpr)
+{
+}
+
+#endif
+
+namespace Drill4dotNet
+{
+    template <typename TArgument>
+    auto ConvertArgument(const OpArgsVal argument)
+    {
+        if constexpr (std::is_same_v<TArgument, OpCodeArgumentType::InlineNone>)
+        {
+            return std::monostate{};
+        }
+        else if constexpr (
+            std::is_same_v<TArgument, OpCodeArgumentType::ShortInlineR>
+            || std::is_same_v<TArgument, OpCodeArgumentType::InlineR>)
+        {
+            return static_cast<TArgument>(argument.r);
+        }
+        else if constexpr (
+            std::is_same_v<TArgument, OpCodeArgumentType::InlineI8>)
+        {
+            return static_cast<TArgument>(argument.i8);
+        }
+        else if constexpr (
+            std::is_same_v<TArgument, OpCodeArgumentType::InlineSwitch>)
+        {
+            auto begin = (int32_t*)(argument.switch_.targets);
+            auto end = begin + argument.switch_.count;
+            return std::vector<int32_t>(begin, end);
+        }
+        else if constexpr (
+            std::is_same_v<TArgument, OpCodeArgumentType::InlinePhi>)
+        {
+            auto begin = (uint16_t*)(argument.phi.vars);
+            auto end = begin + argument.phi.count;
+            return std::vector<uint16_t>(begin, end);
+        }
+        else
+        {
+            return static_cast<TArgument>(argument.i);
+        }
+    }
+
+    MethodBody::MethodBody(const std::vector<std::byte>& bodyBytes)
+    {
+        if ((bodyBytes[0] & s_TinyHeaderFlagsMask) == s_TinyHeaderFlag)
+        { // tiny header
+            m_flags = static_cast<uint16_t>(bodyBytes[0] & s_TinyHeaderFlagsMask);
+            m_headerSize = sizeof(std::byte);
+            m_maxStack = std::nullopt;
+            m_codeSize = static_cast<uint32_t>(bodyBytes[0] & s_TinyHeaderSizeMask) >> 2;
+            m_localVariables = std::nullopt;
+        }
+        else
+        { // fat header
+            const IMAGE_COR_ILMETHOD_FAT& fatHeader
+                = *reinterpret_cast<const IMAGE_COR_ILMETHOD_FAT*>(bodyBytes.data());
+            m_flags = fatHeader.Flags;
+            m_headerSize = static_cast<uint8_t>(sizeof(uint32_t) * fatHeader.Size);
+            m_maxStack = static_cast<uint16_t>(fatHeader.MaxStack);
+            m_codeSize = fatHeader.CodeSize;
+            m_localVariables = fatHeader.LocalVarSigTok == 0
+                ? std::optional<uint32_t>(std::nullopt) : fatHeader.LocalVarSigTok;
+            m_fatHeaderRemainder.assign(
+                bodyBytes.cbegin() + sizeof(fatHeader),
+                bodyBytes.cbegin() + m_headerSize);
+        }
+
+        m_instructions = Decompile(
+            bodyBytes,
+            m_headerSize,
+            m_codeSize);
+    }
+
+    std::vector<OpCodeVariant> MethodBody::Decompile(
+        const std::vector<std::byte>& bodyBytes,
+        uint8_t headerSize,
+        const uint32_t codeSize)
+    {
+        // Uses
+        // const BYTE* OpInfo::fetch(const BYTE * instrPtr, OpArgsVal * args)
+        OpInfo parser{};
+        std::vector<OpCodeVariant> result{};
+        const auto begin = reinterpret_cast<const BYTE*>(bodyBytes.data() + headerSize);
+        const auto end = begin + codeSize;
+        auto currentInstruction{ begin };
+        while (currentInstruction < end)
+        {
+            OpArgsVal inlineArguments;
+            currentInstruction = parser.fetch(
+                currentInstruction,
+                &inlineArguments);
+            switch (parser.getOpcode())
+            {
+#define OPDEF_REAL_INSTRUCTION( \
+    canonicalName, \
+    stringName, \
+    stackPop, \
+    stackPush, \
+    inlineArgumentType, \
+    operationKind, \
+    codeLength, \
+    byte1, \
+    byte2, \
+    controlBehavior) \
+            case opcode_t:: ## canonicalName : \
+            { \
+                result.push_back( OpCodeVariant ( \
+                    OpCodeVariant::InstructionCode { std::byte { byte1 }, std::byte {byte2} }, \
+                    OpCodeVariant::VariantType(ConvertArgument<OpCodeArgumentType :: ## inlineArgumentType >(inlineArguments)))); \
+            } \
+\
+            break;
+#include "DefineOpCodesGeneratorSpecializations.h"
+#include <opcode.def>
+#include "UnDefineOpCodesGeneratorSpecializations.h"
+#undef OPDEF_REAL_INSTRUCTION
+            }
+        }
+
+        return result;
+    }
+
+    template <typename T>
+    void AppendAsBytes(std::vector<std::byte>& target, const T& value)
+    {
+        for (const auto b : (std::array<std::byte, sizeof(T)>&)value)
+        {
+            target.push_back(b);
+        }
+    }
+
+    std::vector<std::byte> MethodBody::Compile() const
+    {
+        std::vector<std::byte> result{};
+        result.reserve(m_instructions.size() + m_headerSize); // each instruction takes at least 1 byte, so all this storage will be used
+
+        if (m_headerSize == sizeof(std::byte)) // Dangerous, need to recalculate header type
+        { // tiny header
+            result.push_back(std::byte{ m_flags | m_codeSize << 2 }); // Dangerous, need to recalculate m_codeSize
+        }
+        else
+        { // fat header
+            IMAGE_COR_ILMETHOD_FAT header;
+            header.Flags = m_flags;
+            header.Size = m_headerSize / sizeof(uint32_t); // Dangerous, assert m_headerSize / sizeof(int32_t) == 0
+            header.MaxStack = m_maxStack.value(); // Dangerous, may be std::nullopt
+            header.LocalVarSigTok = m_localVariables.has_value() ? *m_localVariables : 0;
+            header.CodeSize = m_codeSize; // Dangerous, need to recalculate m_codeSize
+
+            AppendAsBytes(result, header);
+            std::copy(
+                m_fatHeaderRemainder.cbegin(),
+                m_fatHeaderRemainder.cend(),
+                std::back_inserter(result));
+        }
+
+        for (const auto& instruction : m_instructions)
+        {
+            instruction.m_code.AppendToVector(result);
+            std::visit(
+                [&result](const auto argument)
+                {
+                    using T = std::remove_cv_t<decltype(argument)>;
+                    if constexpr (std::is_same_v<T, std::monostate>)
+                    {
+                        return;
+                    }
+                    else if constexpr (std::is_same_v<T, OpCodeArgumentType::InlineSwitch>)
+                    {
+                        AppendAsBytes(result, static_cast<uint32_t>(argument.size()));
+                        for (const auto label : argument)
+                        {
+                            AppendAsBytes(result, label);
+                        }
+                    }
+                    else if constexpr (std::is_same_v<T, OpCodeArgumentType::InlinePhi>)
+                    {
+                        AppendAsBytes(result, static_cast<uint8_t>(argument.size()));
+                        for (const auto var : argument)
+                        {
+                            AppendAsBytes(result, var);
+                        }
+                    }
+                    else
+                    {
+                        AppendAsBytes(result, argument);
+                    }
+                },
+                instruction.m_argument);
+        }
+
+        // Dangerous: need to add processing of exception clauses;
+
+        return result;
+    }
+
+    void MethodBody::Insert(
+        const std::vector<OpCodeVariant>::const_iterator position,
+        const OpCodeVariant opcode)
+    {
+        // Dangerous: need to update branching instructions, exceptions handling, and maxstack
+        m_codeSize += opcode.SizeWithArgument();
+        m_instructions.insert(position, opcode);
+    }
+}
+

--- a/Drill4dotNet/Drill4dotNet/MethodBody.h
+++ b/Drill4dotNet/Drill4dotNet/MethodBody.h
@@ -1,0 +1,116 @@
+#pragma once
+
+#include "OpCodes.h"
+
+namespace Drill4dotNet
+{
+    // Object representation of method body bytes.
+    // Allows converting back to bytes representation.
+    // Reference: ECMA-335, Common Language Infrastructure,
+    // part II.25.4 Common Intermediate Language physical layout
+    // https://www.ecma-international.org/publications/files/ECMA-ST/ECMA-335.pdf
+    class MethodBody
+    {
+    private:
+        // 2 bits for tiny header, 12 bits for fat header
+        uint16_t m_flags;
+
+        // Size of header in bytes.
+        // Has value "1" for tiny header, or
+        // value from the fat header (typically 12)
+        uint8_t m_headerSize;
+
+        // fat header only
+        std::optional<uint16_t> m_maxStack;
+
+        // 6 bits for tiny header, 32 bits for fat header
+        uint32_t m_codeSize;
+
+        // 32 bits in fat header only
+        std::optional<uint32_t> m_localVariables;
+
+        // If there were a fat header bigger that the current
+        // standard.
+        std::vector<std::byte> m_fatHeaderRemainder;
+
+        // The parsed instructions.
+        std::vector<OpCodeVariant> m_instructions;
+
+        // Identifies the tiny method header type.
+        inline static const std::byte s_TinyHeaderFlag{ CorILMethod_TinyFormat };
+
+        // Allows to get the flags from the tiny header.
+        inline static const std::byte s_TinyHeaderFlagsMask{ 0b00000011 };
+
+        // Allows to get the instructions size from the tiny header.
+        inline static const std::byte s_TinyHeaderSizeMask{ ~s_TinyHeaderFlagsMask };
+
+        // Parses a byte representation of instructions into a vector.
+        static std::vector<OpCodeVariant> Decompile(
+            const std::vector<std::byte>& bodyBytes,
+            uint8_t headerSize,
+            const uint32_t codeSize);
+
+    public:
+        // Creates the object representation of the method body.
+        // @param bodyBytes : the bytes of method body.
+        explicit MethodBody(const std::vector<std::byte>& bodyBytes);
+
+        // Makes a binary representation of the method body.
+        std::vector<std::byte> Compile() const;
+
+        // Inserts the given instruction into the instructions list.
+        // @param position : the point at which to insert,
+        //    must be in range [begin(), end()]
+        // @param opcode : the instruction to insert.
+        void Insert(
+            const std::vector<OpCodeVariant>::const_iterator position,
+            const OpCodeVariant opcode);
+
+        // Gets the beginning of the instructions list.
+        std::vector<OpCodeVariant>::const_iterator begin() const noexcept
+        {
+            return m_instructions.cbegin();
+        }
+
+        // Gets the ending of the instructions list.
+        std::vector<OpCodeVariant>::const_iterator end() const noexcept
+        {
+            return m_instructions.cend();
+        }
+
+        // Allows printing the instructions to standard streams.
+        template <typename TChar>
+        friend std::basic_ostream<TChar>& operator <<(std::basic_ostream<TChar>& target, const MethodBody& data)
+        {
+            for (const auto& x : data.m_instructions)
+            {
+                x.Visit([&target](const auto opcode)
+                {
+                    using T = std::remove_cv_t<decltype(opcode)>;
+                    target << T::Name();
+
+                    if constexpr (T::HasArgument())
+                    {
+                        target << L" ";
+                        if constexpr (std::is_same_v<T::ArgumentType, OpCodeArgumentType::InlineSwitch>
+                            || std::is_same_v<T::ArgumentType, OpCodeArgumentType::InlinePhi>)
+                        {
+                            const auto& argument = opcode.Argument();
+                            target << InSquareBrackets(argument.size()) << InCurlyBrackets(Delimitered(argument, L", "));
+                        }
+                        else
+                        {
+                            target << opcode.Argument();
+                        }
+                    }
+
+                    target << L";" << std::endl;
+                });
+            }
+
+            return target;
+        }
+    };
+}
+

--- a/Drill4dotNet/Drill4dotNet/MethodMalloc.h
+++ b/Drill4dotNet/Drill4dotNet/MethodMalloc.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include "framework.h"
+#include "ComWrapperBase.h"
+
+namespace Drill4dotNet
+{
+    // Provides logging and error handling capabilities for IMethodMalloc.
+    // TLogger: class with methods bool IsLogEnabled()
+    //     and Log(). The second one should provide some
+    //     object allowing to output data with << in the
+    //     same manner as standard output streams do.
+    template <typename TLogger>
+    class MethodMalloc
+    {
+    private:
+        ATL::CComQIPtr<IMethodMalloc> m_methodMalloc;
+        TLogger m_logger;
+
+        // Getting this from IMethodMalloc::Alloc will mean no space was found
+        // at the address space of the target module.
+        inline static const void* s_AllocFailed { (void*)E_OUTOFMEMORY };
+
+    public:
+        // Captures IMethodMalloc object allowing safe access to its methods.
+        // methodMalloc: the IMethodMalloc object, which allows allocation memory
+        //      for method bodies.
+        MethodMalloc(
+            ATL::CComQIPtr<IMethodMalloc> methodMalloc,
+            TLogger logger)
+            : m_logger(logger),
+            m_methodMalloc(methodMalloc)
+        {
+        }
+
+        // Tries to allocate a memory block of the given size.
+        // Wraps IMethodMalloc::Alloc.
+        // Returns std::nullopt if it could not find space in the target
+        // module's address space.
+        // @param size : the desired size of the resulting memory block.
+        std::optional<void*> TryAlloc(uint32_t size)
+        {
+            void* const result = m_methodMalloc->Alloc(size);
+            if (result == nullptr || result == s_AllocFailed)
+            {
+                if (m_logger.IsLogEnabled())
+                {
+                    m_logger.Log()
+                        << L"MethodAlloc::TryAlloc failed. Could not allocate memory in the target module's address space.";
+                }
+
+                return std::nullopt;
+            }
+
+            return result;
+        }
+
+        // Allocates a memory block of the given size.
+        // Wraps IMethodMalloc::Alloc.
+        // Throws _com_error if it could not find space in the target
+        // module's address space.
+        // @param size : the desired size of the resulting memory block.
+        void* Alloc(uint32_t size)
+        {
+            void* const result = m_methodMalloc->Alloc(size);
+            if (result == nullptr || result == s_AllocFailed)
+            {
+                if (m_logger.IsLogEnabled())
+                {
+                    m_logger.Log()
+                        << L"MethodAlloc::Alloc failed. Could not allocate memory in the target module's address space.";
+                }
+
+                throw _com_error(E_OUTOFMEMORY);
+            }
+
+            return result;
+        }
+    };
+}

--- a/Drill4dotNet/Drill4dotNet/OpCodes.cpp
+++ b/Drill4dotNet/Drill4dotNet/OpCodes.cpp
@@ -57,5 +57,7 @@ namespace Drill4dotNet
 
         target.push_back(SecondByte);
     }
+
+
 }
 

--- a/Drill4dotNet/Drill4dotNet/OpCodes.cpp
+++ b/Drill4dotNet/Drill4dotNet/OpCodes.cpp
@@ -3,5 +3,59 @@
 
 namespace Drill4dotNet
 {
+    OpCodeVariant::OpCodeVariant(
+        InstructionCode code,
+        VariantType argument)
+        : m_code(code),
+        m_argument { argument }
+    {
+    }
+
+    OpCodeVariant::OpCodeVariant()
+        : m_code(OpCodeInstruction<OpCode_CEE_NOP>::Code),
+        m_argument {}
+    {
+    }
+
+    bool OpCodeVariant::HasArgument() const
+    {
+        return !std::holds_alternative<std::monostate>(m_argument);
+    }
+
+    uint32_t OpCodeVariant::SizeWithArgument() const
+    {
+        uint32_t instructionSize { m_code.Size() };
+        return instructionSize + std::visit([](const auto& argument)
+            {
+                using T = std::decay_t<decltype(argument)>;
+                if constexpr (std::is_same_v<T, std::monostate>)
+                {
+                    return static_cast<uint32_t>(0);
+                }
+                else if constexpr (std::is_same_v<T, OpCodeArgumentType::InlinePhi>)
+                {
+                    return static_cast<uint32_t>(argument.size() * sizeof(uint16_t) + sizeof(uint8_t));
+                }
+                else if constexpr (std::is_same_v<T, OpCodeArgumentType::InlineSwitch>)
+                {
+                    return static_cast<uint32_t>(argument.size() * sizeof(int32_t) + sizeof(int32_t));
+                }
+                else
+                {
+                    return static_cast<uint32_t>(sizeof(argument));
+                }
+            },
+            m_argument);
+    }
+
+    void OpCodeVariant::InstructionCode::AppendToVector(std::vector<std::byte>& target) const
+    {
+        if (!IsOneByte())
+        {
+            target.push_back(FirstByte);
+        }
+
+        target.push_back(SecondByte);
+    }
 }
 

--- a/Drill4dotNet/Drill4dotNet/OpCodes.cpp
+++ b/Drill4dotNet/Drill4dotNet/OpCodes.cpp
@@ -1,0 +1,7 @@
+#include "pch.h"
+#include "OpCodes.h"
+
+namespace Drill4dotNet
+{
+}
+

--- a/Drill4dotNet/Drill4dotNet/OpCodes.h
+++ b/Drill4dotNet/Drill4dotNet/OpCodes.h
@@ -219,6 +219,8 @@ namespace Drill4dotNet
     class OpCodeVariant
     {
     private:
+        friend class MethodBody;
+
         // Variant which can store any possible inline argument type,
         // std::monostate is for no inline argument case.
         using VariantType = ParameterPack<

--- a/Drill4dotNet/Drill4dotNet/OpCodes.h
+++ b/Drill4dotNet/Drill4dotNet/OpCodes.h
@@ -1,6 +1,170 @@
 #pragma once
 
+#include <cstdint>
+#include <vector>
+#include <string_view>
+
 namespace Drill4dotNet
 {
+    // Defines possible options for type of
+    // an OpCode inline argument, for reference see
+    // https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.operandtype?view=netframework-4.8
+    class OpCodeArgumentType
+    {
+    public:
+        using InlineNone = void;
+        using InlineVar = uint16_t;
+        using InlineI = int32_t;
+        using InlineR = double;
+        using InlineBrTarget = int32_t;
+        using InlineI8 = int64_t;
+        using InlineMethod = uint32_t;
+        using InlineField = uint32_t;
+        using InlineType = uint32_t;
+        using InlineString = uint32_t;
+        using InlineSig = uint32_t;
+        using InlineRVA = uint32_t;
+        using InlineTok = uint32_t;
+        using InlineSwitch = std::vector<int32_t>;
+        using InlinePhi = std::vector<uint16_t>;
+        using ShortInlineVar = uint8_t;
+        using ShortInlineI = int8_t;
+        using ShortInlineR = float;
+        using ShortInlineBrTarget = int8_t;
+    };
+
+    // Common base class for all opcodes.
+    // Intentionally left empty.
+    // Should only be used for type compatibility checking.
+    class OpCodeTag
+    {
+    };
+
+    // Base class with interface methods for all opcodes.
+    // Not intended for direct usage by clients of the header.
+    // Uses CRTP ( https://www.fluentcpp.com/2017/05/12/curiously-recurring-template-pattern/ )
+    // to provide methods and values specific to the opcode.
+    // Parameters:
+    // TOpCode - the opcode to produce values for.
+    // TOpCodeTemplate - the OpCode for a friend declaration.
+    // TArgument - the type of the OpCode inline argument.
+    template <
+        typename TOpCode,
+        typename TOpCodeTemplate,
+        typename TArgument>
+    class OpCodeBase : public OpCodeTag
+    {
+    private:
+        // The constructor is hidden in the private section,
+        // so only TOpCodeTemplate can inherit this class.
+        OpCodeBase()
+        {
+        }
+
+    public:
+        // The type describing a specific instruction.
+        using OpCodeType = TOpCode;
+
+        // The type of an inline argument.
+        // See OpCodeArgumentType for possible values.
+        using ArgumentType = TArgument;
+
+        // Gets the value indicating whether
+        // the specific instruction has an inline argument.
+        constexpr static bool HasArgument()
+        {
+            return !std::is_same_v<
+                TArgument,
+                OpCodeArgumentType::InlineNone>;
+        }
+
+        // Gets the printable name of the instruction.
+        constexpr static std::wstring_view Name() noexcept
+        {
+            return TOpCode::CanonicalName;
+        }
+
+        friend TOpCodeTemplate;
+    };
+
+    // Base class for instructions with an argument.
+    // Also not intended for direct use by clients of the header.
+    // Also uses CRTP. Parameters:
+    // TOpCode : the specific instruction type.
+    // TArgument : the type of the inline argument.
+    template <typename TOpCode, typename TArgument>
+    class OpCode : public OpCodeBase<
+        TOpCode,
+        OpCode<TOpCode, TArgument>,
+        TArgument>
+    {
+    private:
+        TArgument m_argument;
+
+    public:
+        // Creates a new opcode value with the
+        // given argument.
+        // @param argument : the value to use.
+        OpCode(const TArgument argument)
+            : OpCodeBase(),
+            m_argument{ argument }
+        {
+        }
+
+        // Gets the inline argument.
+        TArgument Argument() const
+        {
+            return m_argument;
+        }
+
+        // Sets the inline argument.
+        // @param argument : the value to set.
+        void SetArgument(TArgument argument)
+        {
+            return m_argument = argument;
+        }
+    };
+
+    // Special case when there is no inline argument.
+    template <typename TOpCode>
+    class OpCode<TOpCode, OpCodeArgumentType::InlineNone> : public OpCodeBase<
+        TOpCode,
+        OpCode<TOpCode, OpCodeArgumentType::InlineNone>,
+        OpCodeArgumentType::InlineNone>
+    {
+    public:
+        OpCode()
+            : OpCodeBase()
+        {
+        }
+    };
+
+    // Using the OPDEF_REAL_INSTRUCTION macro, the next invocation
+    // of <opcode.def> will generate a set of OpCode_* classes, each
+    // corresponding to a specific Intermediate Language instruction.
+
+#define OPDEF_REAL_INSTRUCTION( \
+    canonicalName, \
+    stringName, \
+    stackPop, \
+    stackPush, \
+    inlineArgumentType, \
+    operationKind, \
+    codeLength, \
+    byte1, \
+    byte2, \
+    controlBehavior) \
+    class OpCode_ ## canonicalName : public OpCode<\
+        OpCode_ ## canonicalName , \
+        OpCodeArgumentType:: ## inlineArgumentType > \
+    { \
+    public: \
+        inline static std::wstring_view CanonicalName { L ## stringName }; \
+        using OpCode::OpCode; \
+    };
+#include "DefineOpCodesGeneratorSpecializations.h"
+#include <opcode.def>
+#include "UnDefineOpCodesGeneratorSpecializations.h"
+#undef OPDEF_REAL_INSTRUCTION
 }
 

--- a/Drill4dotNet/Drill4dotNet/OpCodes.h
+++ b/Drill4dotNet/Drill4dotNet/OpCodes.h
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace Drill4dotNet
+{
+}
+

--- a/Drill4dotNet/Drill4dotNet/OpCodes.h
+++ b/Drill4dotNet/Drill4dotNet/OpCodes.h
@@ -3,6 +3,9 @@
 #include <cstdint>
 #include <vector>
 #include <string_view>
+#include <optional>
+#include <variant>
+#include <type_traits>
 
 namespace Drill4dotNet
 {
@@ -166,5 +169,294 @@ namespace Drill4dotNet
 #include <opcode.def>
 #include "UnDefineOpCodesGeneratorSpecializations.h"
 #undef OPDEF_REAL_INSTRUCTION
+
+    // Provides compile-time operations on a set of types.
+    template <typename ...>
+    class ParameterPack;
+
+    // Allows to merge two sets of types.
+    template <typename TPack1, typename TPack2>
+    class Tail;
+
+    // Merging two sets of types: primary specialization.
+    template <typename ... TFirst, typename ... TSecond>
+    class Tail<ParameterPack<TFirst ...>, ParameterPack<TSecond ...>>
+    {
+    public:
+        using Type = typename ParameterPack<TFirst ..., TSecond ...>;
+    };
+
+    // Compile-time operations for 1 type.
+    template <typename T>
+    class ParameterPack<T>
+    {
+    public:
+        // Applies the type to the given template.
+        template <template <typename T> class TTemplate>
+        using Apply = TTemplate<T>;
+
+        // Provides a set of types with removed duplicates.
+        using RemoveDuplicates = typename ParameterPack<T>;
+    };
+
+    // Compile-time operations for 2 or more types.
+    template <typename T, typename T2, typename ... Ts>
+    class ParameterPack<T, T2, Ts...>
+    {
+    public:
+        // Applies the given types to given template.
+        template <template <typename T, typename T2, typename ... Ts> class TTemplate>
+        using Apply = TTemplate<T, T2, Ts ...>;
+
+        // Provides a set of types with duplicates removed.
+        using RemoveDuplicates = typename std::conditional_t <
+            std::is_same_v<T, T2> || ( std::is_same_v<T, Ts> || ... ),
+            typename ParameterPack<T2, Ts ...>::RemoveDuplicates,
+            typename Tail<ParameterPack<T>, typename ParameterPack<T2, Ts ...>::RemoveDuplicates>::Type>;
+    };
+
+    // Stores one of possible Intermediate Language instructions.
+    class OpCodeVariant
+    {
+    private:
+        // Variant which can store any possible inline argument type,
+        // std::monostate is for no inline argument case.
+        using VariantType = ParameterPack<
+            std::monostate,
+            OpCodeArgumentType::InlineBrTarget,
+            OpCodeArgumentType::InlineField,
+            OpCodeArgumentType::InlineI,
+            OpCodeArgumentType::InlineI8,
+            OpCodeArgumentType::InlineMethod,
+            OpCodeArgumentType::InlinePhi,
+            OpCodeArgumentType::InlineR,
+            OpCodeArgumentType::InlineRVA,
+            OpCodeArgumentType::InlineSig,
+            OpCodeArgumentType::InlineString,
+            OpCodeArgumentType::InlineSwitch,
+            OpCodeArgumentType::InlineTok,
+            OpCodeArgumentType::InlineType,
+            OpCodeArgumentType::InlineVar,
+            OpCodeArgumentType::ShortInlineBrTarget,
+            OpCodeArgumentType::ShortInlineI,
+            OpCodeArgumentType::ShortInlineR,
+            OpCodeArgumentType::ShortInlineVar
+        >::RemoveDuplicates::Apply<std::variant>;
+
+        // Represents instruction code. Has maximum 2 bytes,
+        // but some codes can be in 1-byte form.
+        class InstructionCode
+        {
+        private:
+            inline static const std::byte s_OneByteMarker = std::byte(0xFF);
+
+        public:
+            // The first byte. Can be a one-byte form marker.
+            std::byte FirstByte;
+
+            // The second byte.
+            std::byte SecondByte;
+
+            // Gets the value indicating whether this code
+            // can be in 1-byte form.
+            constexpr bool IsOneByte() const
+            {
+                return FirstByte == s_OneByteMarker;
+            }
+
+            // Gets the size of binary representation, in bytes.
+            constexpr uint32_t Size() const
+            {
+                return IsOneByte() ? 1 : 2;
+            }
+
+            // Gets the combined uint16_t value to use in switch-case statements.
+            constexpr uint16_t AsKey() const
+            {
+                return static_cast<uint16_t>(FirstByte) << 8 | static_cast<uint16_t>(SecondByte);
+            }
+
+            // Append the binary representation to the given vector.
+            // @param target : the vector to append to.
+            void AppendToVector(std::vector<std::byte>& target) const;
+
+            // Compares two codes for equality.
+            constexpr bool operator==(const InstructionCode other) const
+            {
+                return FirstByte == other.FirstByte && SecondByte == other.SecondByte;
+            }
+
+            // Compares two codes for inequality.
+            constexpr bool operator!=(const InstructionCode other) const
+            {
+                return !(*this == other);
+            }
+        };
+
+        // Allows to get an instruction code for a
+        // specific OpCode type.
+        // The next call to <opcode.def> will specialize
+        // for each possible instruction.
+        template <typename TOpCode>
+        struct OpCodeInstruction;
+
+#define OPDEF_REAL_INSTRUCTION( \
+    canonicalName, \
+    stringName, \
+    stackPop, \
+    stackPush, \
+    inlineArgumentType, \
+    operationKind, \
+    codeLength, \
+    byte1, \
+    byte2, \
+    controlBehavior) \
+template <> \
+class OpCodeInstruction<OpCode_ ## canonicalName> \
+{ \
+public: \
+    static constexpr InstructionCode Code { std::byte { byte1 }, std::byte { byte2 } }; \
+};
+
+#include "DefineOpCodesGeneratorSpecializations.h"
+#include <opcode.def>
+#include "UnDefineOpCodesGeneratorSpecializations.h"
+#undef OPDEF_REAL_INSTRUCTION
+
+        // Stores the instruction code.
+        InstructionCode m_code;
+
+        // Stores the inline argument.
+        VariantType m_argument;
+
+        // Intended to use from MethodBody.
+        OpCodeVariant(
+            InstructionCode code,
+            VariantType argument);
+
+        // Gets the opcode of the given type,
+        // with the argument stored in this variant.
+        // Does not do any checks, so made private.
+        template <typename TOpCode>
+        TOpCode Get() const
+        {
+            if constexpr (TOpCode::HasArgument())
+            {
+                return TOpCode(std::get<TOpCode::ArgumentType>(m_argument));
+            }
+            else
+            {
+                return TOpCode{};
+            }
+        }
+
+    public:
+        // Constructs a variant holding OpCode_CEE_NOP instruction,
+        // which means no operation.
+        OpCodeVariant();
+
+        // Value indicating whether the given class is a valid OpCode class.
+        template <typename TOpCode>
+        static constexpr bool IsOpCodeClass = std::is_assignable_v<OpCodeTag&, TOpCode>;
+
+        // Constructs the variant holding the given opcode.
+        // @param opCode : instruction to store.
+        template <typename TOpCode, std::enable_if_t<IsOpCodeClass<TOpCode>, int> = 0>
+        OpCodeVariant(const TOpCode opCode)
+            : m_code (OpCodeInstruction<TOpCode>::Code),
+            m_argument{}
+        {
+            if constexpr (TOpCode::HasArgument())
+            {
+                m_argument = opCode.Argument();
+            }
+        }
+
+        // Puts the given opcode into this variant.
+        // @param opCode : the instruction to store.
+        template <typename TOpCode, std::enable_if_t<IsOpCodeClass<TOpCode>, int> = 0>
+        OpCodeVariant& operator=(const TOpCode opCode)
+        {
+            m_code = OpCodeInstruction<TOpCode>::Code;
+            if constexpr (TOpCode::HasArgument())
+            {
+                m_argument = opCode.Argument();
+            }
+            else
+            {
+                m_argument = std::monostate{};
+            }
+
+            return *this;
+        }
+
+        // Gets the value indicating whether the
+        // variant contains an opcode of the given type.
+        // TOpCode : the opcode type to check for.
+        template <typename TOpCode, std::enable_if_t<IsOpCodeClass<TOpCode>, int> = 0>
+        bool HoldsAlternative() const
+        {
+            return m_code == OpCodeInstruction<TOpCode>::Code;
+        }
+
+        // If the variant contains an opcode of the given type,
+        // gets it. std::nullopt otherwise.
+        // TOpCode : the opcode type to check for.
+        template <typename TOpCode, std::enable_if_t<IsOpCodeClass<TOpCode>, int> = 0>
+        std::optional<TOpCode> GetIf() const
+        {
+            if (HoldsAlternative<TOpCode>())
+            {
+                return Get<TOpCode>();
+            }
+            else
+            {
+                return std::nullopt;
+            }
+        }
+
+        // Gets the value indicating whether the opcode
+        // this variant contains has an inline argument.
+        bool HasArgument() const;
+
+        // Gets the size of binary representation of the
+        // opcode this variant contains, including the instruction
+        // code and the inline argument (if any).
+        uint32_t SizeWithArgument() const;
+
+        // Calls the visitor with the instruction this variant contains.
+        // TVisitor must provide overload for each possible OpCode_* class.
+        // This is usually done with a template lambda.
+        // @param : must have method accepting the OpCode_* instance.
+        template <typename TVisitor>
+        void Visit(TVisitor&& visitor) const
+        {
+            switch (m_code.AsKey())
+            {
+#define OPDEF_REAL_INSTRUCTION( \
+    canonicalName, \
+    stringName, \
+    stackPop, \
+    stackPush, \
+    inlineArgumentType, \
+    operationKind, \
+    codeLength, \
+    byte1, \
+    byte2, \
+    controlBehavior) \
+            case InstructionCode { std::byte { byte1 }, std::byte { byte2 } }.AsKey() : \
+            { \
+                visitor(Get< OpCode_ ## canonicalName >()); \
+            } \
+\
+            break;
+
+#include "DefineOpCodesGeneratorSpecializations.h"
+#include <opcode.def>
+#include "UnDefineOpCodesGeneratorSpecializations.h"
+#undef OPDEF_REAL_INSTRUCTION
+            }
+        }
+    };
 }
 

--- a/Drill4dotNet/Drill4dotNet/UnDefineOpCodesGeneratorSpecializations.h
+++ b/Drill4dotNet/Drill4dotNet/UnDefineOpCodesGeneratorSpecializations.h
@@ -1,0 +1,13 @@
+
+// Works in conjuction with OpCodesGeneratorSpecializations.h.
+
+#ifdef OPDEF_SPECIALIZATIONS_DEFINED
+
+#undef OPDEF_LENGTH_SPECIALIZATION_0
+#undef OPDEF_LENGTH_SPECIALIZATION_1
+#undef OPDEF_LENGTH_SPECIALIZATION_2
+#undef OPDEF
+
+#undef OPDEF_SPECIALIZATIONS_DEFINED
+
+#endif

--- a/HelloWorld/HelloWorld/Program.cs
+++ b/HelloWorld/HelloWorld/Program.cs
@@ -6,9 +6,19 @@ namespace HelloWorld
     {
         static void Main(string[] args)
         {
+            MyInjectionTarget();
+
             Console.WriteLine("Hello World!");
             Console.WriteLine("Press Enter.");
             Console.ReadLine();
+        }
+
+        private static void MyInjectionTarget()
+        {
+            int x = 1;
+            int y = 2;
+            int z = x + y;
+            Console.WriteLine(z);
         }
     }
 }

--- a/HelloWorld/HelloWorldFramework/Program.cs
+++ b/HelloWorld/HelloWorldFramework/Program.cs
@@ -10,9 +10,19 @@ namespace HelloWorld
     {
         static void Main(string[] args)
         {
+            MyInjectionTarget();
+
             Console.WriteLine("Hello World!");
             Console.WriteLine("Press Enter.");
             Console.ReadLine();
+        }
+
+        private static void MyInjectionTarget()
+        {
+            int x = 1;
+            int y = 2;
+            int z = x + y;
+            Console.WriteLine(z);
         }
     }
 }


### PR DESCRIPTION
- Introduce `OpCodes.h` and `OpCodes.cpp` to hold the logic
- Introduce the set of `OpCode_*` classes to represent the possible Intermediate Language instructions
- Introduce `OpCodeVariant`, which can hold one of possible `OpCode_*` classes
- Introduce class `MethodBody`, which parses and compiles back the method header and the stream on instructions
- Introduce methods in COM wrappers, to allow code injection
- Make example injection for method `MyInjectionTarget`

References:
- [ECMA-335, Common Language Infrastructure, part II.25.4 Common Intermediate Language physical layout](https://www.ecma-international.org/publications/files/ECMA-ST/ECMA-335.pdf)
- [Documentation for System.Reflection.Emit](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit?view=netframework-4.8), and related articles
