### PR TITLE
EPMDJ-2348: Mock for `ICoreInteract` interface and use it

### DIFF
--- a/Drill4dotNet/Drill4dotNet-Tests/CProfilerCallbackTest.cpp
+++ b/Drill4dotNet/Drill4dotNet-Tests/CProfilerCallbackTest.cpp
@@ -25,7 +25,7 @@ public:
     }
 
     std::unique_ptr<CoreInteractMock> coreInteractMock;
-    std::unique_ptr <ProClient> proClient;
+    std::unique_ptr<ProClient> proClient;
     std::unique_ptr<CProfilerCallback> profilerCallback;
 };
 
@@ -35,7 +35,7 @@ namespace Drill4dotNet
     std::unique_ptr<ICoreInteract> CreateCorProfilerInfo(TQueryInterface query, const TLogger logger)
     {
         // we pass ownership over the caller
-        return std::unique_ptr<ICoreInteract>(reinterpret_cast<CProfilerCallbackTest*>(query)->coreInteractMock.release());
+        return std::move(reinterpret_cast<CProfilerCallbackTest*>(query)->coreInteractMock);
     }
 
     template
@@ -47,7 +47,7 @@ namespace Drill4dotNet
     std::unique_ptr<ICoreInteract> TryCreateCorProfilerInfo(TQueryInterface query, const TLogger logger)
     {
         // we pass ownership over the caller
-        return std::unique_ptr<ICoreInteract>(reinterpret_cast<CProfilerCallbackTest*>(query)->coreInteractMock.release());
+        return std::move(reinterpret_cast<CProfilerCallbackTest*>(query)->coreInteractMock);
     }
 
     template

--- a/Drill4dotNet/Drill4dotNet-Tests/CProfilerCallbackTest.cpp
+++ b/Drill4dotNet/Drill4dotNet-Tests/CProfilerCallbackTest.cpp
@@ -1,0 +1,90 @@
+#include "pch.h"
+#include "CoreInteractMock.h"
+#include "ProClient.h"
+#include <CProfilerCallback.h>
+
+using namespace Drill4dotNet;
+using namespace testing;
+
+class CProfilerCallbackTest : public Test
+{
+public:
+    CProfilerCallbackTest()
+    {
+    }
+
+    void SetUp()
+    {
+        profilerCallback = new CProfilerCallback(*proClient);
+    }
+
+    void TearDown()
+    {
+        delete profilerCallback;
+    }
+
+    ~CProfilerCallbackTest()
+    {
+        delete proClient;
+    }
+
+    ProClient * proClient = new ProClient;
+    CProfilerCallback * profilerCallback = nullptr;
+};
+
+namespace Drill4dotNet
+{
+    static CoreInteractMock* coreInteractMock(new CoreInteractMock);
+
+    template<typename TQueryInterface, typename TLogger>
+    std::unique_ptr<ICoreInteract> CreateCorProfilerInfo(TQueryInterface query, const TLogger logger)
+    {
+        return std::unique_ptr<ICoreInteract>(coreInteractMock);
+    }
+
+    template
+        std::unique_ptr<ICoreInteract> CreateCorProfilerInfo<IUnknown*, LogToProClient>(
+            IUnknown* pICorProfilerInfoUnk,
+            const LogToProClient logger);
+
+    template<typename TQueryInterface, typename TLogger>
+    std::unique_ptr<ICoreInteract> TryCreateCorProfilerInfo(TQueryInterface query, const TLogger logger)
+    {
+        return std::unique_ptr<ICoreInteract>(coreInteractMock);
+    }
+
+    template
+        std::unique_ptr<ICoreInteract> TryCreateCorProfilerInfo<IUnknown*, LogToProClient>(
+            IUnknown* pICorProfilerInfoUnk,
+            const LogToProClient logger);
+}
+
+TEST_F(CProfilerCallbackTest, GetClient)
+{
+    ProClient _proClient;
+    CProfilerCallback _obj(_proClient);
+    EXPECT_EQ(&_proClient, &(_obj.GetClient()));
+}
+
+TEST_F(CProfilerCallbackTest, Initialize)
+{
+    const auto rti_expected = std::optional<RuntimeInformation>({ 0, COR_PRF_DESKTOP_CLR, 9, 9, 999, 8 });
+    EXPECT_CALL(*coreInteractMock, TryGetRuntimeInformation()).WillOnce(Return(rti_expected));
+    EXPECT_CALL(*coreInteractMock, SetEventMask(_)).WillOnce(Return());
+    EXPECT_CALL(*coreInteractMock, SetEnterLeaveFunctionHooks(_,_,_)).WillOnce(Return());
+    EXPECT_CALL(*coreInteractMock, SetFunctionIDMapper(_)).WillOnce(Return());
+
+    IUnknown* p = (IUnknown *)(~(NULL));
+    EXPECT_HRESULT_SUCCEEDED(profilerCallback->Initialize(p));
+    EXPECT_EQ(typeid(CoreInteractMock), typeid(profilerCallback->GetCorProfilerInfo()) );
+    EXPECT_EQ(coreInteractMock, &profilerCallback->GetCorProfilerInfo());
+}
+
+TEST_F(CProfilerCallbackTest, Shutdown)
+{
+    EXPECT_HRESULT_SUCCEEDED(profilerCallback->Shutdown());
+    EXPECT_EQ(NULL, &profilerCallback->GetCorProfilerInfo());
+}
+
+// Attach definitions of IID_ICorProfilerCallback, IID_ICorProfilerCallback2, IID_ICorProfilerInfo2, IID_ICorProfilerInfo3, etc.
+#include <corprof_i.cpp>

