### PR TITLE
Ability to inject code into methods with branching and try-catches

### DIFF
--- a/Drill4dotNet/Drill4dotNet/ByteUtils.h
+++ b/Drill4dotNet/Drill4dotNet/ByteUtils.h
@@ -2,4 +2,36 @@
 
 namespace Drill4dotNet
 {
+    // Gets the value indicating whether
+    // the given numeric value cannot be converted to
+    // another numeric type without an overflow.
+    // Returns true if the overflow happens.
+    // TTarget : the type to which the value is being converted.
+    // TSource : the type of the value.
+    // @param value : the value to check.
+    template <typename TTarget, typename TSource>
+    constexpr bool Overflows(const TSource value) noexcept
+    {
+        constexpr bool sourceSigned{ std::numeric_limits<std::decay_t<TSource>>::is_signed };
+        using Limits = std::numeric_limits<std::decay_t<TTarget>>;
+        constexpr bool targetSigned{ Limits::is_signed };
+
+        if constexpr (sourceSigned ^ targetSigned)
+        {
+            if constexpr (sourceSigned)
+            {
+                if (value < 0)
+                {
+                    return true;
+                }
+            }
+
+            if constexpr (targetSigned)
+            {
+                return value > Limits::max();
+            }
+        }
+
+        return !(Limits::min() <= value && value <= Limits::max());
+    }
 }

--- a/Drill4dotNet/Drill4dotNet/ByteUtils.h
+++ b/Drill4dotNet/Drill4dotNet/ByteUtils.h
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace Drill4dotNet
+{
+}

--- a/Drill4dotNet/Drill4dotNet/ByteUtils.h
+++ b/Drill4dotNet/Drill4dotNet/ByteUtils.h
@@ -1,7 +1,22 @@
 #pragma once
 
+#include <array>
+
 namespace Drill4dotNet
 {
+    // Appends the binary representation of the
+    // given object to the bytes vector.
+    // @param target : the vector to append bytes to.
+    // @param value : the object to extract raw bytes from.
+    template <typename T>
+    void AppendAsBytes(std::vector<std::byte>& target, const T& value)
+    {
+        for (const auto b : (std::array<std::byte, sizeof(T)>&)value)
+        {
+            target.push_back(b);
+        }
+    }
+
     // Gets the value indicating whether
     // the given numeric value cannot be converted to
     // another numeric type without an overflow.

--- a/Drill4dotNet/Drill4dotNet/ByteUtils.h
+++ b/Drill4dotNet/Drill4dotNet/ByteUtils.h
@@ -17,6 +17,25 @@ namespace Drill4dotNet
         }
     }
 
+    // Calculates how far the given iterator must be advanced
+    // to achieve the given byte alignment.
+    // alignment : the alignment in bytes
+    // @param position : the iterator, which must made aligned.
+    // @param vector : the vector of to which the position belongs.
+    template <size_t alignment>
+    ptrdiff_t AdvanceToBoundary(
+        const std::vector<std::byte>::const_iterator position,
+        const std::vector<std::byte>& vector)
+    {
+        ptrdiff_t result = (position - vector.cbegin()) % alignment;
+        if (result == 0)
+        {
+            return result;
+        }
+
+        return alignment - result;
+    }
+
     // Gets the value indicating whether
     // the given numeric value cannot be converted to
     // another numeric type without an overflow.

--- a/Drill4dotNet/Drill4dotNet/CProfilerCallback.cpp
+++ b/Drill4dotNet/Drill4dotNet/CProfilerCallback.cpp
@@ -525,13 +525,9 @@ namespace Drill4dotNet
 
             const auto insertionPosition
             {
-                std::find_if(
+                FindInstruction<OpCode_CEE_CALL>(
                     functionBody.begin(),
-                    functionBody.end(),
-                    [](const OpCodeVariant& variant)
-                    {
-                        return variant.HoldsAlternative<OpCode_CEE_CALL>();
-                    })
+                    functionBody.end())
             };
 
             if (insertionPosition == functionBody.end())

--- a/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj
+++ b/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj
@@ -236,6 +236,7 @@
   <ItemGroup>
     <ClInclude Include="ByteUtils.h" />
     <ClInclude Include="CoreInteract.h" />
+    <ClInclude Include="InstructionStream.h" />
     <ClInclude Include="MethodBody.h" />
     <ClInclude Include="MethodHeader.h" />
     <ClInclude Include="MethodMalloc.h" />
@@ -272,6 +273,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="InfoHandler.cpp" />
+    <ClCompile Include="InstructionStream.cpp" />
     <ClCompile Include="MethodBody.cpp" />
     <ClCompile Include="MethodHeader.cpp" />
     <ClCompile Include="OpCodes.cpp" />

--- a/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj
+++ b/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj
@@ -237,6 +237,7 @@
     <ClInclude Include="ByteUtils.h" />
     <ClInclude Include="CoreInteract.h" />
     <ClInclude Include="InstructionStream.h" />
+    <ClInclude Include="ExceptionClause.h" />
     <ClInclude Include="MethodBody.h" />
     <ClInclude Include="MethodHeader.h" />
     <ClInclude Include="MethodMalloc.h" />
@@ -272,6 +273,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="ExceptionClause.cpp" />
     <ClCompile Include="InfoHandler.cpp" />
     <ClCompile Include="InstructionStream.cpp" />
     <ClCompile Include="MethodBody.cpp" />

--- a/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj
+++ b/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj
@@ -234,6 +234,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="ByteUtils.h" />
     <ClInclude Include="CoreInteract.h" />
     <ClInclude Include="MethodBody.h" />
     <ClInclude Include="MethodMalloc.h" />

--- a/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj
+++ b/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj
@@ -237,6 +237,7 @@
     <ClInclude Include="ByteUtils.h" />
     <ClInclude Include="CoreInteract.h" />
     <ClInclude Include="MethodBody.h" />
+    <ClInclude Include="MethodHeader.h" />
     <ClInclude Include="MethodMalloc.h" />
     <ClInclude Include="OpCodes.h" />
     <ClInclude Include="CDrillProfiler.h" />
@@ -272,6 +273,7 @@
     </ClCompile>
     <ClCompile Include="InfoHandler.cpp" />
     <ClCompile Include="MethodBody.cpp" />
+    <ClCompile Include="MethodHeader.cpp" />
     <ClCompile Include="OpCodes.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>

--- a/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj
+++ b/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj
@@ -238,6 +238,7 @@
     <ClInclude Include="CoreInteract.h" />
     <ClInclude Include="InstructionStream.h" />
     <ClInclude Include="ExceptionClause.h" />
+    <ClInclude Include="ExceptionsSection.h" />
     <ClInclude Include="MethodBody.h" />
     <ClInclude Include="MethodHeader.h" />
     <ClInclude Include="MethodMalloc.h" />
@@ -274,6 +275,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="ExceptionClause.cpp" />
+    <ClCompile Include="ExceptionsSection.cpp" />
     <ClCompile Include="InfoHandler.cpp" />
     <ClCompile Include="InstructionStream.cpp" />
     <ClCompile Include="MethodBody.cpp" />

--- a/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj.filters
+++ b/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj.filters
@@ -94,6 +94,9 @@
     <ClInclude Include="ExceptionClause.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="ExceptionsSection.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="ByteUtils.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -139,6 +142,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="ExceptionClause.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ExceptionsSection.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj.filters
+++ b/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj.filters
@@ -85,6 +85,9 @@
     <ClInclude Include="CoreInteract.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="MethodHeader.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="ByteUtils.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -121,6 +124,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="CorProfilerInfo.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="MethodHeader.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj.filters
+++ b/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj.filters
@@ -85,6 +85,9 @@
     <ClInclude Include="CoreInteract.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="ByteUtils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Drill4dotNet.cpp">

--- a/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj.filters
+++ b/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj.filters
@@ -85,6 +85,9 @@
     <ClInclude Include="CoreInteract.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="InstructionStream.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="MethodHeader.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -124,6 +127,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="CorProfilerInfo.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="InstructionStream.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="MethodHeader.cpp">

--- a/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj.filters
+++ b/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj.filters
@@ -91,6 +91,9 @@
     <ClInclude Include="MethodHeader.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="ExceptionClause.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="ByteUtils.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -133,6 +136,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="MethodHeader.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ExceptionClause.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Drill4dotNet/Drill4dotNet/ExceptionClause.cpp
+++ b/Drill4dotNet/Drill4dotNet/ExceptionClause.cpp
@@ -1,6 +1,164 @@
 #include "pch.h"
 #include "ExceptionClause.h"
