### PR TITLE
Refactoring on CorProfilerInfo

### DIFF
--- a/Drill4dotNet/Drill4dotNet/CProfilerCallback.cpp
+++ b/Drill4dotNet/Drill4dotNet/CProfilerCallback.cpp
@@ -53,10 +53,10 @@ namespace Drill4dotNet
         {
             if (!g_cb) return;
 
-            if (std::optional<FunctionName> functionName = g_cb->GetInfoHandler().TryGetFunctionName(funcId);
-                functionName)
+            if (std::optional<FunctionInfo> functionInfo = g_cb->GetInfoHandler().TryGetFunctionInfo(funcId);
+                functionInfo.has_value())
             {
-                g_cb->GetClient().Log() << L"Enter function: " << functionName->fullName();
+                g_cb->GetClient().Log() << L"Enter function: " << functionInfo->fullName();
             }
             else
             {
@@ -74,10 +74,10 @@ namespace Drill4dotNet
         {
             if (!g_cb) return;
 
-            if (std::optional<FunctionName> functionName = g_cb->GetInfoHandler().TryGetFunctionName(funcId);
-                functionName)
+            if (std::optional<FunctionInfo> functionInfo = g_cb->GetInfoHandler().TryGetFunctionInfo(funcId);
+                functionInfo.has_value())
             {
-                g_cb->GetClient().Log() << L"Leave function: " << functionName->fullName();
+                g_cb->GetClient().Log() << L"Leave function: " << functionInfo->fullName();
             }
             else
             {
@@ -93,10 +93,10 @@ namespace Drill4dotNet
         {
             if (!g_cb) return;
 
-            if (std::optional<FunctionName> functionName = g_cb->GetInfoHandler().TryGetFunctionName(funcId);
-                functionName)
+            if (std::optional<FunctionInfo> functionInfo = g_cb->GetInfoHandler().TryGetFunctionInfo(funcId);
+                functionInfo.has_value())
             {
-                g_cb->GetClient().Log() << L"Tailcall at function: " << functionName->fullName();
+                g_cb->GetClient().Log() << L"Tailcall at function: " << functionInfo->fullName();
             }
             else
             {
@@ -110,11 +110,11 @@ namespace Drill4dotNet
         {
             if (!g_cb) return funcId;
 
-            if (auto functionName = g_cb->GetCorProfilerInfo().TryGetFunctionFullName(funcId);
-                functionName)
+            if (auto functionInfo = g_cb->GetCorProfilerInfo().TryGetFunctionInfo(funcId);
+                functionInfo.has_value())
             {
-                g_cb->GetClient().Log() << "Mapping   function[" << funcId << "] to " << functionName->fullName();
-                g_cb->GetInfoHandler().MapFunctionName(funcId, functionName.value());
+                g_cb->GetClient().Log() << "Mapping   function[" << funcId << "] to " << functionInfo->fullName();
+                g_cb->GetInfoHandler().MapFunctionInfo(funcId, functionInfo.value());
             }
 
             if (pbHookFunction)
@@ -481,24 +481,22 @@ namespace Drill4dotNet
             // HelloWorld.Program.MyInjectionTarget function, at the place of
             // the Console.WriteLine call.
 
-            const std::optional<FunctionName> functionName{
-                m_corProfilerInfo->TryGetFunctionFullName(functionId) };
-
-            const FunctionInfo info = m_corProfilerInfo->GetFunctionInfo(functionId);
+            const FunctionInfo functionInfo{
+                m_corProfilerInfo->GetFunctionInfo(functionId) };
 
             const std::vector<std::byte> functionBytes{
-                m_corProfilerInfo->GetMethodIntermediateLanguageBody(info) };
+                m_corProfilerInfo->GetMethodIntermediateLanguageBody(functionInfo) };
 
             GetClient().Log()
                 << L"Compiling function "
                 << InSquareBrackets(functionId)
                 << L" "
-                << functionName->fullName()
+                << functionInfo.fullName()
                 << L" IL Body size: "
                 << functionBytes.size()
                 << L" bytes";
 
-            if (!functionName.has_value() || functionName->fullName() != L"HelloWorld.Program.MyInjectionTarget")
+            if (functionInfo.fullName() != L"HelloWorld.Program.MyInjectionTarget")
             {
                 return S_OK;
             }
@@ -556,7 +554,7 @@ namespace Drill4dotNet
                 << std::endl
                 << functionBody;
 
-            m_corProfilerInfo->SetILFunctionBody(info, afterInjection);
+            m_corProfilerInfo->SetILFunctionBody(functionInfo, afterInjection);
             GetClient().Log() << L"Injected successfully.";
 
             return S_OK;

--- a/Drill4dotNet/Drill4dotNet/CProfilerCallback.h
+++ b/Drill4dotNet/Drill4dotNet/CProfilerCallback.h
@@ -4,7 +4,7 @@
 #include <type_traits>
 
 #include "LogBuffer.h"
-#include "CorProfilerInfo.h"
+#include "CoreInteract.h"
 
 namespace Drill4dotNet
 {
@@ -39,11 +39,11 @@ namespace Drill4dotNet
     protected:
         ProClient& m_pImplClient;
         volatile ULONG m_lRef = 0;
-        std::optional<CorProfilerInfo<LogToProClient>> m_corProfilerInfo{};
+        std::unique_ptr<ICoreInteract> m_corProfilerInfo;
     public:
         CProfilerCallback(ProClient& client);
         ProClient& GetClient();
-        CorProfilerInfo<LogToProClient>& GetCorProfilerInfo();
+        ICoreInteract& GetCorProfilerInfo();
         InfoHandler& GetInfoHandler();
 
         // Inherited via IUnknown

--- a/Drill4dotNet/Drill4dotNet/CorDataStructures.h
+++ b/Drill4dotNet/Drill4dotNet/CorDataStructures.h
@@ -5,19 +5,20 @@
 
 namespace Drill4dotNet
 {
+    struct FunctionName
+    {
+        std::wstring ownName;
+        std::wstring className;
+    };
     struct FunctionInfo
     {
         ClassID classId;
         ModuleID moduleId;
         mdToken token;
-    };
-    struct FunctionName
-    {
-        std::wstring name;
-        std::wstring className;
+        FunctionName name;
         std::wstring fullName() const
         {
-            return className + L"." + name;
+            return name.className + L"." + name.ownName;
         }
     };
     struct AppDomainInfo

--- a/Drill4dotNet/Drill4dotNet/CorProfilerInfo.cpp
+++ b/Drill4dotNet/Drill4dotNet/CorProfilerInfo.cpp
@@ -1,0 +1,36 @@
+#include "pch.h"
+#include "CorProfilerInfo.h"
+#include "CProfilerCallback.h"
+
+// This file contains concrete implementations of factory-like functions to create instances of `ICoreInteract` from `CorProfilerInfo` class
+// It can be replaced to alternative implementatons of `ICoreInteract`, for example in Unit tests project.
+
+namespace Drill4dotNet
+{
+    template<typename TQueryInterface, typename TLogger>
+    std::unique_ptr<ICoreInteract> CreateCorProfilerInfo(TQueryInterface query, const TLogger logger)
+    {
+        return std::unique_ptr<ICoreInteract>{ new CorProfilerInfo(query, logger) };
+    }
+
+    template
+        std::unique_ptr<ICoreInteract> CreateCorProfilerInfo<IUnknown*, LogToProClient>(
+            IUnknown* pICorProfilerInfoUnk,
+            const LogToProClient logger);
+
+    template<typename TQueryInterface, typename TLogger>
+    std::unique_ptr<ICoreInteract> TryCreateCorProfilerInfo(TQueryInterface query, const TLogger logger)
+    {
+        if (const auto oCorProfilerInfo = CorProfilerInfo<TLogger>::TryCreate(query, logger);
+            oCorProfilerInfo.has_value())
+        {
+            return std::unique_ptr<ICoreInteract>{ new CorProfilerInfo(std::move(oCorProfilerInfo.value())) };
+        }
+        return nullptr;
+    }
+
+    template
+        std::unique_ptr<ICoreInteract> TryCreateCorProfilerInfo<IUnknown*, LogToProClient>(
+            IUnknown* pICorProfilerInfoUnk,
+            const LogToProClient logger);
+}

--- a/Drill4dotNet/Drill4dotNet/CoreInteract.h
+++ b/Drill4dotNet/Drill4dotNet/CoreInteract.h
@@ -72,10 +72,6 @@ namespace Drill4dotNet
         // Gets information about Functon (Method) by id. Returns std::nullopt in case of errors.
         virtual std::optional<FunctionInfo> TryGetFunctionInfo(const FunctionID functionId) const = 0;
 
-        //TODO: merge to above
-        virtual FunctionName GetFunctionFullName(const FunctionID functionId) const = 0;
-        virtual std::optional<FunctionName> TryGetFunctionFullName(const FunctionID functionId) const = 0;
-
         // Gets the Intermediate Language representation of the Function body. Throws on errors.
         // @returns a vector of bytes containing the function body in IL.
         // @param functionInfo : identifies the Function. @see GetFunctionInfo.

--- a/Drill4dotNet/Drill4dotNet/CoreInteract.h
+++ b/Drill4dotNet/Drill4dotNet/CoreInteract.h
@@ -1,0 +1,113 @@
+#pragma once
+
+#include "CorDataStructures.h"
+#include <optional>
+#include <vector>
+
+namespace Drill4dotNet
+{
+    // Interface to interact with CLR: to request information and to set profiler options
+    class ICoreInteract
+    {
+    public:
+        virtual ~ICoreInteract() = default;
+
+        // Gets information about CLR the profiler is running in. Throws on errors.
+        virtual RuntimeInformation GetRuntimeInformation() const = 0;
+
+        // Gets information about CLR the profiler is running in. Returns std::nullopt in case of errors.
+        virtual std::optional<RuntimeInformation> TryGetRuntimeInformation() const = 0;
+
+        // Sets the mask of events the profiler wants to receive notifications. Throws on errors.
+        virtual void SetEventMask(const uint32_t eventMask) const = 0;
+
+        // Sets the mask of events the profiler wants to receive notifications. Returns false on errors.
+        virtual bool TrySetEventMask(const uint32_t eventMask) const = 0;
+
+        // Sets the Function Mapper callback. Throws on errors.
+        virtual void SetFunctionIDMapper(FunctionIDMapper* pFunc) const = 0;
+
+        // Sets the Function Mapper callback. Returns false on errors.
+        virtual bool TrySetFunctionIDMapper(FunctionIDMapper* pFunc) const = 0;
+
+        // Sets Enter/Leave function callbacks (version 2). Throws on errors.
+        virtual void SetEnterLeaveFunctionHooks(
+            FunctionEnter2* pFuncEnter,
+            FunctionLeave2* pFuncLeave,
+            FunctionTailcall2* pFuncTailcall) const = 0;
+
+        // Sets Enter/Leave function callbacks (version 2). Returns false on errors.
+        virtual bool TrySetEnterLeaveFunctionHooks(
+            FunctionEnter2* pFuncEnter,
+            FunctionLeave2* pFuncLeave,
+            FunctionTailcall2* pFuncTailcall) const = 0;
+
+        // Gets information about Application Domain by id. Throws on errors.
+        virtual AppDomainInfo GetAppDomainInfo(const AppDomainID appDomainId) const = 0;
+
+        // Gets information about Application Domain by id. Returns std::nullopt in case of errors.
+        virtual std::optional<AppDomainInfo> TryGetAppDomainInfo(const AppDomainID appDomainId) const = 0;
+
+        // Gets information about Assembly by id. Throws on errors.
+        virtual AssemblyInfo GetAssemblyInfo(const AssemblyID assemblyId) const = 0;
+
+        // Gets information about Assembly by id. Returns std::nullopt in case of errors.
+        virtual std::optional<AssemblyInfo> TryGetAssemblyInfo(const AssemblyID assemblyId) const = 0;
+
+        // Gets information about Module by id. Throws on errors.
+        virtual ModuleInfo GetModuleInfo(const ModuleID moduleId) const = 0;
+
+        // Gets information about Module by id. Returns std::nullopt in case of errors.
+        virtual std::optional<ModuleInfo> TryGetModuleInfo(const ModuleID moduleId) const = 0;
+
+        // Gets information about Class (type) by id. Throws on errors.
+        virtual ClassInfo GetClassInfo(const ClassID classId) const = 0;
+
+        // Gets information about Class (type) by id. Returns std::nullopt in case of errors.
+        virtual std::optional<ClassInfo> TryGetClassInfo(const ClassID classId) const = 0;
+
+        // Gets information about Functon (Method) by id. Throws on errors.
+        virtual FunctionInfo GetFunctionInfo(const FunctionID functionId) const = 0;
+
+        // Gets information about Functon (Method) by id. Returns std::nullopt in case of errors.
+        virtual std::optional<FunctionInfo> TryGetFunctionInfo(const FunctionID functionId) const = 0;
+
+        //TODO: merge to above
+        virtual FunctionName GetFunctionFullName(const FunctionID functionId) const = 0;
+        virtual std::optional<FunctionName> TryGetFunctionFullName(const FunctionID functionId) const = 0;
+
+        // Gets the Intermediate Language representation of the Function body. Throws on errors.
+        // @returns a vector of bytes containing the function body in IL.
+        // @param functionInfo : identifies the Function. @see GetFunctionInfo.
+        virtual std::vector<std::byte> GetMethodIntermediateLanguageBody(const FunctionInfo& functionInfo) const = 0;
+
+        // Gets the Intermediate Language representation of the Function body. Returns std::nullopt in case of errors.
+        // @returns an optional vector of bytes containing the function body in IL.
+        // @param functionInfo : identifies the Function. @see GetFunctionInfo.
+        virtual std::optional<std::vector<std::byte>> TryGetMethodIntermediateLanguageBody(const FunctionInfo& functionInfo) const = 0;
+
+        // Sets the given the Intermediate Language representation to the Function body. Throws on errors.
+        // @param target : identifies the Function. @see GetFunctionInfo.
+        // @param newILMethodHeader : a vector of bytes to replace the Function body.
+        virtual void SetILFunctionBody(
+            const FunctionInfo& target,
+            const std::vector<std::byte>& newILMethodBody) const = 0;
+
+        // Sets the given the Intermediate Language representation to the Function body. Returns false on errors.
+        // @param target : identifies the Function. @see GetFunctionInfo.
+        // @param newILMethodHeader : a vector of bytes to replace the Function body.
+        virtual bool TrySetILFunctionBody(
+            const FunctionInfo& target,
+            const std::vector<std::byte>& newILMethodBody) const = 0;
+    };
+
+    // Factory-like function to create an instance of `ICoreInteract` interface. Throws on errors.
+    // Concrete implementations should be defined and instantiated in a separate cpp file.
+    template<typename TQueryInterface, typename TLogger>
+    std::unique_ptr<ICoreInteract> CreateCorProfilerInfo(TQueryInterface query, const TLogger logger);
+
+    // Factory-like function to create an instance of `ICoreInteract` interface. Returns unique_ptr(nullptr_t) on errors.
+    // Concrete implementations should be defined and instantiated in a separate cpp file.
+    template<typename TQueryInterface, typename TLogger>
+    std::unique_ptr<ICoreInteract> TryCreateCorProfilerInfo(TQueryInterface query, const TLogger logger);
+}

--- a/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj
+++ b/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj
@@ -234,6 +234,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="CoreInteract.h" />
     <ClInclude Include="MethodBody.h" />
     <ClInclude Include="MethodMalloc.h" />
     <ClInclude Include="OpCodes.h" />
@@ -258,6 +259,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="CDrillProfiler.cpp" />
+    <ClCompile Include="CorProfilerInfo.cpp" />
     <ClCompile Include="CProfilerCallback.cpp" />
     <ClCompile Include="dllmain.cpp" />
     <ClCompile Include="Drill4dotNet.cpp" />

--- a/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj.filters
+++ b/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj.filters
@@ -82,6 +82,9 @@
     <ClInclude Include="MethodMalloc.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="CoreInteract.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Drill4dotNet.cpp">
@@ -112,6 +115,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="MethodBody.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="CorProfilerInfo.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Drill4dotNet/Drill4dotNet/InfoHandler.cpp
+++ b/Drill4dotNet/Drill4dotNet/InfoHandler.cpp
@@ -17,36 +17,36 @@ namespace Drill4dotNet
         return LogBuffer<std::wostream>(m_ostream);
     }
 
-    void InfoHandler::MapFunctionName(const FunctionID id, const FunctionName& info) noexcept
+    void InfoHandler::MapFunctionInfo(const FunctionID id, const FunctionInfo& info) noexcept
     {
         try
         {
-            m_functionNames[id] = info;
+            m_functionInfos[id] = info;
             m_functionCounts[id] = { 0 };
         }
         catch (const std::exception & ex)
         {
-            Log() << "InfoHandler::MapFunctionName: exception while inserting function info by id [" << id << "]. " << ex.what();
+            Log() << "InfoHandler::MapFunctionInfo: exception while inserting function info by id [" << id << "]. " << ex.what();
         }
     }
 
-    std::optional<FunctionName> InfoHandler::TryGetFunctionName(const FunctionID id) const noexcept
+    std::optional<FunctionInfo> InfoHandler::TryGetFunctionInfo(const FunctionID id) const noexcept
     {
         try
         {
-            if (const auto it = m_functionNames.find(id);
-                m_functionNames.end() != it)
+            if (const auto it = m_functionInfos.find(id);
+                m_functionInfos.end() != it)
             {
                 return it->second;
             }
             else
             {
-                Log() << "InfoHandler::TryGetFunctionName: cannot find function by id [" << id << "].";
+                Log() << "InfoHandler::TryGetFunctionInfo: cannot find function by id [" << id << "].";
             }
         }
         catch (const std::exception & ex)
         {
-            Log() << "InfoHandler::TryGetFunctionName: exception while accessing function info by id [" << id << "]. " << ex.what();
+            Log() << "InfoHandler::TryGetFunctionInfo: exception while accessing function info by id [" << id << "]. " << ex.what();
         }
         return std::nullopt;
     }
@@ -74,7 +74,7 @@ namespace Drill4dotNet
     void InfoHandler::OutputStatistics() const
     {
         Log() << L"Statistics:";
-        Log() << L"Total number of functions mapped: " << m_functionNames.size();
+        Log() << L"Total number of functions mapped: " << m_functionInfos.size();
 
         size_t countFunctionsCalled = std::count_if(
             m_functionCounts.cbegin(),

--- a/Drill4dotNet/Drill4dotNet/InfoHandler.h
+++ b/Drill4dotNet/Drill4dotNet/InfoHandler.h
@@ -18,7 +18,7 @@ namespace Drill4dotNet
     using TAssemblyInfoMap = std::unordered_map<AssemblyID, AssemblyInfo>;
     using TModuleInfoMap = std::unordered_map<ModuleID, ModuleInfo>;
     using TClassInfoMap = std::unordered_map<ClassID, ClassInfo>;
-    using TFunctionNameMap = std::unordered_map<FunctionID, FunctionName>;
+    using TFunctionInfoMap = std::unordered_map<FunctionID, FunctionInfo>;
     using TFunctionRuntimeInfoMap = std::unordered_map<FunctionID, FunctionRuntimeInfo>;
 
     class InfoHandler
@@ -27,8 +27,8 @@ namespace Drill4dotNet
         explicit InfoHandler(std::wostream& log);
 
         void OutputStatistics() const;
-        void MapFunctionName(const FunctionID id, const FunctionName& info) noexcept;
-        std::optional<FunctionName> TryGetFunctionName(const FunctionID id) const noexcept;
+        void MapFunctionInfo(const FunctionID id, const FunctionInfo& info) noexcept;
+        std::optional<FunctionInfo> TryGetFunctionInfo(const FunctionID id) const noexcept;
         void FunctionCalled(const FunctionID id) noexcept;
         void MapAppDomainInfo(const AppDomainID id, const AppDomainInfo& info) noexcept;
         std::optional<AppDomainInfo> TryGetAppDomainInfo(const AppDomainID id) const noexcept;
@@ -46,7 +46,7 @@ namespace Drill4dotNet
         using Logger = LogBuffer<std::wostream>;
         Logger Log() const;
         std::wostream& m_ostream;
-        TFunctionNameMap m_functionNames;
+        TFunctionInfoMap m_functionInfos;
         TFunctionRuntimeInfoMap m_functionCounts;
         TAppDomainInfoMap m_appDomainInfos;
         TAssemblyInfoMap m_assemblyInfos;


### PR DESCRIPTION
Part 1. `ICoreInteract` interface
* Introduced `ICoreInteract` interface on `CorProfilerInfo` class;
* Isolated `CProfilerCallback` class from `CorProfilerInfo` class via `ICoreInteract` interface, thus allowing to vary implementation;
* Added isolated concrete implementation of factory-like functions in separate `CorProfileInfo.cpp` file, which can be varied with implementation, for example, in Unit test projects;
* Added implementations of missing pure virtual methods (in pair Get/TryGet) to `CorProfilerInfo` class and corresponding methods to `MetaDataImport` class;
* Hid `MethodMalloc` class usage inside `CorProfilerInfo::SetILFunctionBody`method, which now accepts `vector<byte>` as a new body.

Part 2. Merge `FunctionName` to `FunctionInfo`.
* Merge `FunctionName` structure to `FunctionInfo` structure and get function names right with other info in CorProfilerInfo::[Try]GetFunctionInfo;
* Removed `ICoreInteract::[Try]GetFunction[Full]Name` methods and their implementations.