--- a/Drill4dotNet/Drill4dotNet-Tests/CoreInteractMock.h
+++ b/Drill4dotNet/Drill4dotNet-Tests/CoreInteractMock.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "CoreInteract.h"
+#include <gmock/gmock.h>
+
+namespace Drill4dotNet
+{
+    class CoreInteractMock : public ICoreInteract
+    {
+    public:
+        MOCK_METHOD(RuntimeInformation, GetRuntimeInformation, (), (const));
+        MOCK_METHOD(std::optional<RuntimeInformation>, TryGetRuntimeInformation, (), (const));
+        MOCK_METHOD(void, SetEventMask, (const uint32_t eventMask), (const));
+        MOCK_METHOD(bool, TrySetEventMask, (const uint32_t eventMask), (const));
+        MOCK_METHOD(void, SetFunctionIDMapper, (FunctionIDMapper* pFunc), (const));
+        MOCK_METHOD(bool, TrySetFunctionIDMapper, (FunctionIDMapper* pFunc), (const));
+        MOCK_METHOD(void, SetEnterLeaveFunctionHooks, (FunctionEnter2* pFuncEnter, FunctionLeave2* pFuncLeave, FunctionTailcall2* pFuncTailcall), (const));
+        MOCK_METHOD(bool, TrySetEnterLeaveFunctionHooks, (FunctionEnter2* pFuncEnter, FunctionLeave2* pFuncLeave, FunctionTailcall2* pFuncTailcall), (const));
+        MOCK_METHOD(AppDomainInfo, GetAppDomainInfo, (const AppDomainID appDomainId), (const));
+        MOCK_METHOD(std::optional<AppDomainInfo>, TryGetAppDomainInfo, (const AppDomainID appDomainId), (const));
+        MOCK_METHOD(AssemblyInfo, GetAssemblyInfo, (const AssemblyID assemblyId), (const));
+        MOCK_METHOD(std::optional<AssemblyInfo>, TryGetAssemblyInfo, (const AssemblyID assemblyId), (const));
+        MOCK_METHOD(ModuleInfo, GetModuleInfo, (const ModuleID moduleId), (const));
+        MOCK_METHOD(std::optional<ModuleInfo>, TryGetModuleInfo, (const ModuleID moduleId), (const));
+        MOCK_METHOD(std::optional<ClassInfo>, TryGetClassInfo, (const ClassID classId), (const));
+        MOCK_METHOD(FunctionInfo, GetFunctionInfo, (const FunctionID functionId), (const));
+        MOCK_METHOD(std::optional<FunctionInfo>, TryGetFunctionInfo, (const FunctionID functionId), (const));
+        MOCK_METHOD(std::vector<std::byte>, GetMethodIntermediateLanguageBody, (const FunctionInfo& functionInfo), (const));
+        MOCK_METHOD(std::optional<std::vector<std::byte>>, TryGetMethodIntermediateLanguageBody, (const FunctionInfo& functionInfo), (const));
+        MOCK_METHOD(void, SetILFunctionBody, (const FunctionInfo& target, const std::vector<std::byte>& newILMethodBody), (const));
+        MOCK_METHOD(bool, TrySetILFunctionBody, (const FunctionInfo& target, const std::vector<std::byte>& newILMethodBody), (const));
+        MOCK_METHOD(ClassInfo, GetClassInfo, (const ClassID classId), (const));
+    };
+}