+#include <limits>
 
 namespace Drill4dotNet
 {
+    // Maximum size of a protected code block, which can be represented by a small header.
+    const uint8_t s_MaxSmallExceptionClauseCodeSize = std::numeric_limits<uint8_t>::max();
+
+    // Maximum offset of a protected code block, which can be represented by a small header.
+    const uint16_t s_MaxSmallExceptionClauseOffset = std::numeric_limits<uint16_t>::max();
+
+    template <typename THeader>
+    ExceptionClause::ExceptionClause(
+        InstructionStream& target,
+        LabelCreator& labelCreator,
+        const THeader& header)
+        : m_fat{ std::is_same_v<THeader, IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_FAT> },
+        m_flags{ static_cast<CorExceptionFlag>(header.Flags) },
+        m_tryOffset{ CreateLabelAtAbsoluteOffset(
+            target,
+            labelCreator,
+            static_cast<AbsoluteOffset>(header.TryOffset)) },
+        m_tryEndOffset{ CreateLabelAtAbsoluteOffset(
+            target,
+            labelCreator,
+            static_cast<AbsoluteOffset>(header.TryOffset + header.TryLength)) },
+        m_handlerOffset{ CreateLabelAtAbsoluteOffset(
+            target,
+            labelCreator,
+            static_cast<AbsoluteOffset>(header.HandlerOffset)) },
+        m_handlerEndOffset{ CreateLabelAtAbsoluteOffset(
+            target,
+            labelCreator,
+            static_cast<AbsoluteOffset>(header.HandlerOffset + header.HandlerLength)) },
+        m_target{ target }
+    {
+        if ((header.Flags & COR_ILEXCEPTION_CLAUSE_FILTER) != 0)
+        {
+            m_handler = CreateLabelAtAbsoluteOffset(
+                target,
+                labelCreator,
+                static_cast<AbsoluteOffset>(header.FilterOffset));
+        }
+        else
+        {
+            m_handler = mdTypeDef{ header.ClassToken };
+        }
+    }
+
+    ExceptionClause::ExceptionClause(
+        const IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_FAT& header,
+        InstructionStream& target,
+        LabelCreator& labelCreator)
+        : ExceptionClause(
+            target,
+            labelCreator,
+            header)
+    {
+    }
+
+    ExceptionClause::ExceptionClause(
+        const IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_SMALL& header,
+        InstructionStream& target,
+        LabelCreator& labelCreator)
+        : ExceptionClause(
+            target,
+            labelCreator,
+            header)
+    {
+    }
+
+    Label ExceptionClause::CreateLabelAtAbsoluteOffset(
+        InstructionStream& target,
+        LabelCreator& labelCreator,
+        const AbsoluteOffset offset)
+    {
+        const ConstStreamPosition insertionPoint = ResolveAbsoluteOffset(target, offset);
+        if (insertionPoint == target.cend())
+        {
+            throw std::runtime_error("Could not find an instruction by the given absolute offset.");
+        }
+
+        Label result{ labelCreator.CreateLabel() };
+        target.insert(insertionPoint, result);
+        return result;
+    }
+
+    bool ExceptionClause::CanPutToSmallHeader() const
+    {
+        if (m_fat)
+        {
+            return false;
+        }
+
+        return CanPutLabelPairToSmallHeader(m_tryOffset, m_tryEndOffset)
+            && CanPutLabelPairToSmallHeader(m_handlerOffset, m_handlerEndOffset);
+    }
+
+    bool ExceptionClause::CanPutLabelPairToSmallHeader(
+        const Label begin,
+        const Label end) const
+    {
+        const LongJump::Offset beginOffset = CalculateAbsoluteOffset(begin);
+        if (beginOffset > s_MaxSmallExceptionClauseOffset)
+        {
+            return false;
+        }
+
+        const LongJump::Offset endOffset = CalculateAbsoluteOffset(end);
+        return endOffset - beginOffset <= s_MaxSmallExceptionClauseCodeSize;
+    }
+
+    AbsoluteOffset ExceptionClause::CalculateAbsoluteOffset(const Label label) const
+    {
+        const ConstStreamPosition labelPosition { FindLabel(m_target, label) };
+        if (labelPosition == m_target.cend())
+        {
+            throw std::logic_error("Compilation failed: unresolved label.");
+        }
+
+        return Drill4dotNet::CalculateAbsoluteOffset(m_target, labelPosition);
+    }
+
+    template <typename Header>
+    Header ExceptionClause::FillHeader() const
+    {
+        Header result{};
+        result.Flags = m_flags;
+        result.TryOffset = CalculateAbsoluteOffset(m_tryOffset);
+        result.TryLength = CalculateAbsoluteOffset(m_tryEndOffset) - result.TryOffset;
+        result.HandlerOffset = CalculateAbsoluteOffset(m_handlerOffset);
+        result.HandlerLength = CalculateAbsoluteOffset(m_handlerEndOffset) - result.HandlerOffset;
+        return std::visit([&result, this](const auto& exceptionTypeOrFilter)
+        {
+            if constexpr (std::is_same_v<std::decay_t<decltype(exceptionTypeOrFilter)>, Label>)
+            {
+                result.FilterOffset = CalculateAbsoluteOffset(exceptionTypeOrFilter);
+            }
+            else
+            {
+                result.ClassToken = exceptionTypeOrFilter;
+            }
+
+            return result;
+        },
+            m_handler);
+    }
+
+    IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_SMALL ExceptionClause::FillSmallHeader() const
+    {
+        if (!CanPutToSmallHeader())
+        {
+            throw std::logic_error("Cannot put this exception clause to a small header");
+        }
+
+        return FillHeader<IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_SMALL>();
+    }
+
+    IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_FAT ExceptionClause::FillFatHeader() const
+    {
+        return FillHeader<IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_FAT>();
+    }
 }

--- a/Drill4dotNet/Drill4dotNet/ExceptionClause.cpp
+++ b/Drill4dotNet/Drill4dotNet/ExceptionClause.cpp
@@ -1,0 +1,6 @@
+#include "pch.h"
+#include "ExceptionClause.h"
+
+namespace Drill4dotNet
+{
+}

--- a/Drill4dotNet/Drill4dotNet/ExceptionClause.h
+++ b/Drill4dotNet/Drill4dotNet/ExceptionClause.h
@@ -1,5 +1,206 @@
 #pragma once
 
+#include "OpCodes.h"
+#include "InstructionStream.h"
+#include "framework.h"
+
 namespace Drill4dotNet
 {
+    // Represents one try-catch or try-finally block.
+    // Can be constructed from .net api structures and
+    // converted back to them.
+    // Reference: ECMA-335, Common Language Infrastructure,
+    // part II.25.4.6 Exception handling clauses
+    // https://www.ecma-international.org/publications/files/ECMA-ST/ECMA-335.pdf
+    class ExceptionClause
+    {
+    private:
+        // Value indicating whether the instance was
+        // created from a fat structure.
+        bool m_fat;
+
+        // Flags describing whether this is try-catch or try-finally
+        CorExceptionFlag m_flags;
+
+        // Label to the first instruction belonging to the try block
+        Label m_tryOffset;
+
+        // Label to the first instruction after the try block
+        Label m_tryEndOffset;
+
+        // Label to the first instruction of the catch or finally block
+        Label m_handlerOffset;
+
+        // Label to the first instruction after the catch or finally block
+        Label m_handlerEndOffset;
+
+        // mdTypeDef if it is a catch without when clause.
+        // Otherwise, Label to the first instruction of the when filter.
+        std::variant<mdTypeDef, Label> m_handler;
+
+        // The instructions sequence, in which this try-catch or try-finally is used.
+        const InstructionStream& m_target;
+
+        // Adds a new label to the given instruction stream.
+        // @param target : the instruction stream to create label in.
+        // @param labelCreator : tool to emit new labels.
+        // @param offset : absolute offset from the beginning of the target.
+        static Label CreateLabelAtAbsoluteOffset(
+            InstructionStream& target,
+            LabelCreator& labelCreator,
+            const AbsoluteOffset offset);
+
+        // Creates a new instance from the given type of header.
+        // Adds new labels to the target instructions stream.
+        template <typename THeader>
+        ExceptionClause(
+            InstructionStream& target,
+            LabelCreator& labelCreator,
+            const THeader& header);
+
+        // Gets the value indicating whether both
+        // the given labels can be represented by
+        // a small header.
+        // @param begin : the first label to check
+        // @param end : the second label to check
+        bool CanPutLabelPairToSmallHeader(
+            const Label begin,
+            const Label end) const;
+
+        // Calculates the absolute offset.
+        // @param label : the label to calculate offset of.
+        AbsoluteOffset CalculateAbsoluteOffset(const Label label) const;
+
+        // Creates a header of the given type, storing the
+        // information from this instance.
+        template <typename Header>
+        Header FillHeader() const;
+
+    public:
+
+        // Fills a new instance from the given fat header.
+        // @param header : the fat header with the clause information.
+        // @param target : will insert new labels into this instruction stream.
+        // @param labelCreator : tool to emit new labels.
+        ExceptionClause(
+            const IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_FAT& header,
+            InstructionStream& target,
+            LabelCreator& labelCreator);
+
+        // Fills a new instance from the given small header.
+        // @param header : the small header with the clause information.
+        // @param target : will insert new labels into this instruction stream.
+        // @param labelCreator : tool to emit new labels.
+        ExceptionClause(
+            const IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_SMALL& header,
+            InstructionStream& target,
+            LabelCreator& labelCreator);
+
+        // Gets the value indicating whether
+        // this clause can be represented by
+        // a small header.
+        bool CanPutToSmallHeader() const;
+
+        // Creates a small header with information from this instance.
+        // Throws std::logic_error if a fat header must be used.
+        IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_SMALL FillSmallHeader() const;
+
+        // Creates a fat header with information from this instance.
+        IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_FAT FillFatHeader() const;
+
+        // Label to the first instruction belonging to the try block
+        constexpr Label TryOffset() const noexcept
+        {
+            return m_tryOffset;
+        }
+
+        // Label to the first instruction after the try block
+        constexpr Label TryEndOffset() const noexcept
+        {
+            return m_tryEndOffset;
+        }
+
+        // Label to the first instruction of the catch or finally block
+        constexpr Label HandlerOffset() const noexcept
+        {
+            return m_handlerOffset;
+        }
+
+        // Label to the first instruction after the catch or finally block
+        constexpr Label HandlerEndOffset() const noexcept
+        {
+            return m_handlerEndOffset;
+        }
+
+        // mdTypeDef if it is a catch without when clause.
+        // Otherwise, Label to the first instruction of the when filter.
+        constexpr std::variant<mdTypeDef, Label> Handler() const noexcept
+        {
+            return m_handler;
+        }
+
+        // True, if this clause represents try-finally or try-fault.
+        // False, if this clause represents try-catch or try-catch with when.
+        constexpr bool IsFinally() const noexcept
+        {
+            return (m_flags & CorExceptionFlag::COR_ILEXCEPTION_CLAUSE_FINALLY) != 0
+                || (m_flags & CorExceptionFlag::COR_ILEXCEPTION_CLAUSE_FAULT) != 0;
+        }
+
+        // If the given label is the same as boundaries of
+        // protected block or handler block, writes the
+        // boundary description to the given output stream.
+        // @param target : the output stream.
+        // @param maybeBelongsToThisClause : the label which
+        //     possibly the same as TryOffset, TryEndOffset,
+        //     HandlerOffset, or HandlerEndOffset.
+        template <typename TChar>
+        std::basic_ostream<TChar>& WriteTryCatchIfNeeded(
+            std::basic_ostream<TChar>& target,
+            const Label maybeBelongsToThisClause) const
+        {
+            if (TryOffset() == maybeBelongsToThisClause)
+            {
+                target << L"try" << std::endl << L"{" << std::endl;
+            }
+            else if (TryEndOffset() == maybeBelongsToThisClause)
+            {
+                target << L"}" << std::endl;
+            }
+            else if (HandlerOffset() == maybeBelongsToThisClause)
+            {
+                if (IsFinally())
+                {
+                    target << L"finally";
+                }
+                else
+                {
+                    target << L" catch (";
+                    std::visit([&target](const auto& methodOrLabel)
+                        {
+                            if constexpr (std::is_same_v<std::decay_t<decltype(methodOrLabel)>, Label>)
+                            {
+                                target << L"filter ";
+                            }
+                            else
+                            {
+                                target << L"ofType ";
+                            }
+
+                            target << InSquareBrackets(methodOrLabel);
+                        },
+                        Handler());
+                    target << L")";
+                }
+                target << std::endl;
+                target << L"{" << std::endl;
+            }
+            else if (HandlerEndOffset() == maybeBelongsToThisClause)
+            {
+                target << L"}" << std::endl;
+            }
+
+            return target;
+        }
+    };
 }

--- a/Drill4dotNet/Drill4dotNet/ExceptionClause.h
+++ b/Drill4dotNet/Drill4dotNet/ExceptionClause.h
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace Drill4dotNet
+{
+}

--- a/Drill4dotNet/Drill4dotNet/ExceptionsSection.cpp
+++ b/Drill4dotNet/Drill4dotNet/ExceptionsSection.cpp
@@ -1,6 +1,144 @@
 #include "pch.h"
 #include "ExceptionsSection.h"
 
+#include <algorithm>
+
 namespace Drill4dotNet
 {
+    template<typename TSection, typename TClause>
+    void ReadClauses(
+        std::vector<std::byte>::const_iterator& source,
+        const std::vector<std::byte>::const_iterator sourceEnd,
+        InstructionStream& target,
+        LabelCreator& labelCreator,
+        std::vector<ExceptionClause>& clauses)
+    {
+        constexpr size_t clauseSize = sizeof(TClause);
+
+        // same for SMALL and FAT, SMALL has padding for equal header sizes
+        constexpr size_t headerSize = sizeof(IMAGE_COR_ILMETHOD_SECT_FAT);
+
+        if (sourceEnd - source < headerSize)
+        {
+            throw std::runtime_error("Unexpected end of the input in the middle of exception section header");
+        }
+
+        const TSection& sectionHeader = *(reinterpret_cast<const TSection*>(&*source));
+
+        const size_t clausesCount = (sectionHeader.DataSize - headerSize) / clauseSize;
+        if (clausesCount * clauseSize + headerSize != sectionHeader.DataSize)
+        {
+            throw std::runtime_error("Unexpected size of exception section: it does not hold a whole number of exception clauses");
+        }
+
+        if (sourceEnd - source < sectionHeader.DataSize)
+        {
+            throw std::runtime_error("Unexpected end of the input in the middle of exception section clauses");
+        }
+
+        clauses.reserve(clausesCount);
+        source += headerSize;
+        for (size_t i = 0; i != clausesCount; ++i)
+        {
+            const TClause& clause = *(reinterpret_cast<const TClause*>(&*source));
+            source += clauseSize;
+            clauses.emplace_back(
+                clause,
+                target,
+                labelCreator);
+        }
+    }
+
+    ExceptionsSection::ExceptionsSection(
+        std::vector<std::byte>::const_iterator& source,
+        const std::vector<std::byte>::const_iterator sourceEnd,
+        InstructionStream& target,
+        LabelCreator& labelCreator)
+    {
+        if (source == sourceEnd)
+        {
+            throw std::runtime_error("Unexpected end of the input: no exception section header provided");
+        }
+
+        std::byte firstByte { *source };
+        if ((firstByte & std::byte { CorILMethodSect::CorILMethod_Sect_EHTable }) == std::byte{ 0 })
+        {
+            throw std::runtime_error("The data section is not an exception handling section");
+        }
+
+        m_fat = (firstByte & std::byte { CorILMethodSect::CorILMethod_Sect_FatFormat }) != std::byte{ 0 };
+        m_hasMoreSections = (firstByte & std::byte { CorILMethodSect::CorILMethod_Sect_MoreSects }) != std::byte{ 0 };
+        if ((firstByte & ~(std::byte{ CorILMethodSect::CorILMethod_Sect_FatFormat }
+            | std::byte{ CorILMethodSect::CorILMethod_Sect_MoreSects }
+            | std::byte{ CorILMethodSect::CorILMethod_Sect_EHTable })) != std::byte{ 0 })
+        {
+            throw std::runtime_error("Unknown section flags detected");
+        }
+
+        if (m_fat)
+        {
+            ReadClauses<IMAGE_COR_ILMETHOD_SECT_FAT, IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_FAT>(
+                source,
+                sourceEnd,
+                target,
+                labelCreator,
+                m_clauses);
+        }
+        else
+        {
+            ReadClauses<IMAGE_COR_ILMETHOD_SECT_SMALL, IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_SMALL>(
+                source,
+                sourceEnd,
+                target,
+                labelCreator,
+                m_clauses);
+        }
+    }
+
+    void ExceptionsSection::AppendToBytes(std::vector<std::byte>& target) const
+    {
+        CorILMethodSect flags{ CorILMethodSect::CorILMethod_Sect_EHTable };
+        bool shouldBeFat = m_fat || std::any_of(
+            m_clauses.cbegin(),
+            m_clauses.cend(),
+            [](const ExceptionClause& c) { return !c.CanPutToSmallHeader(); });
+
+        if (shouldBeFat)
+        {
+            flags = static_cast<CorILMethodSect>(flags | CorILMethodSect::CorILMethod_Sect_FatFormat);
+        }
+
+        if (m_hasMoreSections)
+        {
+            flags = static_cast<CorILMethodSect>(flags | CorILMethodSect::CorILMethod_Sect_MoreSects);
+        }
+
+        // same for SMALL and FAT, SMALL has padding for equal header sizes
+        constexpr size_t headerSize = sizeof(IMAGE_COR_ILMETHOD_SECT_FAT);
+        if (shouldBeFat)
+        {
+            IMAGE_COR_ILMETHOD_SECT_FAT header;
+            header.Kind = flags;
+            header.DataSize = headerSize + sizeof(IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_FAT) * m_clauses.size();
+            AppendAsBytes(target, header);
+            for (size_t i = 0; i != m_clauses.size(); ++i)
+            {
+                IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_FAT clause = m_clauses[i].FillFatHeader();
+                AppendAsBytes(target, clause);
+            }
+        }
+        else
+        {
+            IMAGE_COR_ILMETHOD_SECT_SMALL header;
+            header.Kind = flags;
+            header.DataSize = headerSize + sizeof(IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_SMALL) * m_clauses.size();
+            AppendAsBytes(target, header);
+            AppendAsBytes(target, decltype(std::declval<IMAGE_COR_ILMETHOD_SECT_EH_SMALL>().Reserved) { 0 });
+            for (size_t i = 0; i != m_clauses.size(); ++i)
+            {
+                IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_SMALL clause = m_clauses[i].FillSmallHeader();
+                AppendAsBytes(target, clause);
+            }
+        }
+    }
 }

--- a/Drill4dotNet/Drill4dotNet/ExceptionsSection.cpp
+++ b/Drill4dotNet/Drill4dotNet/ExceptionsSection.cpp
@@ -1,0 +1,6 @@
+#include "pch.h"
+#include "ExceptionsSection.h"
+
+namespace Drill4dotNet
+{
+}

--- a/Drill4dotNet/Drill4dotNet/ExceptionsSection.h
+++ b/Drill4dotNet/Drill4dotNet/ExceptionsSection.h
@@ -1,8 +1,59 @@
 #pragma once
 
+#include "ExceptionClause.h"
+
 namespace Drill4dotNet
 {
+    // Represents one section with definitions of several
+    // try-catch or try-finally blocks.
+    // Can be constructed from .net api structures and
+    // converted back to them.
+    // Reference: ECMA-335, Common Language Infrastructure,
+    // part II.25.4.5 Method data section
+    // https://www.ecma-international.org/publications/files/ECMA-ST/ECMA-335.pdf
     class ExceptionsSection
     {
+    private:
+        // Value indicating whether more sections present in method
+        // after this section.
+        bool m_hasMoreSections;
+
+        // Value indicating whether this instance was constructed from
+        // a fat section header.
+        bool m_fat;
+
+        // Try-catch and try-finally clauses stored in this section.
+        std::vector<ExceptionClause> m_clauses;
+    public:
+
+        // Fills a new instance from method bytes representation.
+        // @param source : the method bytes, will be advanced by the length
+        //     of the section.
+        // @param sourceEnd : the end of the method bytes.
+        // @param target : the instructions stream to add new labels to.
+        // @param labelCreator : the tool to emit new labels.
+        ExceptionsSection(
+            std::vector<std::byte>::const_iterator& source,
+            const std::vector<std::byte>::const_iterator sourceEnd,
+            InstructionStream& target,
+            LabelCreator& labelCreator);
+
+        // Serializes this instance as bytes and adds them to the
+        // given vector.
+        // @param target : will append serialized bytes there.
+        void AppendToBytes(std::vector<std::byte>& target) const;
+
+        // Value indicating whether more sections present in method
+        // after this section.
+        constexpr bool HasMoreSections() const noexcept
+        {
+            return m_hasMoreSections;
+        }
+
+        // Try-catch and try-finally clauses stored in this section.
+        constexpr const std::vector<ExceptionClause>& Clauses() const noexcept
+        {
+            return m_clauses;
+        }
     };
 }

--- a/Drill4dotNet/Drill4dotNet/ExceptionsSection.h
+++ b/Drill4dotNet/Drill4dotNet/ExceptionsSection.h
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace Drill4dotNet
+{
+    class ExceptionsSection
+    {
+    };
+}

--- a/Drill4dotNet/Drill4dotNet/InstructionStream.cpp
+++ b/Drill4dotNet/Drill4dotNet/InstructionStream.cpp
@@ -1,6 +1,242 @@
 #include "pch.h"
 #include "InstructionStream.h"
 