--- a/Drill4dotNet/Drill4dotNet-Tests/Drill4dotNet-Tests.vcxproj
+++ b/Drill4dotNet/Drill4dotNet-Tests/Drill4dotNet-Tests.vcxproj
@@ -48,11 +48,27 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Use</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Use</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="..\Drill4dotNet\ExceptionClause.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Use</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Use</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="..\Drill4dotNet\ExceptionsSection.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Use</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Use</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="..\Drill4dotNet\InfoHandler.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Use</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Use</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="..\Drill4dotNet\InstructionStream.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Use</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Use</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="..\Drill4dotNet\MethodBody.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Use</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Use</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="..\Drill4dotNet\MethodHeader.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Use</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Use</PrecompiledHeader>
     </ClCompile>

--- a/Drill4dotNet/Drill4dotNet-Tests/Drill4dotNet-Tests.vcxproj
+++ b/Drill4dotNet/Drill4dotNet-Tests/Drill4dotNet-Tests.vcxproj
@@ -40,10 +40,35 @@
     <IncludePath>$(SolutionDir)Drill4dotNet\Drill4dotNet;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemGroup>
+    <ClInclude Include="CoreInteractMock.h" />
     <ClInclude Include="pch.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\Drill4dotNet\CProfilerCallback.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Use</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Use</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="..\Drill4dotNet\InfoHandler.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Use</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Use</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="..\Drill4dotNet\MethodBody.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Use</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Use</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="..\Drill4dotNet\OpCodes.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Use</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Use</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="..\Drill4dotNet\ProClient.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Use</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Use</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="main.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Use</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Use</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="CProfilerCallbackTest.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Use</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Use</PrecompiledHeader>
     </ClCompile>
@@ -90,6 +115,7 @@
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <InlineFunctionExpansion>Disabled</InlineFunctionExpansion>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/Drill4dotNet/Drill4dotNet-Tests/Drill4dotNet-Tests.vcxproj.filters
+++ b/Drill4dotNet/Drill4dotNet-Tests/Drill4dotNet-Tests.vcxproj.filters
@@ -11,9 +11,30 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\native\src\gmock\gmock-all.cc">
       <Filter>Package Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\Drill4dotNet\CProfilerCallback.cpp">
+      <Filter>Tested Source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Drill4dotNet\ProClient.cpp">
+      <Filter>Tested Source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Drill4dotNet\InfoHandler.cpp">
+      <Filter>Tested Source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Drill4dotNet\MethodBody.cpp">
+      <Filter>Tested Source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Drill4dotNet\OpCodes.cpp">
+      <Filter>Tested Source</Filter>
+    </ClCompile>
+    <ClCompile Include="CProfilerCallbackTest.cpp">
+      <Filter>Unit Tests</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
+    <ClInclude Include="CoreInteractMock.h">
+      <Filter>Unit Tests</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config">

--- a/Drill4dotNet/Drill4dotNet-Tests/Drill4dotNet-Tests.vcxproj.filters
+++ b/Drill4dotNet/Drill4dotNet-Tests/Drill4dotNet-Tests.vcxproj.filters
@@ -29,6 +29,18 @@
     <ClCompile Include="CProfilerCallbackTest.cpp">
       <Filter>Unit Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Drill4dotNet\InstructionStream.cpp">
+      <Filter>Tested Source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Drill4dotNet\ExceptionsSection.cpp">
+      <Filter>Tested Source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Drill4dotNet\ExceptionClause.cpp">
+      <Filter>Tested Source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Drill4dotNet\MethodHeader.cpp">
+      <Filter>Tested Source</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />


### PR DESCRIPTION
* EPMDJ-2348: Mock for `ICoreInteract` interface, Tests for `CProfilerCallback` class using the mock.

It is based on previous commit / pull-request #27.