+#include <cassert>
+#include <numeric>
+
 namespace Drill4dotNet
 {
+    // If the given stream element is an instruction, returns
+    // its size with argument, in bytes. Returns 0 for label.
+    // @param position : instruction or label.
+    AbsoluteOffset InstructionSize(const StreamElement& position) noexcept
+    {
+        return std::visit(
+            [](const auto& instruction)
+            {
+                if constexpr (std::is_same_v<std::decay_t<decltype(instruction)>, OpCodeVariant>)
+                {
+                    return instruction.SizeWithArgument();
+                }
+
+                return AbsoluteOffset { 0 };
+            },
+            position);
+    }
+
+    // Walks the given part of instructions stream,
+    // until exactly the given amount of bytes is passed.
+    // Returns the reached position.
+    // @param start : the position where to start walk from
+    // @param end : points immediately after the last element to walk.
+    //     Returned if the position is not found.
+    // @param target : the offset to reach.
+    ConstStreamPosition ReachPositiveOffset(
+        const ConstStreamPosition start,
+        const ConstStreamPosition end,
+        const AbsoluteOffset target)
+    {
+        AbsoluteOffset distance { 0 };
+        return std::find_if(
+            start,
+            end,
+            [&distance, target](const StreamElement& instruction)
+            {
+                if (distance == target)
+                {
+                    return true;
+                }
+
+                distance += InstructionSize(instruction);
+                return false;
+            });
+    }
+
+    // Walks the given part of instructions stream, in reverse
+    // order, until exactly the given amount of bytes is passed.
+    // Returns the reached position.
+    // @param start : the position where to start walk from
+    // @param begin : points at the last element to walk.
+    // @param end : points immediately after the last element of
+    //     the instruction stream. Returned if the position is not found.
+    // @param target : the offset to reach. Must be negative.
+    ConstStreamPosition ReachNegativeOffset(
+        const ConstStreamPosition start,
+        const ConstStreamPosition begin,
+        const ConstStreamPosition end,
+        const LongJump::Offset target)
+    {
+        AbsoluteOffset distance { 0 };
+        ConstStreamPosition current { start };
+        while (current != begin)
+        {
+            --current;
+            distance -= InstructionSize(*current);
+            if (distance == target)
+            {
+                return current;
+            }
+        }
+
+        return end;
+    }
+
+    ConstStreamPosition ResolveJumpOffset(
+        const InstructionStream& stream,
+        const ConstStreamPosition source,
+        const LongJump::Offset offset)
+    {
+        if (source == stream.cend())
+        {
+            return stream.cend();
+        }
+
+        const ConstStreamPosition origin = FindNextInstruction(source, stream.cend());
+
+        if (offset == 0)
+        {
+            return origin;
+        }
+
+        ConstStreamPosition target;
+        const bool forward = offset > 0;
+        if (forward)
+        {
+            if (origin == stream.cend())
+            {
+                return stream.cend();
+            }
+
+            target = ReachPositiveOffset(
+                origin,
+                stream.cend(),
+                offset);
+        }
+        else
+        {
+            target = ReachNegativeOffset(
+                origin,
+                stream.cbegin(),
+                stream.cend(),
+                offset);
+        }
+
+        return SkipLabels(target, stream.end());
+    }
+
+    ConstStreamPosition SkipLabels(
+        const ConstStreamPosition startPoint,
+        const ConstStreamPosition end)
+    {
+        return std::find_if(
+            startPoint,
+            end,
+            [](const StreamElement& instructionOrLabel)
+            {
+                return std::holds_alternative<OpCodeVariant>(instructionOrLabel);
+            });
+    }
+
+    ConstStreamPosition FindNextInstruction(
+        const ConstStreamPosition startPoint,
+        const ConstStreamPosition end)
+    {
+        auto currentInstruction = SkipLabels(startPoint, end);
+        if (currentInstruction == end)
+        {
+            return end;
+        }
+
+        ++currentInstruction;
+        if (currentInstruction == end)
+        {
+            return end;
+        }
+
+        return SkipLabels(currentInstruction, end);
+    }
+
+    ConstStreamPosition GetNthInstruction(const InstructionStream& stream, const size_t number)
+    {
+        ptrdiff_t instructions{ 0 };
+        return SkipLabels(
+            std::find_if(
+                stream.cbegin(),
+                stream.cend(),
+                [&instructions, number](const StreamElement& variant)
+                {
+                    const bool targetReached = instructions == number;
+                    if (!targetReached && std::holds_alternative<OpCodeVariant>(variant))
+                    {
+                        ++instructions;
+                    }
+
+                    return targetReached;
+                }),
+            stream.cend());
+    }
+
+    // Calculates the distance, in bytes,
+    // between two given positions in the instructions stream.
+    // 0 corresponds to the from location.
+    // @param from : the first instruction to count.
+    // @param to : the first instruction not to count.
+    //     Must be after from.
+    AbsoluteOffset CalculateDistance(
+        const ConstStreamPosition from,
+        const ConstStreamPosition to)
+    {
+        assert(from <= to);
+
+        return std::accumulate(
+            from,
+            to,
+            AbsoluteOffset { 0 },
+            [](const AbsoluteOffset sum, const StreamElement& variant) noexcept
+            {
+                return sum + InstructionSize(variant);
+            });
+    }
+
+    LongJump::Offset CalculateJumpOffset(
+        const InstructionStream& stream,
+        const ConstStreamPosition from,
+        const ConstStreamPosition to)
+    {
+        const ConstStreamPosition origin = FindNextInstruction(from, stream.cend());
+        const int64_t result = origin > to
+            ? int64_t { -1 } * CalculateDistance(to, origin)
+            : CalculateDistance(origin, to);
+
+        if (!LongJump::CanSafelyStoreOffset(result))
+        {
+            throw std::overflow_error("The relative jump is too far and cannot be represented as a long jump");
+        }
+
+        return static_cast<LongJump::Offset>(result);
+    }
+
+    ConstStreamPosition FindLabel(
+        const InstructionStream& stream,
+        const Label label)
+    {
+        return std::find_if(
+            stream.cbegin(),
+            stream.cend(),
+            [label](const auto& maybeLabel)
+            {
+                if (const Label* const candidate = std::get_if<Label>(&maybeLabel)
+                    ; candidate != nullptr)
+                {
+                    return *candidate == label;
+                }
+
+                return false;
+            });
+    }
+
+    Label LabelCreator::CreateLabel() noexcept
+    {
+        return Label(m_nextUnusedLabelId++);
+    }
 }

--- a/Drill4dotNet/Drill4dotNet/InstructionStream.cpp
+++ b/Drill4dotNet/Drill4dotNet/InstructionStream.cpp
@@ -1,0 +1,6 @@
+#include "pch.h"
+#include "InstructionStream.h"
+
+namespace Drill4dotNet
+{
+}

--- a/Drill4dotNet/Drill4dotNet/InstructionStream.cpp
+++ b/Drill4dotNet/Drill4dotNet/InstructionStream.cpp
@@ -156,6 +156,18 @@ namespace Drill4dotNet
         return SkipLabels(currentInstruction, end);
     }
 
+    ConstStreamPosition ResolveAbsoluteOffset(
+        const InstructionStream& stream,
+        const AbsoluteOffset offset)
+    {
+        return SkipLabels(
+            ReachPositiveOffset(
+                stream.cbegin(),
+                stream.cend(),
+                offset),
+            stream.cend());
+    }
+
     ConstStreamPosition GetNthInstruction(const InstructionStream& stream, const size_t number)
     {
         ptrdiff_t instructions{ 0 };
@@ -214,6 +226,13 @@ namespace Drill4dotNet
         }
 
         return static_cast<LongJump::Offset>(result);
+    }
+
+    AbsoluteOffset CalculateAbsoluteOffset(
+        const InstructionStream& instructionStream,
+        const ConstStreamPosition to)
+    {
+        return CalculateDistance(instructionStream.cbegin(), to);
     }
 
     ConstStreamPosition FindLabel(

--- a/Drill4dotNet/Drill4dotNet/InstructionStream.h
+++ b/Drill4dotNet/Drill4dotNet/InstructionStream.h
@@ -4,8 +4,9 @@
 
 namespace Drill4dotNet
 {
-    // An opcode in an instructions stream.
-    using StreamElement = OpCodeVariant;
+    // An item in an instructions stream. Can be an opcode
+    // or a label.
+    using StreamElement = std::variant<OpCodeVariant, Label>;
 
     // Instructions stream - sequence of opcodes, with added
     // labels before some of the opcodes.
@@ -18,5 +19,108 @@ namespace Drill4dotNet
     // Position in the instructions stream,
     // which content cannot be modified.
     using ConstStreamPosition = InstructionStream::const_iterator;
+
+    // Searches for a specific instruction in the
+    // given range of instructions stream.
+    // TOpCode : type of instruction to search for.
+    // @param start : points to the first element of
+    //     the search range.
+    // @param end : points to the position immediately
+    //     after the last element of the search range.
+    template<
+        typename TOpCode,
+        std::enable_if_t<OpCodeVariant::IsOpCodeClass<TOpCode>, int> = 0>
+        ConstStreamPosition FindInstruction(
+            const ConstStreamPosition start,
+            const ConstStreamPosition end)
+    {
+        return std::find_if(
+            start,
+            end,
+            [](const StreamElement& current)
+            {
+                if (const OpCodeVariant* instruction = std::get_if<OpCodeVariant>(&current)
+                    ; instruction != nullptr)
+                {
+                    return instruction->HoldsAlternative<TOpCode>();
+                }
+
+                return false;
+            });
+    }
+
+    // Searches for an instruction in the given
+    // instructions stream, which would be
+    // the jump target from the given instruction.
+    // Returns cend() of stream, if no corresponding
+    // position found.
+    // @param stream : the instructions stream to search in.
+    // @param source : the instruction to start search from.
+    // @param offset : signed offset from source, in bytes, 0
+    //     corresponds the instruction immediately after source.
+    ConstStreamPosition ResolveJumpOffset(
+        const InstructionStream& stream,
+        const ConstStreamPosition source,
+        const LongJump::Offset offset);
+
+    // Searches for the position of the N-th instruction from
+    // the beginning of the given instructions stream.
+    // Returns cend() of stream, if no corresponding
+    // position found.
+    // @param stream : the instructions stream to search in.
+    // @param number : the number of instruction to retrieve.
+    ConstStreamPosition GetNthInstruction(const InstructionStream& stream, const size_t number);
+
+    // Calculates which jump value should be used to
+    // transfer control between two given instructions.
+    // @param stream : the instructions stream the instructions belong to.
+    // @param from : the instruction from which jump is performed.
+    // @param to : the jump target instruction.
+    LongJump::Offset CalculateJumpOffset(
+        const InstructionStream& stream,
+        const ConstStreamPosition from,
+        const ConstStreamPosition to);
+
+    // Returns the position in the instruction stream,
+    // where the given label is located.
+    // @param stream : the instructions stream to search in.
+    // @param label : the label to search for.
+    ConstStreamPosition FindLabel(
+        const InstructionStream& stream,
+        const Label label);
+
+    // Skips all the labels and returns the
+    // first instruction, starting from the
+    // given point in the instructions stream.
+    // @param startPoint : the search start position
+    // @param end : points to the position immediately
+    //     after the last element of the search range.
+    //     Returned if an instruction not found.
+    ConstStreamPosition SkipLabels(
+        const ConstStreamPosition startPoint,
+        const ConstStreamPosition end);
+
+    // Returns the position of the second instruction,
+    // starting from the given point in the instructions stream.
+    // Skips all labels.
+    // @param startPoint : the search start position
+    // @param end : points to the position immediately
+    //     after the last element of the search range.
+    //     Returned if the instruction not found.
+    ConstStreamPosition FindNextInstruction(
+        const ConstStreamPosition startPoint,
+        const ConstStreamPosition end);
+
+    // Tool to emit new labels.
+    class LabelCreator
+    {
+    private:
+        // Stores the id of the next label to emit.
+        Label::Id m_nextUnusedLabelId { 0 };
+
+    public:
+        // Emits a new label.
+        Label CreateLabel() noexcept;
+    };
 }
 

--- a/Drill4dotNet/Drill4dotNet/InstructionStream.h
+++ b/Drill4dotNet/Drill4dotNet/InstructionStream.h
@@ -1,6 +1,22 @@
 #pragma once
 
+#include "OpCodes.h"
+
 namespace Drill4dotNet
 {
+    // An opcode in an instructions stream.
+    using StreamElement = OpCodeVariant;
+
+    // Instructions stream - sequence of opcodes, with added
+    // labels before some of the opcodes.
+    using InstructionStream = std::vector<StreamElement>;
+
+    // Position in the instructions stream,
+    // which content can be modified.
+    using StreamPosition = InstructionStream::iterator;
+
+    // Position in the instructions stream,
+    // which content cannot be modified.
+    using ConstStreamPosition = InstructionStream::const_iterator;
 }
 

--- a/Drill4dotNet/Drill4dotNet/InstructionStream.h
+++ b/Drill4dotNet/Drill4dotNet/InstructionStream.h
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace Drill4dotNet
+{
+}
+

--- a/Drill4dotNet/Drill4dotNet/InstructionStream.h
+++ b/Drill4dotNet/Drill4dotNet/InstructionStream.h
@@ -63,6 +63,19 @@ namespace Drill4dotNet
         const ConstStreamPosition source,
         const LongJump::Offset offset);
 
+    // Searches for an instruction in the given
+    // instructions stream, which would be
+    // located in the given amount of bytes from the
+    // beginning of the method.
+    // Returns cend() of stream, if no corresponding
+    // position found.
+    // @param stream : the instructions stream to search in.
+    // @param offset : unsigned offset, in bytes, 0 corresponds
+    //     the first instruction of the method.
+    ConstStreamPosition ResolveAbsoluteOffset(
+        const InstructionStream& stream,
+        const AbsoluteOffset offset);
+
     // Searches for the position of the N-th instruction from
     // the beginning of the given instructions stream.
     // Returns cend() of stream, if no corresponding
@@ -79,6 +92,14 @@ namespace Drill4dotNet
     LongJump::Offset CalculateJumpOffset(
         const InstructionStream& stream,
         const ConstStreamPosition from,
+        const ConstStreamPosition to);
+
+    // Calculate distance in bytes between the
+    // method start and the given instruction.
+    // @param stream : the instructions stream the instruction belongs to.
+    // @param to : the instruction to calculate distance to.
+    AbsoluteOffset CalculateAbsoluteOffset(
+        const InstructionStream& instructionStream,
         const ConstStreamPosition to);
 
     // Returns the position in the instruction stream,

--- a/Drill4dotNet/Drill4dotNet/MethodBody.cpp
+++ b/Drill4dotNet/Drill4dotNet/MethodBody.cpp
@@ -74,7 +74,7 @@ namespace Drill4dotNet
             m_flags = static_cast<uint16_t>(bodyBytes[0] & s_TinyHeaderFlagsMask);
             m_headerSize = sizeof(std::byte);
             m_maxStack = std::nullopt;
-            m_codeSize = static_cast<uint32_t>(bodyBytes[0] & s_TinyHeaderSizeMask) >> 2;
+            m_codeSize = static_cast<AbsoluteOffset>(bodyBytes[0] & s_TinyHeaderSizeMask) >> 2;
             m_localVariables = std::nullopt;
         }
         else
@@ -101,7 +101,7 @@ namespace Drill4dotNet
     std::vector<OpCodeVariant> MethodBody::Decompile(
         const std::vector<std::byte>& bodyBytes,
         uint8_t headerSize,
-        const uint32_t codeSize)
+        const AbsoluteOffset codeSize)
     {
         // Uses
         // const BYTE* OpInfo::fetch(const BYTE * instrPtr, OpArgsVal * args)

--- a/Drill4dotNet/Drill4dotNet/MethodBody.cpp
+++ b/Drill4dotNet/Drill4dotNet/MethodBody.cpp
@@ -34,13 +34,49 @@ namespace Drill4dotNet
     class MethodBody::ArgumentConverter<OpArgsVal>
     {
     public:
+        // Jump extracted from the opcode argument.
+        struct Jump
+        {
+            // The label associated with the jump.
+            Label Label;
+
+            // The offset of the jump, in bytes,
+            // relative to the instruction immediately after
+            // the branching instruction.
+            LongJump::Offset Offset;
+        };
+
         // The instructions stream to store parsed instructions.
         InstructionStream& Target;
 
+        // The tool to emit new labels.
+        LabelCreator& LabelCreator;
+
+        // For each position in Target, has corresponding vector
+        // of jumps from that position.
+        std::vector<std::vector<Jump>> JumpOffsets;
+
+    private:
+        // Adds a new Jump with the given offset to JumpOffsets.
+        // Returns a Jump to store in a branching instruction argument.
+        // TJump : ShortJump or LongJump
+        // @param jumpOffset : the offset in bytes.
+        template <typename TJump>
+        TJump CreateJump(const LongJump::Offset jumpOffset)
+        {
+            const Label label { LabelCreator.CreateLabel() };
+            JumpOffsets.back().push_back( Jump { label, jumpOffset } );
+            return TJump { label };
+        }
+
+    public:
+
         // Creates a new converter with the given values.
         ArgumentConverter(
-            InstructionStream& target) noexcept
-            : Target { target }
+            InstructionStream& target,
+            Drill4dotNet::LabelCreator& labelCreator) noexcept
+            : Target { target },
+            LabelCreator { labelCreator }
         {
         }
 
@@ -58,6 +94,7 @@ namespace Drill4dotNet
         {
             OpCodeVariant::InstructionCode code{ firstByte, secondByte };
             OpCodeVariant::VariantType argument{};
+            JumpOffsets.emplace_back();
             if constexpr (std::is_same_v<TArgument, OpCodeArgumentType::InlineNone>)
             {
                 argument = std::monostate{};
@@ -76,10 +113,18 @@ namespace Drill4dotNet
             else if constexpr (
                 std::is_same_v<TArgument, OpCodeArgumentType::InlineSwitch>)
             {
-                auto begin = (int32_t*)(rawArgument.switch_.targets);
-                auto end = begin + rawArgument.switch_.count;
+                auto begin = static_cast<LongJump::Offset*>(rawArgument.switch_.targets);
+                auto count = rawArgument.switch_.count;
+                auto end = begin + count;
 
-                argument = std::vector<int32_t>(begin, end);
+                std::vector<LongJump> jumpTable{};
+                jumpTable.reserve(count);
+                std::for_each(begin, end, [this, &jumpTable](LongJump::Offset offset)
+                    {
+                        jumpTable.push_back(CreateJump<LongJump>(offset));
+                    });
+
+                argument = jumpTable;
             }
             else if constexpr (
                 std::is_same_v<TArgument, OpCodeArgumentType::InlinePhi>)
@@ -87,6 +132,18 @@ namespace Drill4dotNet
                 auto begin = (uint16_t*)(rawArgument.phi.vars);
                 auto end = begin + rawArgument.phi.count;
                 argument = std::vector<uint16_t>(begin, end);
+            }
+            else if constexpr (
+                std::is_same_v<TArgument, OpCodeArgumentType::ShortInlineBrTarget>)
+            {
+                const LongJump::Offset offset { static_cast<ShortJump::Offset>(
+                    rawArgument.i) };
+                argument = CreateJump<TArgument>(offset);
+            }
+            else if constexpr (
+                std::is_same_v<TArgument, OpCodeArgumentType::InlineBrTarget>)
+            {
+                argument = CreateJump<TArgument>(rawArgument.i);
             }
             else
             {
@@ -100,25 +157,13 @@ namespace Drill4dotNet
     MethodBody::MethodBody(const std::vector<std::byte>& bodyBytes)
         : m_header(bodyBytes)
     {
-        m_stream = Decompile(
-            bodyBytes,
-            m_header.Size(),
-            m_header.CodeSize());
-    }
-
-    InstructionStream MethodBody::Decompile(
-        const std::vector<std::byte>& bodyBytes,
-        uint8_t headerSize,
-        const AbsoluteOffset codeSize)
-    {
         // Uses
         // const BYTE* OpInfo::fetch(const BYTE * instrPtr, OpArgsVal * args)
         OpInfo parser{};
-        InstructionStream result{};
-        const auto begin = reinterpret_cast<const BYTE*>(bodyBytes.data() + headerSize);
-        const auto end = begin + codeSize;
+        const auto begin = reinterpret_cast<const BYTE*>(bodyBytes.data() + m_header.Size());
+        const auto end = begin + m_header.CodeSize();
         auto currentInstruction{ begin };
-        ArgumentConverter<OpArgsVal> converter { result };
+        ArgumentConverter<OpArgsVal> converter { m_stream, m_labelCreator };
         while (currentInstruction < end)
         {
             OpArgsVal inlineArguments;
@@ -154,7 +199,27 @@ namespace Drill4dotNet
             }
         }
 
-        return result;
+
+        size_t instructionsCounter { 0 };
+        for (const auto& jumpTable : converter.JumpOffsets)
+        {
+            for (const auto jump : jumpTable)
+            {
+                auto insertAt { ResolveJumpOffset(
+                    m_stream,
+                    GetNthInstruction(m_stream, instructionsCounter),
+                    jump.Offset) };
+
+                if (insertAt == m_stream.cend())
+                {
+                    throw std::runtime_error("Could not find an instruction by the given jump offset.");
+                }
+
+                m_stream.insert(insertAt, jump.Label);
+            }
+
+            ++instructionsCounter;
+        }
     }
 
     std::vector<std::byte> MethodBody::Compile() const
@@ -164,39 +229,78 @@ namespace Drill4dotNet
 
         m_header.AppendToBytes(result);
 
-        for (const auto& instruction : m_stream)
+        for (ConstStreamPosition current = m_stream.cbegin(); current != m_stream.cend(); ++current)
         {
-            instruction.m_code.AppendToVector(result);
-            std::visit(
-                [&result](const auto argument)
-                {
-                    using T = std::remove_cv_t<decltype(argument)>;
-                    if constexpr (std::is_same_v<T, std::monostate>)
+            const StreamElement& variant{ *current };
+            if (const OpCodeVariant* instruction = std::get_if<OpCodeVariant>(&variant)
+                ; instruction != nullptr)
+            {
+                instruction->m_code.AppendToVector(result);
+                std::visit(
+                    [this, current, &result](const auto argument)
                     {
-                        return;
-                    }
-                    else if constexpr (std::is_same_v<T, OpCodeArgumentType::InlineSwitch>)
-                    {
-                        AppendAsBytes(result, static_cast<uint32_t>(argument.size()));
-                        for (const auto label : argument)
+                        using T = std::remove_cv_t<decltype(argument)>;
+                        if constexpr (std::is_same_v<T, std::monostate>)
                         {
-                            AppendAsBytes(result, label);
+                            return;
                         }
-                    }
-                    else if constexpr (std::is_same_v<T, OpCodeArgumentType::InlinePhi>)
-                    {
-                        AppendAsBytes(result, static_cast<uint8_t>(argument.size()));
-                        for (const auto var : argument)
+                        else if constexpr (std::is_same_v<T, OpCodeArgumentType::InlineSwitch>)
                         {
-                            AppendAsBytes(result, var);
+                            AppendAsBytes(result, static_cast<AbsoluteOffset>(argument.size()));
+                            for (const auto jump : argument)
+                            {
+                                auto labelPosition = FindLabel(m_stream, jump.Label());
+                                if (labelPosition == m_stream.cend())
+                                {
+                                    throw std::logic_error("Compilation failed: unresolved label.");
+                                }
+
+                                AppendAsBytes(
+                                    result,
+                                    CalculateJumpOffset(m_stream, current, labelPosition));
+                            }
                         }
-                    }
-                    else
-                    {
-                        AppendAsBytes(result, argument);
-                    }
-                },
-                instruction.m_argument);
+                        else if constexpr (std::is_same_v<T, OpCodeArgumentType::InlinePhi>)
+                        {
+                            AppendAsBytes(result, static_cast<uint8_t>(argument.size()));
+                            for (const auto var : argument)
+                            {
+                                AppendAsBytes(result, var);
+                            }
+                        }
+                        else if constexpr (std::is_same_v<T, OpCodeArgumentType::ShortInlineBrTarget>)
+                        {
+                            auto labelPosition = FindLabel(m_stream, argument.Label());
+                            if (labelPosition == m_stream.cend())
+                            {
+                                throw std::logic_error("Compilation failed: unresolved label.");
+                            }
+
+                            const LongJump::Offset offset = CalculateJumpOffset(m_stream, current, labelPosition);
+                            AppendAsBytes(
+                                result,
+                                static_cast<const ShortJump::Offset>(offset));
+                        }
+                        else if constexpr (std::is_same_v<T, OpCodeArgumentType::InlineBrTarget>)
+                        {
+                            auto labelPosition = FindLabel(m_stream, argument.Label());
+                            if (labelPosition == m_stream.cend())
+                            {
+                                throw std::logic_error("Compilation failed: unresolved label.");
+                            }
+
+                            const LongJump::Offset offset = CalculateJumpOffset(m_stream, current, labelPosition);
+                            AppendAsBytes(
+                                result,
+                                offset);
+                        }
+                        else
+                        {
+                            AppendAsBytes(result, argument);
+                        }
+                    },
+                    instruction->m_argument);
+            }
         }
 
         // Dangerous: need to add processing of exception clauses;
@@ -217,6 +321,169 @@ namespace Drill4dotNet
 
         m_header.SetCodeSize(static_cast<AbsoluteOffset>(newCodeSize));
         m_stream.insert(position, opcode);
+        TurnJumpsToLongIfNeeded();
+    }
+
+    // Indicates that the instruction is not a
+    // short branching instruction.
+    using InstructionCannotMadeLong = void;
+
+    // Gets the long branching instruction corresponding to the
+    // given short branching instruction.
+    // TOpCode : instruction type.
+    template <typename TOpCode>
+    class ToLongBranchInstruction
+    {
+    public:
+        // The long branching instruction, or
+        // InstructionCannotMadeLong if TOpCode is not a short
+        // branching instruction.
+        using LongInstruction = InstructionCannotMadeLong;
+    };
+
+    // Declare specializations for all short branching instructions we know
+
+#define DECLARE_TO_LONG_BRANCH_INSTRUCTION_SPECIALIZATION(longName) \
+    template <> \
+    class ToLongBranchInstruction< OpCode_CEE_ ## longName ## _S> \
+    { \
+    static_assert(std::is_same_v< \
+        OpCode_CEE_ ## longName ## _S :: ArgumentType, \
+        OpCodeArgumentType::ShortInlineBrTarget>); \
+\
+    static_assert(std::is_same_v< \
+        OpCode_CEE_ ## longName ## :: ArgumentType, \
+        OpCodeArgumentType::InlineBrTarget>); \
+ \
+   public: \
+        using LongInstruction = OpCode_CEE_ ## longName; \
+    };
+
+    DECLARE_TO_LONG_BRANCH_INSTRUCTION_SPECIALIZATION(BR)
+    DECLARE_TO_LONG_BRANCH_INSTRUCTION_SPECIALIZATION(BRFALSE)
+    DECLARE_TO_LONG_BRANCH_INSTRUCTION_SPECIALIZATION(BRTRUE)
+    DECLARE_TO_LONG_BRANCH_INSTRUCTION_SPECIALIZATION(BEQ)
+    DECLARE_TO_LONG_BRANCH_INSTRUCTION_SPECIALIZATION(BGE)
+    DECLARE_TO_LONG_BRANCH_INSTRUCTION_SPECIALIZATION(BGT)
+    DECLARE_TO_LONG_BRANCH_INSTRUCTION_SPECIALIZATION(BLE)
+    DECLARE_TO_LONG_BRANCH_INSTRUCTION_SPECIALIZATION(BLT)
+    DECLARE_TO_LONG_BRANCH_INSTRUCTION_SPECIALIZATION(BNE_UN)
+    DECLARE_TO_LONG_BRANCH_INSTRUCTION_SPECIALIZATION(BGE_UN)
+    DECLARE_TO_LONG_BRANCH_INSTRUCTION_SPECIALIZATION(BGT_UN)
+    DECLARE_TO_LONG_BRANCH_INSTRUCTION_SPECIALIZATION(BLE_UN)
+    DECLARE_TO_LONG_BRANCH_INSTRUCTION_SPECIALIZATION(BLT_UN)
+    DECLARE_TO_LONG_BRANCH_INSTRUCTION_SPECIALIZATION(LEAVE)
+
+#undef DECLARE_TO_LONG_BRANCH_INSTRUCTION_SPECIALIZATION
+
+    // Check there are no short branching instruction without ToLongBranchInstruction specialization
+
+#define OPDEF_REAL_INSTRUCTION( \
+    canonicalName, \
+    stringName, \
+    stackPop, \
+    stackPush, \
+    inlineArgumentType, \
+    operationKind, \
+    codeLength, \
+    byte1, \
+    byte2, \
+    controlBehavior) \
+    static_assert( \
+        !std::is_same_v< \
+            OpCode_ ## canonicalName ## ::ArgumentType, \
+            OpCodeArgumentType::ShortInlineBrTarget> \
+        || !std::is_same_v< \
+            ToLongBranchInstruction<OpCode_ ## canonicalName >::LongInstruction, \
+            InstructionCannotMadeLong>);
+#include "DefineOpCodesGeneratorSpecializations.h"
+#include <opcode.def>
+#include "UnDefineOpCodesGeneratorSpecializations.h"
+#undef OPDEF_REAL_INSTRUCTION
+
+    bool MethodBody::ConvertJumpInstructionToLongIfNeeded(const StreamPosition instructionPosition)
+    {
+        bool result{ false };
+
+        if (const OpCodeVariant* const instruction = std::get_if<OpCodeVariant>(&*instructionPosition)
+            ; instruction != nullptr)
+        {
+            instruction->Visit(
+                [this, instructionPosition, instruction, &result](const auto& opcode)
+                {
+                    using TLong = ToLongBranchInstruction<std::decay_t<decltype(opcode)>>::LongInstruction;
+                    if constexpr (std::is_same_v<TLong, InstructionCannotMadeLong>)
+                    {
+                        return;
+                    }
+                    else
+                    {
+                        const Label label = opcode.Argument().Label();
+                        const ConstStreamPosition target = FindLabel(m_stream, label);
+                        if (target == m_stream.cend())
+                        {
+                            return;
+                        }
+
+                        LongJump::Offset distance = CalculateJumpOffset(m_stream, instructionPosition, target);
+                        if (ShortJump::CanSafelyStoreOffset(distance))
+                        {
+                            return;
+                        }
+
+                        OpCodeVariant newInstruction{ TLong(LongJump(label)) };
+                        const int64_t newCodeSize = int64_t{ m_header.CodeSize() }
+                            + newInstruction.SizeWithArgument()
+                            - instruction->SizeWithArgument();
+
+                        if (!m_header.IsValidCodeSize(newCodeSize))
+                        {
+                            throw std::overflow_error("There is no room in the target method to convert an existing instruction to long variant");
+                        }
+
+                        m_header.SetCodeSize(static_cast<AbsoluteOffset>(newCodeSize));
+                        *instructionPosition = newInstruction;
+
+                        result = true;
+                    }
+                });
+        }
+
+        return result;
+    }
+
+    void MethodBody::TurnJumpsToLongIfNeeded()
+    {
+        bool jumpsUpdated;
+        do
+        {
+            jumpsUpdated = false;
+
+            for (auto current = m_stream.begin(); current != m_stream.end(); ++current)
+            {
+                jumpsUpdated |= ConvertJumpInstructionToLongIfNeeded(current);
+            }
+        }
+        while (jumpsUpdated);
+    }
+
+    Label MethodBody::CreateLabel()
+    {
+        return m_labelCreator.CreateLabel();
+    }
+
+    void MethodBody::MarkLabel(
+        const ConstStreamPosition target,
+        const Label label)
+    {
+        const ConstStreamPosition existingLabelPosition { FindLabel(m_stream, label) };
+        if (existingLabelPosition != m_stream.cend())
+        {
+            throw std::logic_error("This label has already been marked");
+        }
+
+        m_stream.insert(target, label);
+        TurnJumpsToLongIfNeeded();
     }
 }
 

--- a/Drill4dotNet/Drill4dotNet/MethodBody.h
+++ b/Drill4dotNet/Drill4dotNet/MethodBody.h
@@ -24,7 +24,7 @@ namespace Drill4dotNet
         std::optional<uint16_t> m_maxStack;
 
         // 6 bits for tiny header, 32 bits for fat header
-        uint32_t m_codeSize;
+        AbsoluteOffset m_codeSize;
 
         // 32 bits in fat header only
         std::optional<uint32_t> m_localVariables;
@@ -49,7 +49,7 @@ namespace Drill4dotNet
         static std::vector<OpCodeVariant> Decompile(
             const std::vector<std::byte>& bodyBytes,
             uint8_t headerSize,
-            const uint32_t codeSize);
+            const AbsoluteOffset codeSize);
 
     public:
         // Creates the object representation of the method body.

--- a/Drill4dotNet/Drill4dotNet/MethodBody.h
+++ b/Drill4dotNet/Drill4dotNet/MethodBody.h
@@ -26,6 +26,11 @@ namespace Drill4dotNet
             uint8_t headerSize,
             const AbsoluteOffset codeSize);
 
+
+        // Specialized for .net's OpArgsVal to allow
+        // getting instruction arguments from it.
+        template <typename TOpArgsVal>
+        class ArgumentConverter;
     public:
         // Creates the object representation of the method body.
         // @param bodyBytes : the bytes of method body.

--- a/Drill4dotNet/Drill4dotNet/MethodBody.h
+++ b/Drill4dotNet/Drill4dotNet/MethodBody.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "OpCodes.h"
+#include "InstructionStream.h"
+#include "MethodHeader.h"
 
 namespace Drill4dotNet
 {
@@ -12,38 +14,11 @@ namespace Drill4dotNet
     class MethodBody
     {
     private:
-        // 2 bits for tiny header, 12 bits for fat header
-        uint16_t m_flags;
-
-        // Size of header in bytes.
-        // Has value "1" for tiny header, or
-        // value from the fat header (typically 12)
-        uint8_t m_headerSize;
-
-        // fat header only
-        std::optional<uint16_t> m_maxStack;
-
-        // 6 bits for tiny header, 32 bits for fat header
-        AbsoluteOffset m_codeSize;
-
-        // 32 bits in fat header only
-        std::optional<uint32_t> m_localVariables;
-
-        // If there were a fat header bigger that the current
-        // standard.
-        std::vector<std::byte> m_fatHeaderRemainder;
+        // The header storing information about other method structures.
+        MethodHeader m_header;
 
         // The parsed instructions.
         std::vector<OpCodeVariant> m_instructions;
-
-        // Identifies the tiny method header type.
-        inline static const std::byte s_TinyHeaderFlag{ CorILMethod_TinyFormat };
-
-        // Allows to get the flags from the tiny header.
-        inline static const std::byte s_TinyHeaderFlagsMask{ 0b00000011 };
-
-        // Allows to get the instructions size from the tiny header.
-        inline static const std::byte s_TinyHeaderSizeMask{ ~s_TinyHeaderFlagsMask };
 
         // Parses a byte representation of instructions into a vector.
         static std::vector<OpCodeVariant> Decompile(

--- a/Drill4dotNet/Drill4dotNet/MethodHeader.cpp
+++ b/Drill4dotNet/Drill4dotNet/MethodHeader.cpp
@@ -1,0 +1,6 @@
+#include "pch.h"
+#include "MethodHeader.h"
+
+namespace Drill4dotNet
+{
+}

--- a/Drill4dotNet/Drill4dotNet/MethodHeader.cpp
+++ b/Drill4dotNet/Drill4dotNet/MethodHeader.cpp
@@ -1,6 +1,83 @@
 #include "pch.h"
+
 #include "MethodHeader.h"
 
 namespace Drill4dotNet
 {
+    MethodHeader::MethodHeader(const std::vector<std::byte>& methodBody)
+    {
+        if (methodBody.empty())
+        {
+            throw std::runtime_error("Method header expected");
+        }
+
+        std::byte firstByte = *methodBody.cbegin();
+        if ((firstByte & s_TinyHeaderFlagsMask) == s_TinyHeaderFlag)
+        { // tiny header
+            if (methodBody.size() < sizeof(IMAGE_COR_ILMETHOD_TINY))
+            {
+                throw std::runtime_error("Unexpected method header end");
+            }
+
+            m_flags = static_cast<uint16_t>(firstByte & s_TinyHeaderFlagsMask);
+            m_headerSize = 1;
+            m_maxStack = std::nullopt;
+            m_codeSize = static_cast<AbsoluteOffset>(firstByte & s_TinyHeaderSizeMask) >> 2;
+            m_localVariables = std::nullopt;
+        }
+        else
+        { // fat header
+            if (methodBody.size() < sizeof(IMAGE_COR_ILMETHOD_FAT))
+            {
+                throw std::runtime_error("Unexpected method header end");
+            }
+
+            const IMAGE_COR_ILMETHOD_FAT& fatHeader
+                = *reinterpret_cast<const IMAGE_COR_ILMETHOD_FAT*>(methodBody.data());
+            m_flags = fatHeader.Flags;
+            m_headerSize = static_cast<uint8_t>(sizeof(uint32_t) * fatHeader.Size);
+            m_maxStack = static_cast<uint16_t>(fatHeader.MaxStack);
+            m_codeSize = fatHeader.CodeSize;
+            m_localVariables = fatHeader.LocalVarSigTok == 0
+                ? std::optional<uint32_t>(std::nullopt)
+                : fatHeader.LocalVarSigTok;
+
+            if (methodBody.size() < m_headerSize)
+            {
+                throw std::runtime_error("Unexpected method header end");
+            }
+
+            m_fatHeaderRemainder.assign(
+                methodBody.cbegin() + sizeof(fatHeader),
+                methodBody.cbegin() + m_headerSize);
+        }
+    }
+
+    void MethodHeader::AppendToBytes(std::vector<std::byte>& target) const
+    {
+        if (m_headerSize == sizeof(std::byte)) // Dangerous, need to recalculate header type
+        { // tiny header
+            target.push_back(std::byte{ m_flags | m_codeSize << 2 });
+        }
+        else
+        { // fat header
+            IMAGE_COR_ILMETHOD_FAT header;
+            header.Flags = m_flags;
+            header.Size = m_headerSize / sizeof(uint32_t); // Dangerous, assert m_headerSize / sizeof(int32_t) == 0
+            header.MaxStack = m_maxStack.value(); // Dangerous, may be std::nullopt
+            header.LocalVarSigTok = m_localVariables.has_value() ? *m_localVariables : 0;
+            header.CodeSize = m_codeSize; // Dangerous, need to recalculate m_codeSize
+
+            AppendAsBytes(target, header);
+            std::copy(
+                m_fatHeaderRemainder.cbegin(),
+                m_fatHeaderRemainder.cend(),
+                std::back_inserter(target));
+        }
+    }
+
+    void MethodHeader::SetCodeSize(const AbsoluteOffset codeSize) noexcept
+    {
+        m_codeSize = codeSize;
+    }
 }

--- a/Drill4dotNet/Drill4dotNet/MethodHeader.h
+++ b/Drill4dotNet/Drill4dotNet/MethodHeader.h
@@ -45,6 +45,9 @@ namespace Drill4dotNet
         // Allows to get the instructions size from the tiny header.
         inline static const std::byte s_TinyHeaderSizeMask{ ~s_TinyHeaderFlagsMask };
 
+        // Identifies whether the method has additional data sections.
+        inline static const uint16_t s_SectionsFlag{ CorILMethod_MoreSects };
+
     public:
         // Parses a method header from the given body bytes.
         // @param methodBody : contains method header, instructions stream,
@@ -54,6 +57,14 @@ namespace Drill4dotNet
         // Serializes data from this header to the given bytes vector.
         // @param target : the bytes vector to save data to.
         void AppendToBytes(std::vector<std::byte>& target) const;
+
+        // Gets the value indicating whether
+        // there are one or more additional data
+        // sections after the instructions stream.
+        constexpr bool HasExceptionsSections() const noexcept
+        {
+            return (m_flags & s_SectionsFlag) != 0;
+        }
 
         // Size of this header, in bytes.
         constexpr uint8_t Size() const noexcept

--- a/Drill4dotNet/Drill4dotNet/MethodHeader.h
+++ b/Drill4dotNet/Drill4dotNet/MethodHeader.h
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace Drill4dotNet
+{
+    class MethodHeader
+    {
+    };
+}

--- a/Drill4dotNet/Drill4dotNet/MethodHeader.h
+++ b/Drill4dotNet/Drill4dotNet/MethodHeader.h
@@ -1,8 +1,84 @@
 #pragma once
 
+#include "OpCodes.h"
+
+#include <optional>
+#include <vector>
+
 namespace Drill4dotNet
 {
+    // Represents header describing various method properties.
+    // Located in the beginning of method body bytes.
+    // Reference: ECMA-335, Common Language Infrastructure,
+    // part II.25.4 Common Intermediate Language physical layout
+    // https://www.ecma-international.org/publications/files/ECMA-ST/ECMA-335.pdf
     class MethodHeader
     {
+    private:
+        // 2 bits for tiny header, 12 bits for fat header
+        uint16_t m_flags;
+
+        // Size of header in bytes.
+        // Has value "1" for tiny header, or
+        // value from the fat header (typically 12)
+        uint8_t m_headerSize;
+
+        // fat header only
+        std::optional<uint16_t> m_maxStack;
+
+        // 6 bits for tiny header, 32 bits for fat header
+        AbsoluteOffset m_codeSize;
+
+        // 32 bits in fat header only
+        std::optional<uint32_t> m_localVariables;
+
+        // If there were a fat header bigger than the current
+        // standard.
+        std::vector<std::byte> m_fatHeaderRemainder;
+
+        // Identifies the tiny method header type.
+        inline static const std::byte s_TinyHeaderFlag{ CorILMethod_TinyFormat };
+
+        // Allows to get the flags from the tiny header.
+        inline static const std::byte s_TinyHeaderFlagsMask{ 0b00000011 };
+
+        // Allows to get the instructions size from the tiny header.
+        inline static const std::byte s_TinyHeaderSizeMask{ ~s_TinyHeaderFlagsMask };
+
+    public:
+        // Parses a method header from the given body bytes.
+        // @param methodBody : contains method header, instructions stream,
+        //     and additional data sections as a byte array.
+        MethodHeader(const std::vector<std::byte>& methodBody);
+
+        // Serializes data from this header to the given bytes vector.
+        // @param target : the bytes vector to save data to.
+        void AppendToBytes(std::vector<std::byte>& target) const;
+
+        // Size of this header, in bytes.
+        constexpr uint8_t Size() const noexcept
+        {
+            return m_headerSize;
+        }
+
+        // Size of the instructions stream, in bytes.
+        constexpr AbsoluteOffset CodeSize() const noexcept
+        {
+            return m_codeSize;
+        }
+
+        // Sets the size of the instructions stream, in bytes.
+        void SetCodeSize(const AbsoluteOffset codeSize) noexcept;
+
+        // Gets the value indicating whether
+        // this header can store the given length of an
+        // instructions stream.
+        // Returns true if the codeSize can be used with SetCodeSize.
+        // @param codeSize : the length of an instructions stream.
+        template <typename T>
+        static constexpr bool IsValidCodeSize(const T codeSize) noexcept
+        {
+            return !Overflows<decltype(std::declval<MethodHeader>().m_codeSize)>(codeSize);
+        }
     };
 }

--- a/Drill4dotNet/Drill4dotNet/OpCodes.cpp
+++ b/Drill4dotNet/Drill4dotNet/OpCodes.cpp
@@ -38,7 +38,12 @@ namespace Drill4dotNet
                 }
                 else if constexpr (std::is_same_v<T, OpCodeArgumentType::InlineSwitch>)
                 {
-                    return static_cast<AbsoluteOffset>(argument.size() * sizeof(int32_t) + sizeof(int32_t));
+                    return static_cast<AbsoluteOffset>(argument.size() * sizeof(LongJump::Offset) + sizeof(uint32_t));
+                }
+                else if constexpr (std::is_same_v<T, OpCodeArgumentType::ShortInlineBrTarget>
+                    || std::is_same_v<T, OpCodeArgumentType::InlineBrTarget>)
+                {
+                    return static_cast<AbsoluteOffset>(sizeof(T::Offset));
                 }
                 else
                 {

--- a/Drill4dotNet/Drill4dotNet/OpCodes.cpp
+++ b/Drill4dotNet/Drill4dotNet/OpCodes.cpp
@@ -22,27 +22,27 @@ namespace Drill4dotNet
         return !std::holds_alternative<std::monostate>(m_argument);
     }
 
-    uint32_t OpCodeVariant::SizeWithArgument() const
+    AbsoluteOffset OpCodeVariant::SizeWithArgument() const
     {
-        uint32_t instructionSize { m_code.Size() };
+        AbsoluteOffset instructionSize { m_code.Size() };
         return instructionSize + std::visit([](const auto& argument)
             {
                 using T = std::decay_t<decltype(argument)>;
                 if constexpr (std::is_same_v<T, std::monostate>)
                 {
-                    return static_cast<uint32_t>(0);
+                    return static_cast<AbsoluteOffset>(0);
                 }
                 else if constexpr (std::is_same_v<T, OpCodeArgumentType::InlinePhi>)
                 {
-                    return static_cast<uint32_t>(argument.size() * sizeof(uint16_t) + sizeof(uint8_t));
+                    return static_cast<AbsoluteOffset>(argument.size() * sizeof(uint16_t) + sizeof(uint8_t));
                 }
                 else if constexpr (std::is_same_v<T, OpCodeArgumentType::InlineSwitch>)
                 {
-                    return static_cast<uint32_t>(argument.size() * sizeof(int32_t) + sizeof(int32_t));
+                    return static_cast<AbsoluteOffset>(argument.size() * sizeof(int32_t) + sizeof(int32_t));
                 }
                 else
                 {
-                    return static_cast<uint32_t>(sizeof(argument));
+                    return static_cast<AbsoluteOffset>(sizeof(argument));
                 }
             },
             m_argument);

--- a/Drill4dotNet/Drill4dotNet/OpCodes.h
+++ b/Drill4dotNet/Drill4dotNet/OpCodes.h
@@ -60,7 +60,7 @@ namespace Drill4dotNet
     private:
         // The constructor is hidden in the private section,
         // so only TOpCodeTemplate can inherit this class.
-        OpCodeBase()
+        OpCodeBase() noexcept
         {
         }
 
@@ -108,14 +108,14 @@ namespace Drill4dotNet
         // Creates a new opcode value with the
         // given argument.
         // @param argument : the value to use.
-        OpCode(const TArgument argument)
+        OpCode(const TArgument argument) noexcept
             : OpCodeBase(),
             m_argument{ argument }
         {
         }
 
         // Gets the inline argument.
-        TArgument Argument() const
+        TArgument Argument() const noexcept
         {
             return m_argument;
         }
@@ -136,7 +136,7 @@ namespace Drill4dotNet
         OpCodeArgumentType::InlineNone>
     {
     public:
-        OpCode()
+        OpCode() noexcept
             : OpCodeBase()
         {
         }

--- a/Drill4dotNet/Drill4dotNet/OpCodes.h
+++ b/Drill4dotNet/Drill4dotNet/OpCodes.h
@@ -7,8 +7,16 @@
 #include <variant>
 #include <type_traits>
 
+#include "ByteUtils.h"
+
 namespace Drill4dotNet
 {
+    // Unit to measure sizes of instructions,
+    // sizes of instructions streams, and
+    // distances from instructions stream start to
+    // a specific instruction.
+    using AbsoluteOffset = uint32_t;
+
     // Defines possible options for type of
     // an OpCode inline argument, for reference see
     // https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.operandtype?view=netframework-4.8
@@ -267,7 +275,7 @@ namespace Drill4dotNet
             }
 
             // Gets the size of binary representation, in bytes.
-            constexpr uint32_t Size() const
+            constexpr AbsoluteOffset Size() const
             {
                 return IsOneByte() ? 1 : 2;
             }
@@ -424,7 +432,7 @@ public: \
         // Gets the size of binary representation of the
         // opcode this variant contains, including the instruction
         // code and the inline argument (if any).
-        uint32_t SizeWithArgument() const;
+        AbsoluteOffset SizeWithArgument() const;
 
         // Calls the visitor with the instruction this variant contains.
         // TVisitor must provide overload for each possible OpCode_* class.

--- a/Drill4dotNet/Drill4dotNet/framework.h
+++ b/Drill4dotNet/Drill4dotNet/framework.h
@@ -1,5 +1,9 @@
 #pragma once
 
+// This suppresses definition of macros
+// min and max when including windows.h
+#define NOMINMAX
+
 #ifndef STRICT
 #define STRICT
 #endif

--- a/HelloWorld/HelloWorld/Program.cs
+++ b/HelloWorld/HelloWorld/Program.cs
@@ -15,8 +15,35 @@ namespace HelloWorld
         {
             int x = 1;
             int y = 2;
-            int z = x + y;
-            Console.WriteLine(z);
+            int z;
+            try
+            {
+                z = x + y;
+                Console.WriteLine("Greetings from MyInjectionTarget");
+            }
+            catch (Exception)
+            {
+                z = 0;
+            }
+            finally
+            {
+                string s = "Greetings from the Profiler";
+                // For Debug builds, will inject
+                // Console.WriteLine(s);
+                // Such injection is not possible with Release builds,
+                // because the C# compiler optimizes s variable away.
+            }
+
+            if (z % 2 == 1)
+            {
+                Console.WriteLine(z);
+                // Will inject here
+                // if (x > 0)
+                // {
+                //     Console.WriteLine(42);
+                // }
+                // and 128 NOP operations
+            }
         }
     }
 }

--- a/HelloWorld/HelloWorldFramework/Program.cs
+++ b/HelloWorld/HelloWorldFramework/Program.cs
@@ -19,8 +19,35 @@ namespace HelloWorld
         {
             int x = 1;
             int y = 2;
-            int z = x + y;
-            Console.WriteLine(z);
+            int z;
+            try
+            {
+                z = x + y;
+                Console.WriteLine("Greetings from MyInjectionTarget");
+            }
+            catch (Exception)
+            {
+                z = 0;
+            }
+            finally
+            {
+                string s = "Greetings from the Profiler";
+                // For Debug builds, will inject
+                // Console.WriteLine(s);
+                // Such injection is not possible with Release builds,
+                // because the C# compiler optimizes s variable away.
+            }
+
+            if (z % 2 == 1)
+            {
+                Console.WriteLine(z);
+                // Will inject here
+                // if (x > 0)
+                // {
+                //     Console.WriteLine(42);
+                // }
+                // and 128 NOP operations
+            }
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -96,5 +96,5 @@ In addition to `setruntimeenv.cmd`, you can register the COM DLL in the system u
 
 * The profiler only outputs to stdout; it is not controlled or configured.
 * Only Windows 64-bit (x64) platform is currently supported.
-* ATM, the agent injects CEE_BREAK instruction to the target sample function. Injection is not supported to functions with exceptions, generic functions, unmanaged (native) functions.
+* ATM, the agent injects artificial calls to Console.WriteLine into the target sample function. Injection is not supported to functions with exceptions, generic functions, unmanaged (native) functions.
 * ATM, the profiler is not thread-safe.


### PR DESCRIPTION
Work under EPMDJ-2315.

### Refactoring to make further changes easier:
- Add `noexcept` in several places to fix compiler warnings.
- Introduce `AbsoluteOffset` as a measure for instruction and method body size.
- Extract logic related to method header parsing and serialization from `MethodBody` to `MethodHeader`.
- Introduce `ArgumentConverter` to convert inline arguments from raw bytes to objects.  
 Previously, `ConvertArgument` function was doing that.  
 `ArgumentConverter` is an upgraded version of the `ConvertArgument` function.  
 It looks more like a lambda, and allows to maintain state between parsing subsequent instructions.
- Allow external readonly access to the instructions stream inside the `MethodBody`.

### Support for branching instructions

Previously, it was not possible to inject anything into methods with `if`-`else`, loops, and `switch` statements.  
 The reason is that these statements are implemented in .net as branching instructions.  
 These instructions hold an offset, in bytes, between the branching instruction and the jump destination instruction.  
 If we naively add an instruction in the middle of such method, these offset will become stale, resulting in invalid Intermediate Language code.

With these changes, branching instructions are handled differently than other types of instructions.
- Instructions stream now can not only hold instructions, but also allows to add labels in front of an instruction.
- When `MethodBody` encounters a branching instruction with an offset while decompiling a method, a `Label` is created at the target instruction. The original offset is then thrown away, and the label is stored in the branching instruction.
- Then we can safely add instructions we want, the labels remain with their targets.
- When `MethodBody` compiles, it searches for the target labels and calculates offsets.
  Of course, if the user have not added anything to the method, the offsets should be the same as
  they were before the decompilation.
- When user adds new instructions, some short jump instructions in the instructions stream could not store the offsets to their targets anymore. `MethodBody::Insert` method will automatically convert these short instructions to long form, if needed.
- User can inject his own branching logic using `CreateLabel` and `MarkLabel` methods.

### Support for methods with `try`-`catch` and `try`-`finally` clauses

Each method in .net may have a section, which describes `try`-`catch` and `try`-`finally` clauses.
These clauses are expressed as byte offsets from beginning of the method to the start of `try`, `catch`, or `finally` statement.
Also length of the statement is stored.

Previously, if we added some instruction in the middle of method with such statements,
the byte offsets and lengths would become stale, likely resulting into invalid
Intermediate Language code.

Now, `MethodBody` has special handling for these statements:
- When method is being decompiled, the labels are added to the positions where exception handling statements begin or end.
  The initial offsets and lengths are thrown away then.
- There are `ExceptionClause` and `ExceptionSection` objects, which maintain relation between the labels and the error-handling statements.
- When `MethodBody` is being compiled, the `ExceptionClauses` recalculate the offsets and lengths. This way, if user has injected something, the values will be updated correspondingly. If user has not changed anything, the resulting offsets and lengths should be the same as before decompilation.
- Currently there is no support for injecting new `try`-`catch` and `try`-`finally` clauses, but the object model allows to add such ability in the future, if needed.

### Update for the demo `MyInjectionTarget` method

The demo methods for .NET Core and .NET Framework has been updated to demo these new features.  
 Also, debugger break has been replaced with calls to `Console.WriteLine`, inserted by the profiler.  
 For `Debug` builds of HelloWorld applications, words `Greetings from the Profiler` and `42` will appear in the output. For the `Release` builds, only `42` will appear.
