### PR TITLE
Tests for MethodBody and related classes

### DIFF
--- a/Drill4dotNet/Drill4dotNet-Tests/ByteUtilsTests.cpp
+++ b/Drill4dotNet/Drill4dotNet-Tests/ByteUtilsTests.cpp
@@ -3,3 +3,91 @@
 #include "ByteUtils.h"
 
 using namespace Drill4dotNet;
+
+TEST(ByteUtilsTests, AdvanceToBoundary)
+{
+    // Arrange
+    constexpr size_t boundary{ 4 };
+    const std::vector<std::byte> bytes(boundary * 2 + 3, std::byte{ 0 });
+    const auto firstPosition{ bytes.cbegin() };
+    const auto secondPosition{ bytes.cbegin() + boundary };
+    const auto thirdPosition{ bytes.cbegin() + boundary + 1 };
+    const auto forthPosition{ bytes.cend() - 1 };
+    const auto fifthPosition{ bytes.cend() };
+
+    // Act
+    const ptrdiff_t first = AdvanceToBoundary<boundary>(firstPosition, bytes);
+    const ptrdiff_t second = AdvanceToBoundary<boundary>(secondPosition, bytes);
+    const ptrdiff_t third = AdvanceToBoundary<boundary>(thirdPosition, bytes);
+    const ptrdiff_t forth = AdvanceToBoundary<boundary>(forthPosition, bytes);
+    const ptrdiff_t fifth = AdvanceToBoundary<boundary>(fifthPosition, bytes);
+
+    // Assert
+    EXPECT_EQ(0, first);
+    EXPECT_EQ(0, second);
+    EXPECT_EQ(3, third);
+    EXPECT_EQ(2, forth);
+    EXPECT_EQ(1, fifth);
+}
+
+TEST(ByteUtilsTests, AdvanceToBoundaryEmptyVector)
+{
+    // Arrange
+    constexpr size_t boundary{ 4 };
+    const std::vector<std::byte> bytes{};
+    const auto position{ bytes.cend() };
+
+    // Act
+    const ptrdiff_t mustAdvanceBy = AdvanceToBoundary<boundary>(position, bytes);
+
+    // Assert
+    EXPECT_EQ(0, mustAdvanceBy);
+}
+
+TEST(ByteUtilsTests, AppendAsBytes)
+{
+    // Arrange
+    const int value = 0x0734BDB5;
+    const std::vector<std::byte> expectedBytes
+    {
+        std::byte{ 0xB5 },
+        std::byte{ 0xBD },
+        std::byte{ 0x34 },
+        std::byte{ 0x07 }
+    };
+
+    // Act
+    std::vector<std::byte> bytes{};
+    AppendAsBytes(bytes, value);
+
+    // Assert
+    EXPECT_EQ(expectedBytes, bytes);
+}
+
+TEST(ByteUtilsTests, Overflows)
+{
+    // Arrange
+    const uint32_t tooLarge = 0xFD73EEF2;
+
+    // Act
+    const bool overflows = Overflows<int32_t>(tooLarge);
+
+    // Assert
+    EXPECT_TRUE(overflows);
+}
+
+static_assert(!Overflows<int8_t>(int8_t{ 0 }));
+static_assert(!Overflows<int>(int{ 0 }));
+static_assert(!Overflows<uint8_t>(uint8_t{ 0 }));
+static_assert(!Overflows<uint32_t>(uint32_t{ 0 }));
+static_assert(!Overflows<uint8_t>(int8_t{ 0 }));
+static_assert(!Overflows<uint32_t>(int{ 0 }));
+static_assert(!Overflows<int8_t>(uint8_t{ 0 }));
+static_assert(!Overflows<int>(uint32_t{ 0 }));
+static_assert(!Overflows<uint32_t>(uint8_t{ 0xC0 }));
+static_assert(!Overflows<uint8_t>(uint32_t{ 0xC0 }));
+static_assert(Overflows<uint8_t>(int8_t{ -1 }));
+static_assert(Overflows<uint8_t>(int{ -1 }));
+static_assert(Overflows<uint8_t>(uint32_t{ 0x0100 }));
+static_assert(Overflows<int8_t>(int{ 0x0100 }));
+static_assert(Overflows<int8_t>(int{ -0x0100 }));

--- a/Drill4dotNet/Drill4dotNet-Tests/ByteUtilsTests.cpp
+++ b/Drill4dotNet/Drill4dotNet-Tests/ByteUtilsTests.cpp
@@ -1,0 +1,5 @@
+#include "pch.h"
+
+#include "ByteUtils.h"
+
+using namespace Drill4dotNet;

--- a/Drill4dotNet/Drill4dotNet-Tests/Drill4dotNet-Tests.vcxproj
+++ b/Drill4dotNet/Drill4dotNet-Tests/Drill4dotNet-Tests.vcxproj
@@ -84,11 +84,39 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Use</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Use</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="ByteUtilsTests.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Use</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Use</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="main.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Use</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Use</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="CProfilerCallbackTest.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Use</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Use</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="ExceptionClauseTests.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Use</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Use</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="ExceptionsSectionTests.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Use</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Use</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="InstructionStreamTests.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Use</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Use</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="MethodBodyTests.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Use</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Use</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="MethodHeaderTests.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Use</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Use</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="OpCodeVariantTests.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Use</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Use</PrecompiledHeader>
     </ClCompile>

--- a/Drill4dotNet/Drill4dotNet-Tests/Drill4dotNet-Tests.vcxproj.filters
+++ b/Drill4dotNet/Drill4dotNet-Tests/Drill4dotNet-Tests.vcxproj.filters
@@ -44,6 +44,27 @@
     <ClCompile Include="..\Drill4dotNet\MethodHeader.cpp">
       <Filter>Tested Source</Filter>
     </ClCompile>
+    <ClCompile Include="ExceptionClauseTests.cpp">
+      <Filter>Unit Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="ExceptionsSectionTests.cpp">
+      <Filter>Unit Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="InstructionStreamTests.cpp">
+      <Filter>Unit Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="MethodBodyTests.cpp">
+      <Filter>Unit Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="MethodHeaderTests.cpp">
+      <Filter>Unit Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="OpCodeVariantTests.cpp">
+      <Filter>Unit Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="ByteUtilsTests.cpp">
+      <Filter>Unit Tests</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />

--- a/Drill4dotNet/Drill4dotNet-Tests/ExceptionClauseTests.cpp
+++ b/Drill4dotNet/Drill4dotNet-Tests/ExceptionClauseTests.cpp
@@ -1,0 +1,5 @@
+#include "pch.h"
+
+#include "ExceptionClause.h"
+
+using namespace Drill4dotNet;

--- a/Drill4dotNet/Drill4dotNet-Tests/ExceptionClauseTests.cpp
+++ b/Drill4dotNet/Drill4dotNet-Tests/ExceptionClauseTests.cpp
@@ -3,3 +3,598 @@
 #include "ExceptionClause.h"
 
 using namespace Drill4dotNet;
+
+// Data required to create an ExceptionClause.
+template <typename TRawClause>
+class RawExceptionClause
+{
+public:
+    TRawClause RawClause;
+    InstructionStream Stream;
+    LabelCreator LabelCreator;
+};
+
+// Common part of TryCatch, TryCatchWhen, and TryFinally methods.
+// Returns representation of method
+// int GetSum()
+// {
+//     int x = 1;
+//     int y = 2;
+//     int z;
+//     try
+//     {
+//         z = x + y;
+//     }
+//     // catch or finally handler
+//     {
+//         z = 0;
+//     }
+//
+//     return z;
+// }
+template <typename TRawClause>
+static RawExceptionClause<TRawClause> RawClause()
+{
+    LabelCreator creator{};
+    const Label exitLabel { creator.CreateLabel() };
+
+    // all instructions are 1 byte
+    InstructionStream stream {
+        // int x = 1;
+        OpCode_CEE_LDC_I4_1{},
+        OpCode_CEE_STLOC_0{},
+
+        // int y = 2;
+        OpCode_CEE_LDC_I4_2{},
+        OpCode_CEE_STLOC_1{},
+
+        // will have try { here
+
+        // z = x + y;
+        OpCode_CEE_LDLOC_0{},
+        OpCode_CEE_LDLOC_1{},
+        OpCode_CEE_ADD{},
+        OpCode_CEE_STLOC_2{},
+
+        OpCode_CEE_LEAVE{ exitLabel },
+        // will have
+        // } // end of try
+        // /* begin of handler */
+        // {
+
+        // z = 0;
+        OpCode_CEE_LDC_I4_0{},
+        OpCode_CEE_STLOC_2{},
+        OpCode_CEE_LEAVE_S{exitLabel},
+        // here
+        // Will have } here
+
+        // return z;
+        exitLabel,
+        OpCode_CEE_RET{}
+    };
+
+    TRawClause rawClause;
+    rawClause.TryOffset = 4;
+    rawClause.TryLength = 9;
+    rawClause.HandlerOffset = 13;
+    rawClause.HandlerLength = 4;
+
+    return { rawClause, stream, creator };
+}
+
+// Asserts the instructions stream has the given
+// label at the given postion, and the label has the given id.
+static void AssertLabelAt(
+    const Label label,
+    const ConstStreamPosition position,
+    const Label::Id expectedId)
+{
+    const Label* streamLabel = std::get_if<Label>(&*position);
+
+    EXPECT_NE(nullptr, streamLabel);
+    if (streamLabel == nullptr)
+    {
+        return;
+    }
+
+    EXPECT_EQ(expectedId, streamLabel->GetId());
+    EXPECT_EQ(streamLabel->GetId(), label.GetId());
+}
+
+// Asserts that the given exception clause and
+// instructions stream represent the exception handling
+// structures returned by RawClause().
+static void AssertRightLabelsAdded(const ExceptionClause& clause, const InstructionStream& stream)
+{
+    ASSERT_TRUE(stream.size() > 17);
+
+    AssertLabelAt(
+        clause.TryOffset(),
+        stream.cbegin() + 4,
+        1);
+
+    AssertLabelAt(
+        clause.TryEndOffset(),
+        stream.cbegin() + 10,
+        2);
+
+    AssertLabelAt(
+        clause.HandlerOffset(),
+        stream.cend() - 7,
+        3);
+
+    AssertLabelAt(
+        clause.HandlerEndOffset(),
+        stream.cend() - 2,
+        4);
+}
+
+// Checks that two given exception clauses have all same values.
+template <typename TRawClause>
+static void AssertRawClausesEqual(const TRawClause& expected, const TRawClause& actual)
+{
+    EXPECT_EQ(expected.Flags, actual.Flags);
+    EXPECT_EQ(expected.TryOffset, actual.TryOffset);
+    EXPECT_EQ(expected.TryLength, actual.TryLength);
+    EXPECT_EQ(expected.HandlerOffset, actual.HandlerOffset);
+    EXPECT_EQ(expected.HandlerLength, actual.HandlerLength);
+}
+
+// If TRawClause is IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_FAT,
+// asserts that the given clause cannot be put to a small header.
+// Otherwise, asserts the clause can be put to a small header.
+template <typename TRawClause>
+static void AssertCanPutToSmallHeader(const ExceptionClause& clause)
+{
+    if constexpr (std::is_same_v<TRawClause, IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_FAT>)
+    {
+        EXPECT_FALSE(clause.CanPutToSmallHeader());
+    }
+    else
+    {
+        EXPECT_TRUE(clause.CanPutToSmallHeader());
+    }
+}
+
+// Returns representation of method
+// int GetSum()
+// {
+//     int x = 1;
+//     int y = 2;
+//     int z;
+//     try
+//     {
+//         z = x + y;
+//     }
+//     catch (Exception)
+//     {
+//         z = 0;
+//     }
+//
+//     return z;
+// }
+template <typename TRawClause>
+static RawExceptionClause<TRawClause> TryCatch()
+{
+    auto result = RawClause<TRawClause>();
+    result.RawClause.Flags = COR_ILEXCEPTION_CLAUSE_NONE;
+    result.RawClause.ClassToken = 0x4589D7F3;
+    return result;
+}
+
+// Returns representation of method
+// int GetSum()
+// {
+//     int x = 1;
+//     int y = 2;
+//     int z;
+//     try
+//     {
+//         z = x + y;
+//     }
+//     // Not valid C# or MSIL code, but does not matter
+//     // for the exception clause test.
+//     catch (Exception e) when e == 3
+//     {
+//         z = 0;
+//     }
+//
+//     return z;
+// }
+template <typename TRawClause>
+static RawExceptionClause<TRawClause> TryCatchWhen()
+{
+    auto result = RawClause<TRawClause>();
+    result.Stream.insert(result.Stream.cbegin() + 9,
+        {
+            OpCode_CEE_LDLOC_S{4},
+            OpCode_CEE_LDC_I4_3{},
+            OpCode_CEE_CEQ{}
+        });
+    result.RawClause.Flags = COR_ILEXCEPTION_CLAUSE_FILTER;
+    result.RawClause.FilterOffset = result.RawClause.HandlerOffset;
+    result.RawClause.HandlerOffset += 5;
+    return result;
+}
+
+// Returns representation of method
+// int GetSum()
+// {
+//     int x = 1;
+//     int y = 2;
+//     int z;
+//     try
+//     {
+//         z = x + y;
+//     }
+//     finally
+//     {
+//         z = 0;
+//     }
+//
+//     return z;
+// }
+template <typename TRawClause>
+static RawExceptionClause<TRawClause> TryFinally()
+{
+    auto result = RawClause<TRawClause>();
+    result.RawClause.Flags = COR_ILEXCEPTION_CLAUSE_FINALLY;
+    result.RawClause.ClassToken = 0;
+    return result;
+}
+
+// Checks that ExceptionClause with try..catch is
+// created from a small or fat header.
+template <typename TRawClause>
+static void CreateTryCatch()
+{
+    // Arrange
+    auto [rawClause, stream, labelCreator]
+        = TryCatch<TRawClause>();
+
+    // Act
+    ExceptionClause clause(
+        rawClause,
+        stream,
+        labelCreator);
+
+    // Assert
+    EXPECT_EQ(18, stream.size());
+    AssertRightLabelsAdded(clause, stream);
+    AssertCanPutToSmallHeader<TRawClause>(clause);
+    EXPECT_FALSE(clause.IsFinally());
+    EXPECT_FALSE(std::holds_alternative<Label>(clause.Handler()));
+    ASSERT_TRUE(std::holds_alternative<mdTypeDef>(clause.Handler()));
+    EXPECT_EQ(rawClause.ClassToken, std::get<mdTypeDef>(clause.Handler()));
+}
+
+// Checks that ExceptionClause with try..catch with when
+// is created from a small or fat header.
+template <typename TRawClause>
+static void CreateTryCatchWhen()
+{
+    // Arrange
+    auto [rawClause, stream, labelCreator]
+        = TryCatchWhen<TRawClause>();
+
+    // Act
+    ExceptionClause clause(
+        rawClause,
+        stream,
+        labelCreator);
+
+    // Assert
+    EXPECT_EQ(22, stream.size());
+    AssertRightLabelsAdded(clause, stream);
+    AssertCanPutToSmallHeader<TRawClause>(clause);
+    EXPECT_FALSE(clause.IsFinally());
+    EXPECT_FALSE(std::holds_alternative<mdTypeDef>(clause.Handler()));
+    ASSERT_TRUE(std::holds_alternative<Label>(clause.Handler()));
+    AssertLabelAt(
+        std::get<Label>(clause.Handler()),
+        stream.cbegin() + 11,
+        5);
+}
+
+// Checks that ExceptionClause with try..finally
+// is created from a small or fat header.
+template <typename TRawClause>
+static void CreateTryFinally()
+{
+    // Arrange
+    auto [rawClause, stream, labelCreator]
+        = TryFinally<TRawClause>();
+
+    // Act
+    ExceptionClause clause(
+        rawClause,
+        stream,
+        labelCreator);
+
+    // Assert
+    EXPECT_EQ(18, stream.size());
+    AssertRightLabelsAdded(clause, stream);
+    AssertCanPutToSmallHeader<TRawClause>(clause);
+    EXPECT_TRUE(clause.IsFinally());
+    EXPECT_FALSE(std::holds_alternative<Label>(clause.Handler()));
+    ASSERT_TRUE(std::holds_alternative<mdTypeDef>(clause.Handler()));
+    EXPECT_EQ(rawClause.ClassToken, std::get<mdTypeDef>(clause.Handler()));
+}
+
+// Calls FillSmallHeader() or FillFatHeader() for the given
+// clause, depending on the argument header type.
+template <typename TRawClause>
+static TRawClause FillRawClause(const ExceptionClause& clause)
+{
+    if constexpr (std::is_same_v<TRawClause, IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_SMALL>)
+    {
+        return clause.FillSmallHeader();
+    }
+    else
+    {
+        return clause.FillFatHeader();
+    }
+}
+
+// Checks that ExceptionClause representing try..catch is
+// converted back to fat or small header.
+template <typename TRawClause>
+static void FillRawClauseTryCatch()
+{
+    // Arrange
+    auto [rawClause, stream, labelCreator]
+        = TryCatch<TRawClause>();
+    ExceptionClause clause(
+        rawClause,
+        stream,
+        labelCreator);
+
+    // Act
+    TRawClause serialized{ FillRawClause<TRawClause>(clause) };
+
+    // Assert
+    AssertRawClausesEqual(rawClause, serialized);
+    EXPECT_EQ(rawClause.ClassToken, serialized.ClassToken);
+}
+
+// Checks that ExceptionClause representing try..catch with when is
+// converted back to fat or small header.
+template <typename TRawClause>
+static void FillRawClauseTryCatchWhen()
+{
+    // Arrange
+    auto [rawClause, stream, labelCreator]
+        = TryCatchWhen<TRawClause>();
+    ExceptionClause clause(
+        rawClause,
+        stream,
+        labelCreator);
+
+    // Act
+    TRawClause serialized{ FillRawClause<TRawClause>(clause) };
+
+    // Assert
+    AssertRawClausesEqual(rawClause, serialized);
+    EXPECT_EQ(rawClause.FilterOffset, serialized.FilterOffset);
+}
+
+// Checks that ExceptionClause representing try..finally is
+// converted back to fat or small header.
+template <typename TRawClause>
+static void FillRawClauseTryFinally()
+{
+    // Arrange
+    auto [rawClause, stream, labelCreator]
+        = TryFinally<TRawClause>();
+    ExceptionClause clause(
+        rawClause,
+        stream,
+        labelCreator);
+
+    // Act
+    TRawClause serialized{ FillRawClause<TRawClause>(clause) };
+
+    // Assert
+    AssertRawClausesEqual(rawClause, serialized);
+    EXPECT_EQ(rawClause.ClassToken, serialized.ClassToken);
+}
+
+// Checks that ExceptionClause with try..catch is
+// created from a small header.
+TEST(ExceptionClauseTests, CreateTryCatchFromSmallClause)
+{
+    CreateTryCatch<IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_SMALL>();
+}
+
+// Checks that ExceptionClause with try..catch with when
+// is created from a small header.
+TEST(ExceptionClauseTests, CreateTryCatchWhenFromSmallClause)
+{
+    CreateTryCatchWhen<IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_SMALL>();
+}
+
+// Checks that ExceptionClause with try..finally
+// is created from a small header.
+TEST(ExceptionClauseTests, CreateTryFinallyFromSmallClause)
+{
+    CreateTryFinally<IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_SMALL>();
+}
+
+// Checks that ExceptionClause with try..catch is
+// created from a fat header.
+TEST(ExceptionClauseTests, CreateTryCatchFromFatClause)
+{
+    CreateTryCatch<IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_FAT>();
+}
+
+// Checks that ExceptionClause with try..catch with when
+// is created from a fat header.
+TEST(ExceptionClauseTests, CreateTryCatchWhenFromFatClause)
+{
+    CreateTryCatchWhen<IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_FAT>();
+}
+
+// Checks that ExceptionClause with try..finally
+// is created from a fat header.
+TEST(ExceptionClauseTests, CreateTryFinallyFromFatClause)
+{
+    CreateTryFinally<IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_FAT>();
+}
+
+// Checks that ExceptionClause representing try..catch is
+// converted back to small header.
+TEST(ExceptionClauseTests, FillSmallHeaderTryCatch)
+{
+    FillRawClauseTryCatch<IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_SMALL>();
+}
+
+// Checks that ExceptionClause representing try..catch with when is
+// converted back to small header.
+TEST(ExceptionClauseTests, FillSmallHeaderTryCatchWhen)
+{
+    FillRawClauseTryCatchWhen<IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_SMALL>();
+}
+
+// Checks that ExceptionClause representing try..finally is
+// converted back to small header.
+TEST(ExceptionClauseTests, FillSmallHeaderTryFinally)
+{
+    FillRawClauseTryFinally<IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_SMALL>();
+}
+
+// Checks that ExceptionClause representing try..catch is
+// converted back to fat header.
+TEST(ExceptionClauseTests, FillFatHeaderTryCatch)
+{
+    FillRawClauseTryCatch<IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_FAT>();
+}
+
+// Checks that ExceptionClause representing try..catch with when is
+// converted back to fat header.
+TEST(ExceptionClauseTests, FillFatHeaderTryCatchWhen)
+{
+    FillRawClauseTryCatchWhen<IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_FAT>();
+}
+
+// Checks that ExceptionClause representing try..finally is
+// converted back to fat header.
+TEST(ExceptionClauseTests, FillFatHeaderTryFinally)
+{
+    FillRawClauseTryFinally<IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_FAT>();
+}
+
+// Checks that the ExceptionClause representing try..catch,
+// which was created from a small header, cannot be stored
+// back to a small header after inserting the given
+// amount of No Operation instructions at the given position.
+template<size_t paddingSize, ptrdiff_t paddingPosition>
+static void CanPutToSmallHeaderFalse()
+{
+    // Arrange
+    auto [rawClause, stream, labelCreator]
+        = TryCatch<IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_SMALL>();
+
+    ExceptionClause clause(
+        rawClause,
+        stream,
+        labelCreator);
+
+    // Act
+    stream.insert(
+        stream.cbegin() + paddingPosition,
+        paddingSize,
+        OpCode_CEE_NOP{});
+
+    // Assert
+    EXPECT_FALSE(clause.CanPutToSmallHeader());
+}
+
+// Checks that the ExceptionClause representing try..catch,
+// which was created from a small header, cannot be stored
+// back to a small header after inserting a lot of No Operation
+// instructions before the beginning of try.
+TEST(ExceptionClauseTests, CanPutToSmallHeaderFarTry)
+{
+    CanPutToSmallHeaderFalse<0x00010000, 4>();
+}
+
+// Checks that the ExceptionClause representing try..catch with when,
+// which was created from a small header, cannot be stored
+// back to a small header after inserting a lot of No Operation
+// instructions in the middle of the when block, in case of when
+// block is between try and catch blocks.
+TEST(ExceptionClauseTests, CanPutToSmallHeaderFarCatch)
+{
+    // Arrange
+    auto [rawClause, stream, labelCreator]
+        = TryCatchWhen<IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_SMALL>();
+
+    ExceptionClause clause(
+        rawClause,
+        stream,
+        labelCreator);
+
+    // Act
+    size_t padding { 0x00010000 };
+    stream.insert(
+        stream.cbegin() + 13,
+        padding,
+        OpCode_CEE_NOP{});
+
+    // Assert
+    EXPECT_FALSE(clause.CanPutToSmallHeader());
+}
+
+// Checks that the ExceptionClause representing try..catch,
+// which was created from a small header, cannot be stored
+// back to a small header after inserting a lot of No Operation
+// instructions in the middle of the try block.
+TEST(ExceptionClauseTests, CanPutToSmallHeaderBigTry)
+{
+    CanPutToSmallHeaderFalse<0x0100, 9>();
+}
+
+// Checks that the ExceptionClause representing try..catch,
+// which was created from a small header, cannot be stored
+// back to a small header after inserting a lot of No Operation
+// instructions in the middle of the catch block.
+TEST(ExceptionClauseTests, CanPutToSmallHeaderBigCatch)
+{
+    CanPutToSmallHeaderFalse<0x0100, 13>();
+}
+
+// Checks that the ExceptionClause representing try..catch with when,
+// which was created from a small header, can be stored
+// back to a small header after inserting a lot of No Operation
+// instructions in the middle of the when block, in case of when
+// block is after try and catch blocks.
+TEST(ExceptionClauseTests, CanPutToSmallHeaderFarWhen)
+{
+    // Arrange
+    auto [rawClause, stream, labelCreator]
+        = RawClause<IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_SMALL>();
+    stream.insert(stream.cend(),
+        {
+            OpCode_CEE_LDLOC_S{4},
+            OpCode_CEE_LDC_I4_3{},
+            OpCode_CEE_CEQ{}
+        });
+    rawClause.Flags = COR_ILEXCEPTION_CLAUSE_FILTER;
+    rawClause.FilterOffset = 18;
+
+    ExceptionClause clause(
+        rawClause,
+        stream,
+        labelCreator);
+
+    // Act
+    const size_t paddingSize { 0x00010000 };
+    stream.insert(
+        stream.cbegin() + 18,
+        paddingSize,
+        OpCode_CEE_NOP{});
+
+    // Assert
+    EXPECT_TRUE(clause.CanPutToSmallHeader());
+}

--- a/Drill4dotNet/Drill4dotNet-Tests/ExceptionsSectionTests.cpp
+++ b/Drill4dotNet/Drill4dotNet-Tests/ExceptionsSectionTests.cpp
@@ -3,3 +3,440 @@
 #include "ExceptionsSection.h"
 
 using namespace Drill4dotNet;
+
+// Creates instructions stream containing of
+// four No Operation instructions.
+InstructionStream CreateStream()
+{
+    return InstructionStream(4, OpCode_CEE_NOP{});
+}
+
+// Creates a small exception clause header,
+// compatible with instructions stream
+// from CreateStream().
+constexpr static auto CreateSmallClause()
+{
+    return std::array
+    {
+        // Flags
+        std::byte { 0x00 },
+        std::byte { 0x00 },
+
+        // TryOffset
+        std::byte { 0x01 },
+        std::byte { 0x00 },
+
+        // TryLength
+        std::byte { 0x01 },
+
+        // HandlerOffset
+        std::byte { 0x02 },
+        std::byte { 0x00 },
+
+        // HandlerLength
+        std::byte { 0x01 },
+
+        // ClassToken
+        std::byte { 0x10 },
+        std::byte { 0x20 },
+        std::byte { 0x40 },
+        std::byte { 0x80 }
+    };
+}
+
+// Creates a fat exception clause header,
+// compatible with instructions stream
+// from CreateStream().
+constexpr static auto CreateFatClause()
+{
+    return std::array
+    {
+        // Flags
+        std::byte { 0x00 },
+        std::byte { 0x00 },
+        std::byte { 0x00 },
+        std::byte { 0x00 },
+
+        // TryOffset
+        std::byte { 0x01 },
+        std::byte { 0x00 },
+        std::byte { 0x00 },
+        std::byte { 0x00 },
+
+        // TryLength
+        std::byte { 0x01 },
+        std::byte { 0x00 },
+        std::byte { 0x00 },
+        std::byte { 0x00 },
+
+        // HandlerOffset
+        std::byte { 0x02 },
+        std::byte { 0x00 },
+        std::byte { 0x00 },
+        std::byte { 0x00 },
+
+        // HandlerLength
+        std::byte { 0x01 },
+        std::byte { 0x00 },
+        std::byte { 0x00 },
+        std::byte { 0x00 },
+
+        // ClassToken
+        std::byte { 0x10 },
+        std::byte { 0x20 },
+        std::byte { 0x40 },
+        std::byte { 0x80 }
+    };
+}
+
+// Concatenates several arrays of bytes into one vector
+template <size_t ... sizes>
+static std::vector<std::byte> Concat(const std::array<std::byte, sizes>& ... arrays)
+{
+    std::vector<std::byte> result{};
+    (
+        result.insert(
+            result.cend(),
+            arrays.cbegin(),
+            arrays.cend())
+        ,
+        ...
+    );
+    return result;
+}
+
+// Checks that an ExceptionsSection is created from
+// a small bytes representation and converted back to
+// the same bytes.
+TEST(ExceptionsSectionTests, CreateFromSmallClauses)
+{
+    // Arrange
+    constexpr auto sectionHeader = std::array {
+        std::byte { 0x01 },
+        std::byte { 0x10 },
+        std::byte { 0x00 },
+        std::byte { 0x00 }
+    };
+
+    const std::vector<std::byte> sectionData { Concat(
+        sectionHeader,
+        CreateSmallClause()
+    ) };
+
+    InstructionStream stream { CreateStream() };
+    LabelCreator labelCreator{};
+
+    // Act
+    std::vector<std::byte>::const_iterator iterator { sectionData.cbegin() };
+    ExceptionsSection section(
+        iterator,
+        sectionData.cend(),
+        stream,
+        labelCreator);
+    std::vector<std::byte> serialized{};
+    section.AppendToBytes(serialized);
+
+    // Assert
+    EXPECT_EQ(1, section.Clauses().size());
+    EXPECT_EQ(sectionData, serialized);
+    EXPECT_EQ(sectionData.cend(), iterator);
+    EXPECT_FALSE(section.HasMoreSections());
+}
+
+// Checks that an ExceptionsSection with MoreSections flag
+// is created from a small bytes representation and converted
+// back to the same bytes.
+TEST(ExceptionsSectionTests, CreateFromSmallClausesWithMoreSections)
+{
+    // Arrange
+    constexpr auto firstSectionHeader = std::array {
+        std::byte { 0x81 },
+        std::byte { 0x10 },
+        std::byte { 0x00 },
+        std::byte { 0x00 },
+    };
+
+    constexpr auto secondSectionHeader = std::array {
+        std::byte{ 0x01 },
+        std::byte{ 0x10 },
+        std::byte{ 0x00 },
+        std::byte{ 0x00 }
+    };
+
+    const std::vector<std::byte> expectedSerialized { Concat(
+        firstSectionHeader,
+        CreateSmallClause()
+    ) };
+
+    const std::vector<std::byte> sectionData { Concat(
+        firstSectionHeader,
+        CreateSmallClause(),
+        secondSectionHeader,
+        CreateSmallClause()
+    ) };
+
+    InstructionStream stream { CreateStream() };
+    LabelCreator labelCreator{};
+
+    // Act
+    std::vector<std::byte>::const_iterator iterator { sectionData.cbegin() };
+    ExceptionsSection section(
+        iterator,
+        sectionData.cend(),
+        stream,
+        labelCreator);
+    std::vector<std::byte> serialized{};
+    section.AppendToBytes(serialized);
+
+    // Assert
+    EXPECT_EQ(1, section.Clauses().size());
+    EXPECT_EQ(expectedSerialized, serialized);
+    EXPECT_EQ(sectionData.cbegin() + 0x10, iterator);
+    EXPECT_TRUE(section.HasMoreSections());
+}
+
+// Checks that an ExceptionsSection is created from
+// a fat bytes representation and converted back to
+// the same bytes.
+TEST(ExceptionsSectionTests, CreateFromFatClauses)
+{
+    // Arrange
+    constexpr auto sectionHeader = std::array {
+        std::byte { 0x41 },
+        std::byte { 0x1C },
+        std::byte { 0x00 },
+        std::byte { 0x00 }
+    };
+
+    const std::vector<std::byte> sectionData { Concat(
+        sectionHeader,
+        CreateFatClause()
+    ) };
+
+    InstructionStream stream { CreateStream() };
+    LabelCreator labelCreator{};
+
+    // Act
+    std::vector<std::byte>::const_iterator iterator { sectionData.cbegin() };
+    ExceptionsSection section(
+        iterator,
+        sectionData.cend(),
+        stream,
+        labelCreator);
+    std::vector<std::byte> serialized{};
+    section.AppendToBytes(serialized);
+
+    // Assert
+    EXPECT_EQ(1, section.Clauses().size());
+    EXPECT_EQ(sectionData, serialized);
+    EXPECT_EQ(sectionData.cend(), iterator);
+    EXPECT_FALSE(section.HasMoreSections());
+}
+
+// Checks that an ExceptionsSection with MoreSections flag
+// is created from a fat bytes representation and converted
+// back to the same bytes.
+TEST(ExceptionsSectionTests, CreateFromFatClausesWithMoreSections)
+{
+    // Arrange
+    constexpr auto firstSectionHeader = std::array {
+        std::byte { 0xC1 },
+        std::byte { 0x1C },
+        std::byte { 0x00 },
+        std::byte { 0x00 },
+    };
+
+    constexpr auto secondSectionHeader = std::array {
+        std::byte{ 0x01 },
+        std::byte{ 0x10 },
+        std::byte{ 0x00 },
+        std::byte{ 0x00 }
+    };
+
+    const std::vector<std::byte> expectedSerialized { Concat(
+        firstSectionHeader,
+        CreateFatClause()
+    ) };
+
+    const std::vector<std::byte> sectionData { Concat(
+        firstSectionHeader,
+        CreateFatClause(),
+        secondSectionHeader,
+        CreateSmallClause()
+    ) };
+
+    InstructionStream stream { CreateStream() };
+    LabelCreator labelCreator{};
+
+    // Act
+    std::vector<std::byte>::const_iterator iterator { sectionData.cbegin() };
+    ExceptionsSection section(
+        iterator,
+        sectionData.cend(),
+        stream,
+        labelCreator);
+    std::vector<std::byte> serialized{};
+    section.AppendToBytes(serialized);
+
+    // Assert
+    EXPECT_EQ(1, section.Clauses().size());
+    EXPECT_EQ(expectedSerialized, serialized);
+    EXPECT_EQ(sectionData.cbegin() + 0x1C, iterator);
+    EXPECT_TRUE(section.HasMoreSections());
+}
+
+// Checks that exceptions section created from
+// small bytes representation will convert to
+// a fat bytes representation if one of the
+// exception clauses cannot be stored into small
+// form after injection.
+TEST(ExceptionsSectionTests, ExtendSectionOfSmallClauses)
+{
+    // Arrange
+    constexpr auto sectionHeader = std::array{
+        std::byte { 0x01 },
+        std::byte { 0x1C },
+        std::byte { 0x00 },
+        std::byte { 0x00 }
+    };
+
+    constexpr auto secondClause = std::array
+    {
+        // Flags
+        std::byte { 0x00 },
+        std::byte { 0x00 },
+
+        // TryOffset
+        std::byte { 0x05 },
+        std::byte { 0x00 },
+
+        // TryLength
+        std::byte { 0x01 },
+
+        // HandlerOffset
+        std::byte { 0x06 },
+        std::byte { 0x00 },
+
+        // HandlerLength
+        std::byte { 0x01 },
+
+        // ClassToken
+        std::byte { 0x10 },
+        std::byte { 0x20 },
+        std::byte { 0x40 },
+        std::byte { 0x80 }
+    };
+
+    const std::vector<std::byte> sectionData { Concat(
+        sectionHeader,
+        CreateSmallClause(),
+        secondClause
+    ) };
+
+    InstructionStream stream(8, OpCode_CEE_NOP{});
+    LabelCreator labelCreator{};
+    std::vector<std::byte>::const_iterator iterator{ sectionData.cbegin() };
+    ExceptionsSection section(
+        iterator,
+        sectionData.cend(),
+        stream,
+        labelCreator);
+
+    const std::vector<std::byte> expectedBytes
+    {
+        // Section header
+        std::byte { 0x41 },
+        std::byte { 0x34 },
+        std::byte { 0x00 },
+        std::byte { 0x00 },
+
+        // First clause, fat
+        // Flags
+        std::byte { 0x00 },
+        std::byte { 0x00 },
+        std::byte { 0x00 },
+        std::byte { 0x00 },
+
+        // TryOffset
+        std::byte { 0x01 },
+        std::byte { 0x00 },
+        std::byte { 0x00 },
+        std::byte { 0x00 },
+
+        // TryLength
+        std::byte { 0x01 },
+        std::byte { 0x00 },
+        std::byte { 0x00 },
+        std::byte { 0x00 },
+
+        // HandlerOffset
+        std::byte { 0x02 },
+        std::byte { 0x00 },
+        std::byte { 0x00 },
+        std::byte { 0x00 },
+
+        // HandlerLength
+        std::byte { 0x01 },
+        std::byte { 0x00 },
+        std::byte { 0x00 },
+        std::byte { 0x00 },
+
+        // ClassToken
+        std::byte { 0x10 },
+        std::byte { 0x20 },
+        std::byte { 0x40 },
+        std::byte { 0x80 },
+
+        // Second clause, fat
+        // Flags
+        std::byte { 0x00 },
+        std::byte { 0x00 },
+        std::byte { 0x00 },
+        std::byte { 0x00 },
+
+        // TryOffset
+        std::byte { 0x05 },
+        std::byte { 0x00 },
+        std::byte { 0x01 },
+        std::byte { 0x00 },
+
+        // TryLength
+        std::byte { 0x01 },
+        std::byte { 0x00 },
+        std::byte { 0x00 },
+        std::byte { 0x00 },
+
+        // HandlerOffset
+        std::byte { 0x06 },
+        std::byte { 0x00 },
+        std::byte { 0x01 },
+        std::byte { 0x00 },
+
+        // HandlerLength
+        std::byte { 0x01 },
+        std::byte { 0x00 },
+        std::byte { 0x00 },
+        std::byte { 0x00 },
+
+        // ClassToken
+        std::byte { 0x10 },
+        std::byte { 0x20 },
+        std::byte { 0x40 },
+        std::byte { 0x80 }
+    };
+
+    // Act
+    stream.insert(
+        stream.cbegin() + 8,
+        0x00010000,
+        OpCode_CEE_NOP{});
+
+    std::vector<std::byte> serialized{};
+    section.AppendToBytes(serialized);
+
+    // Assert
+    ASSERT_EQ(2, section.Clauses().size());
+    EXPECT_TRUE(section.Clauses()[0].CanPutToSmallHeader());
+    EXPECT_FALSE(section.Clauses()[1].CanPutToSmallHeader());
+    EXPECT_EQ(expectedBytes, serialized);
+}

--- a/Drill4dotNet/Drill4dotNet-Tests/ExceptionsSectionTests.cpp
+++ b/Drill4dotNet/Drill4dotNet-Tests/ExceptionsSectionTests.cpp
@@ -1,0 +1,5 @@
+#include "pch.h"
+
+#include "ExceptionsSection.h"
+
+using namespace Drill4dotNet;

--- a/Drill4dotNet/Drill4dotNet-Tests/InstructionStreamTests.cpp
+++ b/Drill4dotNet/Drill4dotNet-Tests/InstructionStreamTests.cpp
@@ -3,3 +3,723 @@
 #include "InstructionStream.h"
 
 using namespace Drill4dotNet;
+
+TEST(InstructionStreamTests, FindInstruction)
+{
+    // Arrange
+    const InstructionStream stream { OpCode_CEE_BREAK{}, OpCode_CEE_ADD{} };
+
+    // Act
+    const ConstStreamPosition first { FindInstruction<OpCode_CEE_BREAK>(stream.cbegin(), stream.cend()) };
+    const ConstStreamPosition second { FindInstruction<OpCode_CEE_ADD>(stream.cbegin(), stream.cend()) };
+    const ConstStreamPosition notFound { FindInstruction<OpCode_CEE_NOP>(stream.cbegin(), stream.cend()) };
+
+    // Assert
+    EXPECT_EQ(stream.cbegin(), first);
+    EXPECT_EQ(stream.cbegin() + 1, second);
+    EXPECT_EQ(stream.cend(), notFound);
+}
+
+TEST(InstructionStreamTests, ResolveJumpOffsetZero)
+{
+    // Arrange
+    const InstructionStream stream(10, OpCode_CEE_NOP { });
+    const ConstStreamPosition firstPosition { stream.cbegin() };
+    const ConstStreamPosition secondPosition { stream.cbegin() + 5 };
+    const ConstStreamPosition thirdPosition { stream.cend() - 1 };
+    const LongJump::Offset offset { 0 };
+
+    // Act
+    const ConstStreamPosition first { ResolveJumpOffset(stream, firstPosition, offset) };
+    const ConstStreamPosition second { ResolveJumpOffset(stream, secondPosition, offset) };
+    const ConstStreamPosition third { ResolveJumpOffset(stream, thirdPosition, offset) };
+
+    // Assert
+    EXPECT_EQ(firstPosition + 1, first);
+    EXPECT_EQ(secondPosition + 1, second);
+    EXPECT_EQ(thirdPosition + 1, third);
+}
+
+TEST(InstructionStreamTests, ResolveJumpOffsetPositive)
+{
+    // Arrange
+    const InstructionStream stream(10, OpCode_CEE_NOP { });
+    const ConstStreamPosition firstPosition { stream.cbegin() };
+    const ConstStreamPosition secondPosition { stream.cbegin() + 5 };
+    const ConstStreamPosition thirdPosition { stream.cend() - 1 };
+    const LongJump::Offset offset { +5 };
+
+    // Act
+    const ConstStreamPosition first { ResolveJumpOffset(stream, firstPosition, offset) };
+    const ConstStreamPosition second { ResolveJumpOffset(stream, secondPosition, offset) };
+    const ConstStreamPosition third { ResolveJumpOffset(stream, thirdPosition, offset) };
+
+    // Assert
+    EXPECT_EQ(firstPosition + 6, first);
+    EXPECT_EQ(stream.cend(), second);
+    EXPECT_EQ(stream.cend(), third);
+}
+
+TEST(InstructionStreamTests, ResolveJumpOffsetNegative)
+{
+    // Arrange
+    const InstructionStream stream(10, OpCode_CEE_NOP { });
+    const ConstStreamPosition firstPosition { stream.cbegin() };
+    const ConstStreamPosition secondPosition { stream.cbegin() + 5 };
+    const ConstStreamPosition thirdPosition { stream.cend() - 1 };
+
+    // Act
+    const ConstStreamPosition first { ResolveJumpOffset(stream, firstPosition, -1) };
+    const ConstStreamPosition second { ResolveJumpOffset(stream, secondPosition, -3) };
+    const ConstStreamPosition third { ResolveJumpOffset(stream, thirdPosition, -10) };
+
+    // Assert
+    EXPECT_EQ(firstPosition, first);
+    EXPECT_EQ(stream.cbegin() + 3, second);
+    EXPECT_EQ(stream.cbegin(), third);
+}
+
+TEST(InstructionStreamTests, ResolveJumpOffsetOutOfStream)
+{
+    // Arrange
+    const InstructionStream stream { OpCode_CEE_NOP { } };
+    const ConstStreamPosition position { stream.cbegin() };
+
+    // Act
+    const ConstStreamPosition first { ResolveJumpOffset(stream, position, -10) };
+    const ConstStreamPosition second { ResolveJumpOffset(stream, position, +10) };
+
+    // Assert
+    EXPECT_EQ(stream.cend(), first);
+    EXPECT_EQ(stream.cend(), second);
+}
+
+TEST(InstructionStreamTests, ResolveJumpOffsetEmptyStream)
+{
+    // Arrange
+    const InstructionStream stream {};
+    const ConstStreamPosition position { stream.cend() };
+
+    // Act
+    const ConstStreamPosition first { ResolveJumpOffset(stream, position, -10) };
+    const ConstStreamPosition second { ResolveJumpOffset(stream, position, 0) };
+    const ConstStreamPosition third { ResolveJumpOffset(stream, position, +10) };
+
+    // Assert
+    EXPECT_EQ(position, first);
+    EXPECT_EQ(position, second);
+    EXPECT_EQ(position, third);
+}
+
+TEST(InstructionStreamTests, ResolveJumpOffsetSkipsLabels)
+{
+    // Arrange
+    LabelCreator creator{};
+    const InstructionStream stream {
+        creator.CreateLabel(),
+        OpCode_CEE_NOP{},
+        creator.CreateLabel(),
+        OpCode_CEE_NOP{},
+        creator.CreateLabel(),
+        OpCode_CEE_NOP{}
+    };
+
+    const ConstStreamPosition position { stream.cbegin() + 2 };
+
+    // Act
+    const ConstStreamPosition first { ResolveJumpOffset(stream, position, -2) };
+    const ConstStreamPosition second { ResolveJumpOffset(stream, position, -1) };
+    const ConstStreamPosition third { ResolveJumpOffset(stream, position, 0) };
+    const ConstStreamPosition forth { ResolveJumpOffset(stream, stream.cbegin(), 1) };
+
+    // Assert
+    EXPECT_EQ(stream.cbegin() + 1, first);
+    EXPECT_EQ(stream.cbegin() + 3, second);
+    EXPECT_EQ(stream.cbegin() + 5, third);
+    EXPECT_EQ(stream.cbegin() + 5, forth);
+}
+
+// In .net, a relative jump offset should point exactly to the
+// position where target instruction begins. If ResolveJumpOffset
+// was given an offset pointing to the middle of some instruction,
+// it must return stream.cend() to indicate no target found.
+// The test checks this.
+TEST(InstructionStreamTests, ResolveJumpOffsetIgnoresMiddleOfInstruction)
+{
+    // Arrange
+    const InstructionStream stream{
+        OpCode_CEE_LDARG{0},
+        OpCode_CEE_CEQ{},
+        OpCode_CEE_LDC_I4{42}, 
+        OpCode_CEE_BREAK{}
+    };
+    const ConstStreamPosition position { stream.cbegin() + 1 };
+
+    // Act
+    const ConstStreamPosition first { ResolveJumpOffset(stream, position, -3) };
+    const ConstStreamPosition second { ResolveJumpOffset(stream, position, -1) };
+    const ConstStreamPosition third { ResolveJumpOffset(stream, position, 1) };
+    const ConstStreamPosition forth { ResolveJumpOffset(stream, position, 2) };
+
+    // Assert
+    EXPECT_EQ(stream.cend(), first);
+    EXPECT_EQ(stream.cend(), second);
+    EXPECT_EQ(stream.cend(), third);
+    EXPECT_EQ(stream.cend(), forth);
+}
+
+TEST(InstructionStreamTests, ResolveAbsoluteOffsetEmptyStream)
+{
+    // Arrange
+    const InstructionStream stream {};
+
+    // Act
+    const ConstStreamPosition first { ResolveAbsoluteOffset(stream, 0) };
+    const ConstStreamPosition second { ResolveAbsoluteOffset(stream, 10) };
+
+    // Assert
+    EXPECT_EQ(stream.cend(), first);
+    EXPECT_EQ(stream.cend(), second);
+}
+
+TEST(InstructionStreamTests, ResolveAbsoluteOffsetOutOfStream)
+{
+    // Arrange
+    const InstructionStream stream(10, OpCode_CEE_NOP { });
+
+    // Act
+    const ConstStreamPosition position { ResolveAbsoluteOffset(stream, 100) };
+
+    // Assert
+    EXPECT_EQ(stream.cend(), position);
+}
+
+TEST(InstructionStreamTests, ResolveAbsoluteOffset)
+{
+    // Arrange
+    const InstructionStream stream(10, OpCode_CEE_NOP { });
+    AbsoluteOffset firstPosition { 0 };
+    AbsoluteOffset secondPosition { 4 };
+    AbsoluteOffset thirdPosition { 9 };
+
+
+    // Act
+    const ConstStreamPosition first{ ResolveAbsoluteOffset(stream, firstPosition) };
+    const ConstStreamPosition second{ ResolveAbsoluteOffset(stream, secondPosition) };
+    const ConstStreamPosition third{ ResolveAbsoluteOffset(stream, thirdPosition) };
+
+    // Assert
+    EXPECT_EQ(stream.cbegin() + firstPosition, first);
+    EXPECT_EQ(stream.cbegin() + secondPosition, second);
+    EXPECT_EQ(stream.cbegin() + thirdPosition, third);
+}
+
+template <typename TOpCode>
+static void AssertHolds(const ConstStreamPosition position, const InstructionStream& stream)
+{
+    ASSERT_NE(position, stream.cend());
+    const StreamElement& element = *position;
+    ASSERT_TRUE(std::holds_alternative<OpCodeVariant>(element));
+    const OpCodeVariant& opCode { std::get<OpCodeVariant>(element) };
+    ASSERT_TRUE(opCode.HoldsAlternative<TOpCode>());
+}
+
+TEST(InstructionStreamTests, ResolveAbsoluteOffsetVariousInstructions)
+{
+    // Arrange
+    const InstructionStream stream{
+        OpCode_CEE_CEQ{},
+        OpCode_CEE_LDC_I4{ 42 },
+        OpCode_CEE_ADD{}
+    };
+    AbsoluteOffset firstPosition { 0 };
+    AbsoluteOffset secondPosition { 2 };
+    AbsoluteOffset thirdPosition { 7 };
+
+    // Act
+    const ConstStreamPosition first{ ResolveAbsoluteOffset(stream, firstPosition) };
+    const ConstStreamPosition second{ ResolveAbsoluteOffset(stream, secondPosition) };
+    const ConstStreamPosition third{ ResolveAbsoluteOffset(stream, thirdPosition) };
+
+    // Assert
+    AssertHolds<OpCode_CEE_CEQ>(first, stream);
+    AssertHolds<OpCode_CEE_LDC_I4>(second, stream);
+    AssertHolds<OpCode_CEE_ADD>(third, stream);
+}
+
+// In .net, an offset from the method beginning should point exactly to
+// the position where an instruction begins. If ResolveAbsoluteOffset
+// was given an offset pointing to the middle of some instruction,
+// it must return stream.cend() to indicate no target found.
+// The test checks this.
+TEST(InstructionStreamTests, ResolveAbsoluteOffsetIgnoresMiddleOfInstruction)
+{
+    // Arrange
+    const InstructionStream stream{
+        OpCode_CEE_LDARG{0},
+        OpCode_CEE_CEQ{},
+        OpCode_CEE_LDC_I4{42},
+        OpCode_CEE_BREAK{}
+    };
+
+    // Act
+    const ConstStreamPosition first{ ResolveAbsoluteOffset(stream, 2) };
+    const ConstStreamPosition second{ ResolveAbsoluteOffset(stream, 5) };
+    const ConstStreamPosition third{ ResolveAbsoluteOffset(stream, 8) };
+
+    // Assert
+    EXPECT_EQ(stream.cend(), first);
+    EXPECT_EQ(stream.cend(), second);
+    EXPECT_EQ(stream.cend(), third);
+}
+
+TEST(InstructionStreamTests, GetNthInstruction)
+{
+    // Arrange
+    LabelCreator creator{};
+    const InstructionStream stream {
+        creator.CreateLabel(),
+        OpCode_CEE_LDARG{0},
+        creator.CreateLabel(),
+        creator.CreateLabel(),
+        OpCode_CEE_CEQ{},
+        creator.CreateLabel(),
+        OpCode_CEE_LDC_I4{42},
+        creator.CreateLabel(),
+        OpCode_CEE_BREAK{} };
+
+    // Act
+    const ConstStreamPosition first{ GetNthInstruction(stream, 0) };
+    const ConstStreamPosition second{ GetNthInstruction(stream, 1) };
+    const ConstStreamPosition third{ GetNthInstruction(stream, 2) };
+    const ConstStreamPosition forth{ GetNthInstruction(stream, 3) };
+
+    // Assert
+    AssertHolds<OpCode_CEE_LDARG>(first, stream);
+    AssertHolds<OpCode_CEE_CEQ>(second, stream);
+    AssertHolds<OpCode_CEE_LDC_I4>(third, stream);
+    AssertHolds<OpCode_CEE_BREAK>(forth, stream);
+}
+
+TEST(InstructionStreamTests, CalculateJumpOffsetPositive)
+{
+    // Arrange
+    const InstructionStream stream(10, OpCode_CEE_NOP{ });
+    const ConstStreamPosition firstPosition{ stream.cbegin() };
+    const ConstStreamPosition secondPosition{ stream.cbegin() + 5 };
+    const ConstStreamPosition thirdPosition{ stream.cend() - 1 };
+
+    // Act
+    const LongJump::Offset firstToSecond { CalculateJumpOffset(stream, firstPosition, secondPosition) };
+    const LongJump::Offset firstToThird{ CalculateJumpOffset(stream, firstPosition, thirdPosition) };
+    const LongJump::Offset secondToThird{ CalculateJumpOffset(stream, secondPosition, thirdPosition) };
+
+    // Assert
+    EXPECT_EQ(4, firstToSecond);
+    EXPECT_EQ(8, firstToThird);
+    EXPECT_EQ(3, secondToThird);
+}
+
+TEST(InstructionStreamTests, CalculateJumpOffsetAtSameInstruction)
+{
+    // Arrange
+    const InstructionStream stream(10, OpCode_CEE_NOP{ });
+    const ConstStreamPosition firstPosition{ stream.cbegin() };
+    const ConstStreamPosition secondPosition{ stream.cbegin() + 5 };
+    const ConstStreamPosition thirdPosition{ stream.cend() - 1 };
+
+    // Act
+    const LongJump::Offset first { CalculateJumpOffset(stream, firstPosition, firstPosition) };
+    const LongJump::Offset second { CalculateJumpOffset(stream, secondPosition, secondPosition) };
+    const LongJump::Offset third { CalculateJumpOffset(stream, thirdPosition, thirdPosition) };
+
+    // Assert
+    EXPECT_EQ(-1, first);
+    EXPECT_EQ(-1, second);
+    EXPECT_EQ(-1, third);
+}
+
+TEST(InstructionStreamTests, CalculateJumpOffsetAtNextInstruction)
+{
+    // Arrange
+    const InstructionStream stream(10, OpCode_CEE_NOP{ });
+    const ConstStreamPosition firstPosition{ stream.cbegin() };
+    const ConstStreamPosition secondPosition{ stream.cbegin() + 5 };
+    const ConstStreamPosition thirdPosition{ stream.cend() - 1 };
+
+    // Act
+    const LongJump::Offset first { CalculateJumpOffset(stream, firstPosition, firstPosition + 1) };
+    const LongJump::Offset second { CalculateJumpOffset(stream, secondPosition, secondPosition + 1) };
+    const LongJump::Offset third { CalculateJumpOffset(stream, thirdPosition, thirdPosition + 1) };
+
+    // Assert
+    EXPECT_EQ(0, first);
+    EXPECT_EQ(0, second);
+    EXPECT_EQ(0, third);
+}
+
+TEST(InstructionStreamTests, CalculateJumpOffsetNegative)
+{
+    // Arrange
+    const InstructionStream stream(10, OpCode_CEE_NOP{ });
+    const ConstStreamPosition firstPosition{ stream.cbegin() };
+    const ConstStreamPosition secondPosition{ stream.cbegin() + 5 };
+    const ConstStreamPosition thirdPosition{ stream.cend() - 1 };
+
+    // Act
+    const LongJump::Offset secondToFirst { CalculateJumpOffset(stream, secondPosition, firstPosition) };
+    const LongJump::Offset thirdToSecond { CalculateJumpOffset(stream, thirdPosition, secondPosition) };
+    const LongJump::Offset thirdToFirst { CalculateJumpOffset(stream, thirdPosition, firstPosition) };
+
+    // Assert
+    EXPECT_EQ(-6, secondToFirst);
+    EXPECT_EQ(-5, thirdToSecond);
+    EXPECT_EQ(-10, thirdToFirst);
+}
+
+TEST(InstructionStreamTests, CalculateJumpOffsetSkipsLabels)
+{
+    // Arrange
+    LabelCreator creator{};
+    const InstructionStream stream {
+        creator.CreateLabel(),
+        OpCode_CEE_NOP{},
+        creator.CreateLabel(),
+        OpCode_CEE_NOP{},
+        creator.CreateLabel(),
+        OpCode_CEE_NOP{}
+    };
+
+    const ConstStreamPosition first { stream.cbegin() };
+    const ConstStreamPosition second { stream.cbegin() + 2 };
+    const ConstStreamPosition third { stream.cbegin() + 4 };
+
+    // Act
+    const LongJump::Offset firstToSecond { CalculateJumpOffset(stream, first, second) };
+    const LongJump::Offset firstToThird { CalculateJumpOffset(stream, first, third) };
+    const LongJump::Offset thirdToFirst { CalculateJumpOffset(stream, third, first) };
+
+    // Assert
+    EXPECT_EQ(0, firstToSecond);
+    EXPECT_EQ(1, firstToThird);
+    EXPECT_EQ(-3, thirdToFirst);
+}
+
+TEST(InstructionStreamTests, CalculateJumpOffsetCalculatesSizesProperly)
+{
+    // Arrange
+    const InstructionStream stream{
+        OpCode_CEE_LDARG{0},
+        OpCode_CEE_CEQ{},
+        OpCode_CEE_LDC_I4{42},
+        OpCode_CEE_BREAK{} };
+
+    const ConstStreamPosition first { stream.cbegin() };
+    const ConstStreamPosition second { stream.cbegin() + 1 };
+    const ConstStreamPosition third { stream.cbegin() + 2 };
+    const ConstStreamPosition forth { stream.cbegin() + 3 };
+
+    // Act
+    const LongJump::Offset firstToSecond { CalculateJumpOffset(stream, first, second) };
+    const LongJump::Offset firstToThird { CalculateJumpOffset(stream, first, third) };
+    const LongJump::Offset firstToForth { CalculateJumpOffset(stream, first, forth) };
+
+    // Assert
+    EXPECT_EQ(0, firstToSecond);
+    EXPECT_EQ(2, firstToThird);
+    EXPECT_EQ(7, firstToForth);
+}
+
+TEST(InstructionStreamTests, CalculateAbsoluteOffset)
+{
+    // Arrange
+    const InstructionStream stream(10, OpCode_CEE_NOP{ });
+    const ConstStreamPosition firstPosition{ stream.cbegin() };
+    const ConstStreamPosition secondPosition{ stream.cbegin() + 5 };
+    const ConstStreamPosition thirdPosition{ stream.cend() - 1 };
+
+    // Act
+    const AbsoluteOffset first { CalculateAbsoluteOffset(stream, firstPosition) };
+    const AbsoluteOffset second { CalculateAbsoluteOffset(stream, secondPosition) };
+    const AbsoluteOffset third { CalculateAbsoluteOffset(stream, thirdPosition) };
+
+    // Assert
+    EXPECT_EQ(0, first);
+    EXPECT_EQ(5, second);
+    EXPECT_EQ(9, third);
+}
+
+TEST(InstructionStreamTests, CalculateAbsoluteOffsetSkipsLabels)
+{
+    // Arrange
+    LabelCreator creator{};
+    const InstructionStream stream {
+        creator.CreateLabel(),
+        OpCode_CEE_NOP{},
+        creator.CreateLabel(),
+        OpCode_CEE_NOP{},
+        creator.CreateLabel(),
+        OpCode_CEE_NOP{}
+    };
+
+    const ConstStreamPosition firstPosition{ stream.cbegin() };
+    const ConstStreamPosition secondPosition{ stream.cbegin() + 2 };
+    const ConstStreamPosition thirdPosition{ stream.cbegin() + 4 };
+
+    // Act
+    const AbsoluteOffset first{ CalculateAbsoluteOffset(stream, firstPosition) };
+    const AbsoluteOffset second{ CalculateAbsoluteOffset(stream, secondPosition) };
+    const AbsoluteOffset third{ CalculateAbsoluteOffset(stream, thirdPosition) };
+
+    // Assert
+    EXPECT_EQ(0, first);
+    EXPECT_EQ(1, second);
+    EXPECT_EQ(2, third);
+}
+
+TEST(InstructionStreamTests, CalculateAbsoluteOffsetCalculatesSizesProperly)
+{
+    // Arrange
+    const InstructionStream stream{
+        OpCode_CEE_LDARG{0},
+        OpCode_CEE_CEQ{},
+        OpCode_CEE_LDC_I4{42},
+        OpCode_CEE_BREAK{} };
+
+    const ConstStreamPosition firstPosition{ stream.cbegin() };
+    const ConstStreamPosition secondPosition{ stream.cbegin() + 1 };
+    const ConstStreamPosition thirdPosition{ stream.cbegin() + 2 };
+    const ConstStreamPosition forthPosition{ stream.cbegin() + 3 };
+
+    // Act
+    const AbsoluteOffset first{ CalculateAbsoluteOffset(stream, firstPosition) };
+    const AbsoluteOffset second{ CalculateAbsoluteOffset(stream, secondPosition) };
+    const AbsoluteOffset third{ CalculateAbsoluteOffset(stream, thirdPosition) };
+    const AbsoluteOffset forth{ CalculateAbsoluteOffset(stream, forthPosition) };
+
+    // Assert
+    EXPECT_EQ(0, first);
+    EXPECT_EQ(4, second);
+    EXPECT_EQ(6, third);
+    EXPECT_EQ(11, forth);
+}
+
+TEST(InstructionStreamTests, FindLabelInEmptyStream)
+{
+    // Arrange
+    const InstructionStream stream{};
+    LabelCreator creator{};
+    const Label label{ creator.CreateLabel() };
+
+    // Act
+    const ConstStreamPosition labelPosition { FindLabel(stream, label) };
+
+    // Assert
+    EXPECT_EQ(stream.cend(), labelPosition);
+}
+
+TEST(InstructionStreamTests, FindLabelStreamWithLabel)
+{
+    // Arrange
+    LabelCreator creator{};
+    const Label label{ creator.CreateLabel() };
+    const InstructionStream stream{ label };
+
+    // Act
+    const ConstStreamPosition labelPosition { FindLabel(stream, label) };
+
+    // Assert
+    EXPECT_EQ(stream.cbegin(), labelPosition);
+}
+
+TEST(InstructionStreamTests, FindLabelStreamWithOtherLabelOnly)
+{
+    // Arrange
+    LabelCreator creator{};
+    const Label otherLabel{ creator.CreateLabel() };
+    const InstructionStream stream{ otherLabel };
+    const Label label{ creator.CreateLabel() };
+
+    // Act
+    const ConstStreamPosition labelPosition { FindLabel(stream, label) };
+
+    // Assert
+    EXPECT_EQ(stream.cend(), labelPosition);
+}
+
+TEST(InstructionStreamTests, FindLabelStreamWithOtherLabel)
+{
+    // Arrange
+    LabelCreator creator{};
+    const Label otherLabel{ creator.CreateLabel() };
+    const Label label{ creator.CreateLabel() };
+    const InstructionStream stream{ otherLabel, label };
+
+    // Act
+    const ConstStreamPosition labelPosition { FindLabel(stream, label) };
+
+    // Assert
+    EXPECT_EQ(stream.cbegin() + 1, labelPosition);
+}
+
+TEST(InstructionStreamTests, SkipLabelsInEmptyStream)
+{
+    // Arrange
+    const InstructionStream stream{};
+
+    // Act
+    const ConstStreamPosition nearestInstruction { SkipLabels(stream.cbegin(), stream.cend()) };
+
+    // Assert
+    EXPECT_EQ(stream.cend(), nearestInstruction);
+}
+
+TEST(InstructionStreamTests, SkipLabelsInStreamWithOneLabel)
+{
+    // Arrange
+    LabelCreator creator;
+    const InstructionStream stream{ creator.CreateLabel() };
+
+    // Act
+    const ConstStreamPosition nearestInstruction { SkipLabels(stream.cbegin(), stream.cend()) };
+
+    // Assert
+    EXPECT_EQ(stream.cend(), nearestInstruction);
+}
+
+TEST(InstructionStreamTests, SkipLabelsInStreamWithOneInstruction)
+{
+    // Arrange
+    const InstructionStream stream{ OpCode_CEE_NOP{} };
+
+    // Act
+    const ConstStreamPosition nearestInstruction { SkipLabels(stream.cbegin(), stream.cend()) };
+
+    // Assert
+    EXPECT_EQ(stream.cbegin(), nearestInstruction);
+}
+
+TEST(InstructionStreamTests, SkipLabelsInStreamWithLabelAndInstruction)
+{
+    // Arrange
+    LabelCreator creator;
+    const InstructionStream stream{ creator.CreateLabel(), OpCode_CEE_NOP{} };
+
+    // Act
+    const ConstStreamPosition nearestInstruction { SkipLabels(stream.cbegin(), stream.cend()) };
+
+    // Assert
+    EXPECT_EQ(stream.cbegin() + 1, nearestInstruction);
+}
+
+TEST(InstructionStreamTests, SkipLabelsInStreamWithTwoLabelsAndInstruction)
+{
+    // Arrange
+    LabelCreator creator;
+    const InstructionStream stream{ creator.CreateLabel(), creator.CreateLabel(), OpCode_CEE_NOP{} };
+
+    // Act
+    const ConstStreamPosition nearestInstruction { SkipLabels(stream.cbegin(), stream.cend()) };
+
+    // Assert
+    EXPECT_EQ(stream.cbegin() + 2, nearestInstruction);
+}
+
+TEST(InstructionStreamTests, FindNextInstructionInEmptyStream)
+{
+    // Arrange
+    const InstructionStream stream{};
+
+    // Act
+    const ConstStreamPosition nextInstruction { FindNextInstruction(stream.cbegin(), stream.cend()) };
+
+    // Assert
+    EXPECT_EQ(stream.cend(), nextInstruction);
+}
+
+TEST(InstructionStreamTests, FindNextInstructionInStreamWithOneInstruction)
+{
+    // Arrange
+    const InstructionStream stream{ OpCode_CEE_NOP {} };
+
+    // Act
+    const ConstStreamPosition nextInstruction { FindNextInstruction(stream.cbegin(), stream.cend()) };
+
+    // Assert
+    EXPECT_EQ(stream.cend(), nextInstruction);
+}
+
+TEST(InstructionStreamTests, FindNextInstructionInStreamWithOneInstructionAndOneLabel)
+{
+    // Arrange
+    LabelCreator creator;
+    const InstructionStream stream{ OpCode_CEE_NOP{}, creator.CreateLabel() };
+
+    // Act
+    const ConstStreamPosition nextInstruction{ FindNextInstruction(stream.cbegin(), stream.cend()) };
+
+    // Assert
+    EXPECT_EQ(stream.cend(), nextInstruction);
+}
+
+TEST(InstructionStreamTests, FindNextInstructionInStreamWithTwoInstructionsAndOneLabel)
+{
+    // Arrange
+    LabelCreator creator;
+    const InstructionStream stream{
+        OpCode_CEE_NOP{},
+        creator.CreateLabel(),
+        OpCode_CEE_NOP{}
+    };
+
+    // Act
+    const ConstStreamPosition nextInstruction{ FindNextInstruction(stream.cbegin(), stream.cend()) };
+
+    // Assert
+    EXPECT_EQ(stream.cbegin() + 2, nextInstruction);
+}
+
+TEST(InstructionStreamTests, FindNextInstructionInStreamWithTwoInstructions)
+{
+    // Arrange
+    const InstructionStream stream{ OpCode_CEE_NOP{}, OpCode_CEE_NOP{} };
+
+    // Act
+    const ConstStreamPosition nextInstruction{ FindNextInstruction(stream.cbegin(), stream.cend()) };
+
+    // Assert
+    EXPECT_EQ(stream.cbegin() + 1, nextInstruction);
+}
+
+TEST(InstructionStreamTests, FindNextInstructionInStreamWithTwoLabelsAndTwoInstructions)
+{
+    // Arrange
+    LabelCreator creator;
+    const InstructionStream stream{
+        OpCode_CEE_NOP{},
+        creator.CreateLabel(),
+        creator.CreateLabel(),
+        OpCode_CEE_NOP{} };
+
+    // Act
+    const ConstStreamPosition nextInstruction{ FindNextInstruction(stream.cbegin(), stream.cend()) };
+
+    // Assert
+    EXPECT_EQ(stream.cbegin() + 3, nextInstruction);
+}
+
+// Checks that subsequent calls of
+// LabelCreator::CreateLabel() return
+// different labels.
+TEST(InstructionStreamTests, CreateLabelUnique)
+{
+    // Arrange
+    LabelCreator creator{};
+
+    // Act
+    const Label first { creator.CreateLabel() };
+    const Label second { creator.CreateLabel() };
+
+    // Assert
+    EXPECT_FALSE(first == second);
+}

--- a/Drill4dotNet/Drill4dotNet-Tests/InstructionStreamTests.cpp
+++ b/Drill4dotNet/Drill4dotNet-Tests/InstructionStreamTests.cpp
@@ -1,0 +1,5 @@
+#include "pch.h"
+
+#include "InstructionStream.h"
+
+using namespace Drill4dotNet;

--- a/Drill4dotNet/Drill4dotNet-Tests/MethodBodyTests.cpp
+++ b/Drill4dotNet/Drill4dotNet-Tests/MethodBodyTests.cpp
@@ -1,0 +1,5 @@
+#include "pch.h"
+
+#include "MethodBody.h"
+
+using namespace Drill4dotNet;

--- a/Drill4dotNet/Drill4dotNet-Tests/MethodBodyTests.cpp
+++ b/Drill4dotNet/Drill4dotNet-Tests/MethodBodyTests.cpp
@@ -3,3 +3,1877 @@
 #include "MethodBody.h"
 
 using namespace Drill4dotNet;
+
+// Creates method body representing
+// public static int Sum(int x, int y)
+// {
+//     return x + y;
+// }
+static std::vector<std::byte> CreateSimpleFunction()
+{
+    // created manually
+    return {
+        std::byte { 0x16 },
+        std::byte { 0x02 },
+        std::byte { 0x03 },
+        std::byte { 0x58 },
+        std::byte { 0x2A }
+    };
+}
+
+// Checks the following injection
+// public static int Sum(int x, int y)
+// {
+//     return x + y;
+// }
+// Will replace
+//     return x + y;
+// with
+//     return (x + y) * 2;
+TEST(MethodBodyTests, InsertSimpleFunction)
+{
+    // Arrange
+    const std::vector<std::byte> sourceBytes(CreateSimpleFunction());
+
+    // if we do not inject anything, Compile() should return exactly
+    // the same bytes from which MethodBody was created.
+    const std::vector<std::byte> expectedRoundtripBytes(sourceBytes);
+
+    // based on source bytes
+    const std::vector<std::byte> expectedInjectionBytes{
+        std::byte { 0x1E }, // size updated
+        std::byte { 0x02 },
+        std::byte { 0x03 },
+        std::byte { 0x58 },
+        std::byte { 0x18 }, // inject: ldc.i4.2
+        std::byte { 0x5A }, // inject: mul
+        std::byte { 0x2A }
+    };
+
+    // MethodBody should turn sourceBytes to this
+    const InstructionStream expectedSourceStream{
+        OpCode_CEE_LDARG_0{},
+        OpCode_CEE_LDARG_1{},
+        OpCode_CEE_ADD{},
+        OpCode_CEE_RET{}
+    };
+
+    // MethodBody should have this instructions
+    // stream after injection.
+    const InstructionStream expectedInjectionStream{
+        OpCode_CEE_LDARG_0{},
+        OpCode_CEE_LDARG_1{},
+        OpCode_CEE_ADD{},
+        OpCode_CEE_LDC_I4_2{}, // injection
+        OpCode_CEE_MUL{}, // injection
+        OpCode_CEE_RET{}
+    };
+
+    // Act
+    MethodBody method(sourceBytes);
+
+    const InstructionStream actualSourceStream(method.Stream());
+    const std::vector<std::byte> actualRoundtripBytes(method.Compile());
+    const std::vector<ExceptionsSection> actualExceptionSections(method.ExceptionSections());
+
+    method.Insert(method.begin() + 3, OpCode_CEE_LDC_I4_2{});
+    method.Insert(method.begin() + 4, OpCode_CEE_MUL{});
+
+    const InstructionStream actualInjectionStream(method.Stream());
+    const std::vector<std::byte> actualInjectionBytes(method.Compile());
+
+    // Assert
+    EXPECT_EQ(expectedSourceStream, actualSourceStream);
+    EXPECT_EQ(expectedRoundtripBytes, actualRoundtripBytes);
+    EXPECT_EQ(0, actualExceptionSections.size());
+    EXPECT_EQ(expectedInjectionStream, actualInjectionStream);
+    EXPECT_EQ(expectedInjectionBytes, actualInjectionBytes);
+}
+
+// Tests do similar actions as InsertSimpleFunction, but
+// this use different injection targets and different injections.
+
+// Checks injection to.
+// private static int MyInjectionTarget(bool a, int x, int y)
+// {
+//     if (a)
+//     {
+//         return x * y;
+//     }
+//     else
+//     {
+//         return 0;
+//     }
+// }
+// Will replace line
+// return 0;
+// with
+// return 0 + x + y;
+TEST(MethodBodyTests, InsertFunctionWithIf)
+{
+    // Arrange
+    // Got these values from MS IL decompiler.
+    const std::vector<std::byte> sourceBytes {
+        std::byte { 0x13 }, std::byte { 0x30 }, std::byte { 0x02 }, std::byte { 0x00 },
+        std::byte { 0x14 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x01 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x11 },
+        std::byte { 0x00 }, std::byte { 0x02 }, std::byte { 0x0A }, std::byte { 0x06 },
+        std::byte { 0x2C }, std::byte { 0x07 }, std::byte { 0x00 }, std::byte { 0x03 },
+        std::byte { 0x04 }, std::byte { 0x5A }, std::byte { 0x0B }, std::byte { 0x2B },
+        std::byte { 0x05 }, std::byte { 0x00 }, std::byte { 0x16 }, std::byte { 0x0B },
+        std::byte { 0x2B }, std::byte { 0x00 }, std::byte { 0x07 }, std::byte { 0x2A }
+    };
+
+    const std::vector<std::byte> expectedRoundtripBytes(sourceBytes);
+
+    // Recalculated sourceBytes manually to get this.
+    const std::vector<std::byte> expectedInjectionBytes{
+        std::byte { 0x13 }, std::byte { 0x30 }, std::byte { 0x02 }, std::byte { 0x00 },
+        std::byte { 0x18 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x01 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x11 },
+        std::byte { 0x00 }, std::byte { 0x02 }, std::byte { 0x0A }, std::byte { 0x06 },
+        std::byte { 0x2C }, std::byte { 0x07 }, std::byte { 0x00 }, std::byte { 0x03 },
+        std::byte { 0x04 }, std::byte { 0x5A }, std::byte { 0x0B }, std::byte { 0x2B },
+        std::byte { 0x09 }, std::byte { 0x00 }, std::byte { 0x16 }, std::byte { 0x03 },
+        std::byte { 0x58 }, std::byte { 0x04 }, std::byte { 0x58 }, std::byte { 0x0B },
+        std::byte { 0x2B }, std::byte { 0x00 }, std::byte { 0x07 }, std::byte { 0x2A }
+    };
+
+    LabelCreator sourceStreamLabelCreator{};
+    const Label elseLabel{ sourceStreamLabelCreator.CreateLabel() };
+    const Label endLabel1{ sourceStreamLabelCreator.CreateLabel() };
+    const Label endLabel2{ sourceStreamLabelCreator.CreateLabel() };
+    // Got these values from MS IL decompiler.
+    const InstructionStream expectedSourceStream{
+        // if (a)
+        OpCode_CEE_NOP{},
+        OpCode_CEE_LDARG_0{},
+        OpCode_CEE_STLOC_0{},
+        OpCode_CEE_LDLOC_0{},
+        OpCode_CEE_BRFALSE_S{elseLabel},
+
+        // return x * y; // <- x * y
+        OpCode_CEE_NOP{},
+        OpCode_CEE_LDARG_1{},
+        OpCode_CEE_LDARG_2{},
+        OpCode_CEE_MUL{},
+        OpCode_CEE_STLOC_1{},
+        OpCode_CEE_BR_S{endLabel1},
+
+        // return 0; // <- 0;
+        elseLabel,
+        OpCode_CEE_NOP{},
+        OpCode_CEE_LDC_I4_0{},
+        OpCode_CEE_STLOC_1{},
+        OpCode_CEE_BR_S{endLabel2},
+
+        // return
+        endLabel1,
+        endLabel2,
+        OpCode_CEE_LDLOC_1{},
+        OpCode_CEE_RET{}
+    };
+
+    const InstructionStream expectedInjectionStream{
+        // if (a)
+        OpCode_CEE_NOP{},
+        OpCode_CEE_LDARG_0{},
+        OpCode_CEE_STLOC_0{},
+        OpCode_CEE_LDLOC_0{},
+        OpCode_CEE_BRFALSE_S{elseLabel},
+
+        // return x * y; // <- x * y
+        OpCode_CEE_NOP{},
+        OpCode_CEE_LDARG_1{},
+        OpCode_CEE_LDARG_2{},
+        OpCode_CEE_MUL{},
+        OpCode_CEE_STLOC_1{},
+        OpCode_CEE_BR_S{endLabel1},
+
+        // return 0 + x + y; // <- 0 + x + y;
+        elseLabel,
+        OpCode_CEE_NOP{},
+        OpCode_CEE_LDC_I4_0{},
+        OpCode_CEE_LDARG_1{},
+        OpCode_CEE_ADD{},
+        OpCode_CEE_LDARG_2{},
+        OpCode_CEE_ADD{},
+        OpCode_CEE_STLOC_1{},
+        OpCode_CEE_BR_S{endLabel2},
+
+        // return
+        endLabel1,
+        endLabel2,
+        OpCode_CEE_LDLOC_1{},
+        OpCode_CEE_RET{}
+    };
+
+    // Act
+    MethodBody method(sourceBytes);
+
+    const InstructionStream actualSourceStream(method.Stream());
+    const std::vector<std::byte> actualRoundtripBytes(method.Compile());
+    const std::vector<ExceptionsSection> actualExceptionSections(method.ExceptionSections());
+
+    method.Insert(method.begin() + 14, OpCode_CEE_LDARG_1{});
+    method.Insert(method.begin() + 15, OpCode_CEE_ADD{});
+    method.Insert(method.begin() + 16, OpCode_CEE_LDARG_2{});
+    method.Insert(method.begin() + 17, OpCode_CEE_ADD{});
+
+    const InstructionStream actualInjectionStream(method.Stream());
+    const std::vector<std::byte> actualInjectionBytes(method.Compile());
+
+    // Assert
+    EXPECT_EQ(expectedSourceStream, actualSourceStream);
+    EXPECT_EQ(expectedRoundtripBytes, actualRoundtripBytes);
+    EXPECT_EQ(0, actualExceptionSections.size());
+    EXPECT_EQ(expectedInjectionStream, actualInjectionStream);
+    EXPECT_EQ(expectedInjectionBytes, actualInjectionBytes);
+}
+
+//Checks this injection:
+// private static int MyInjectionTarget(int x)
+// {
+//     if (x < 2)
+//     {
+//         return x;
+//     }
+// 
+//     int previous = 0;
+//     int current = 1;
+// 
+//     for (int i = 2; i <= x; i++)
+//     {
+//         int newCurrent = current + previous;
+//         previous = current;
+//         current = newCurrent;
+//     }
+// 
+//     return current;
+// }
+// Will replace
+//         current = newCurrent;
+// with
+//         current = 2 * newCurrent;
+TEST(MethodBodyTests, InsertFunctionWithLoop)
+{
+    // Arrange
+    // Got these values from MS IL decompiler.
+    const std::vector<std::byte> sourceBytes {
+        std::byte { 0x13 }, std::byte { 0x30 }, std::byte { 0x02 }, std::byte { 0x00 },
+        std::byte { 0x3D }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x01 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x11 },
+        std::byte { 0x00 }, std::byte { 0x02 }, std::byte { 0x18 }, std::byte { 0xFE },
+        std::byte { 0x04 }, std::byte { 0x0C }, std::byte { 0x08 }, std::byte { 0x2C },
+        std::byte { 0x05 }, std::byte { 0x00 }, std::byte { 0x02 }, std::byte { 0x0D },
+        std::byte { 0x2B }, std::byte { 0x2D }, std::byte { 0x16 }, std::byte { 0x0A },
+        std::byte { 0x17 }, std::byte { 0x0B }, std::byte { 0x18 }, std::byte { 0x13 },
+        std::byte { 0x04 }, std::byte { 0x2B }, std::byte { 0x12 }, std::byte { 0x00 },
+        std::byte { 0x07 }, std::byte { 0x06 }, std::byte { 0x58 }, std::byte { 0x13 },
+        std::byte { 0x05 }, std::byte { 0x07 }, std::byte { 0x0A }, std::byte { 0x11 },
+        std::byte { 0x05 }, std::byte { 0x0B }, std::byte { 0x00 }, std::byte { 0x11 },
+        std::byte { 0x04 }, std::byte { 0x17 }, std::byte { 0x58 }, std::byte { 0x13 },
+        std::byte { 0x04 }, std::byte { 0x11 }, std::byte { 0x04 }, std::byte { 0x02 },
+        std::byte { 0xFE }, std::byte { 0x02 }, std::byte { 0x16 }, std::byte { 0xFE },
+        std::byte { 0x01 }, std::byte { 0x13 }, std::byte { 0x06 }, std::byte { 0x11 },
+        std::byte { 0x06 }, std::byte { 0x2D }, std::byte { 0xE0 }, std::byte { 0x07 },
+        std::byte { 0x0D }, std::byte { 0x2B }, std::byte { 0x00 }, std::byte { 0x09 },
+        std::byte { 0x2A }
+    };
+
+    const std::vector<std::byte> expectedRoundtripBytes(sourceBytes);
+
+    // Recalculated sourceBytes manually to get this.
+    const std::vector<std::byte> expectedInjectionBytes{
+        std::byte { 0x13 }, std::byte { 0x30 }, std::byte { 0x02 }, std::byte { 0x00 },
+        std::byte { 0x3F }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x01 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x11 },
+        std::byte { 0x00 }, std::byte { 0x02 }, std::byte { 0x18 }, std::byte { 0xFE },
+        std::byte { 0x04 }, std::byte { 0x0C }, std::byte { 0x08 }, std::byte { 0x2C },
+        std::byte { 0x05 }, std::byte { 0x00 }, std::byte { 0x02 }, std::byte { 0x0D },
+        std::byte { 0x2B }, std::byte { 0x2F }, std::byte { 0x16 }, std::byte { 0x0A },
+        std::byte { 0x17 }, std::byte { 0x0B }, std::byte { 0x18 }, std::byte { 0x13 },
+        std::byte { 0x04 }, std::byte { 0x2B }, std::byte { 0x14 }, std::byte { 0x00 },
+        std::byte { 0x07 }, std::byte { 0x06 }, std::byte { 0x58 }, std::byte { 0x13 },
+        std::byte { 0x05 }, std::byte { 0x07 }, std::byte { 0x0A }, std::byte { 0x18 },
+        std::byte { 0x11 }, std::byte { 0x05 }, std::byte { 0x5A }, std::byte { 0x0B },
+        std::byte { 0x00 }, std::byte { 0x11 }, std::byte { 0x04 }, std::byte { 0x17 },
+        std::byte { 0x58 }, std::byte { 0x13 }, std::byte { 0x04 }, std::byte { 0x11 },
+        std::byte { 0x04 }, std::byte { 0x02 }, std::byte { 0xFE }, std::byte { 0x02 },
+        std::byte { 0x16 }, std::byte { 0xFE }, std::byte { 0x01 }, std::byte { 0x13 },
+        std::byte { 0x06 }, std::byte { 0x11 }, std::byte { 0x06 }, std::byte { 0x2D },
+        std::byte { 0xDE }, std::byte { 0x07 }, std::byte { 0x0D }, std::byte { 0x2B },
+        std::byte { 0x00 }, std::byte { 0x09 }, std::byte { 0x2A }
+    };
+
+    LabelCreator sourceStreamLabelCreator{};
+    const Label elseLabel{ sourceStreamLabelCreator.CreateLabel() };
+    const Label endLabel1{ sourceStreamLabelCreator.CreateLabel() };
+    const Label loopConditionLabel{ sourceStreamLabelCreator.CreateLabel() };
+    const Label loopBodyLabel{ sourceStreamLabelCreator.CreateLabel() };
+    const Label endLabel2{ sourceStreamLabelCreator.CreateLabel() };
+    // Got these values from MS IL decompiler.
+    const InstructionStream expectedSourceStream{
+        // if (x < 2)
+        OpCode_CEE_NOP{},
+        OpCode_CEE_LDARG_0{},
+        OpCode_CEE_LDC_I4_2{},
+        OpCode_CEE_CLT{},
+        OpCode_CEE_STLOC_2{},
+        OpCode_CEE_LDLOC_2{},
+        OpCode_CEE_BRFALSE_S{elseLabel},
+
+        // return x; // <- x
+        OpCode_CEE_NOP{},
+        OpCode_CEE_LDARG_0{},
+        OpCode_CEE_STLOC_3{},
+        OpCode_CEE_BR_S{endLabel1},
+
+        // int previous = 0;
+        elseLabel,
+        OpCode_CEE_LDC_I4_0{},
+        OpCode_CEE_STLOC_0{},
+
+        // int current = 1;
+        OpCode_CEE_LDC_I4_1{},
+        OpCode_CEE_STLOC_1{},
+
+        // for (int i = 2; i <= x; i++) // <- int i = 2
+        OpCode_CEE_LDC_I4_2{},
+        OpCode_CEE_STLOC_S{4},
+        OpCode_CEE_BR_S{loopConditionLabel},
+
+        // int newCurrent = current + previous;
+        loopBodyLabel,
+        OpCode_CEE_NOP{},
+        OpCode_CEE_LDLOC_1{},
+        OpCode_CEE_LDLOC_0{},
+        OpCode_CEE_ADD{},
+        OpCode_CEE_STLOC_S{5},
+
+        // previous = current;
+        OpCode_CEE_LDLOC_1{},
+        OpCode_CEE_STLOC_0{},
+
+        // current = newCurrent;
+        OpCode_CEE_LDLOC_S{5},
+        OpCode_CEE_STLOC_1{},
+
+        // for (int i = 2; i <= x; i++) // <- i++
+        OpCode_CEE_NOP{},
+        OpCode_CEE_LDLOC_S{4},
+        OpCode_CEE_LDC_I4_1{},
+        OpCode_CEE_ADD{},
+        OpCode_CEE_STLOC_S{4},
+
+        // for (int i = 2; i <= x; i++) // <- i <= x
+        loopConditionLabel,
+        OpCode_CEE_LDLOC_S{4},
+        OpCode_CEE_LDARG_0{},
+        OpCode_CEE_CGT{},
+        OpCode_CEE_LDC_I4_0{},
+        OpCode_CEE_CEQ{},
+        OpCode_CEE_STLOC_S{6},
+        OpCode_CEE_LDLOC_S{6},
+        OpCode_CEE_BRTRUE_S{loopBodyLabel},
+
+        // return current; // <- current
+        OpCode_CEE_LDLOC_1{},
+        OpCode_CEE_STLOC_3{},
+        OpCode_CEE_BR_S{endLabel2},
+
+        // return
+        endLabel1,
+        endLabel2,
+        OpCode_CEE_LDLOC_3{},
+        OpCode_CEE_RET{}
+    };
+
+    const InstructionStream expectedInjectionStream{
+        // if (x < 2)
+        OpCode_CEE_NOP{},
+        OpCode_CEE_LDARG_0{},
+        OpCode_CEE_LDC_I4_2{},
+        OpCode_CEE_CLT{},
+        OpCode_CEE_STLOC_2{},
+        OpCode_CEE_LDLOC_2{},
+        OpCode_CEE_BRFALSE_S{elseLabel},
+
+        // return x; // <- x
+        OpCode_CEE_NOP{},
+        OpCode_CEE_LDARG_0{},
+        OpCode_CEE_STLOC_3{},
+        OpCode_CEE_BR_S{endLabel1},
+
+        // int previous = 0;
+        elseLabel,
+        OpCode_CEE_LDC_I4_0{},
+        OpCode_CEE_STLOC_0{},
+
+        // int current = 1;
+        OpCode_CEE_LDC_I4_1{},
+        OpCode_CEE_STLOC_1{},
+
+        // for (int i = 2; i <= x; i++) // <- int i = 2
+        OpCode_CEE_LDC_I4_2{},
+        OpCode_CEE_STLOC_S{4},
+        OpCode_CEE_BR_S{loopConditionLabel},
+
+        // int newCurrent = current + previous;
+        loopBodyLabel,
+        OpCode_CEE_NOP{},
+        OpCode_CEE_LDLOC_1{},
+        OpCode_CEE_LDLOC_0{},
+        OpCode_CEE_ADD{},
+        OpCode_CEE_STLOC_S{5},
+
+        // previous = current;
+        OpCode_CEE_LDLOC_1{},
+        OpCode_CEE_STLOC_0{},
+
+        // current = 2 * newCurrent;
+        OpCode_CEE_LDC_I4_2{},
+        OpCode_CEE_LDLOC_S{5},
+        OpCode_CEE_MUL{},
+        OpCode_CEE_STLOC_1{},
+
+        // for (int i = 2; i <= x; i++) // <- i++
+        OpCode_CEE_NOP{},
+        OpCode_CEE_LDLOC_S{4},
+        OpCode_CEE_LDC_I4_1{},
+        OpCode_CEE_ADD{},
+        OpCode_CEE_STLOC_S{4},
+
+        // for (int i = 2; i <= x; i++) // <- i <= x
+        loopConditionLabel,
+        OpCode_CEE_LDLOC_S{4},
+        OpCode_CEE_LDARG_0{},
+        OpCode_CEE_CGT{},
+        OpCode_CEE_LDC_I4_0{},
+        OpCode_CEE_CEQ{},
+        OpCode_CEE_STLOC_S{6},
+        OpCode_CEE_LDLOC_S{6},
+        OpCode_CEE_BRTRUE_S{loopBodyLabel},
+
+        // return current; // <- current
+        OpCode_CEE_LDLOC_1{},
+        OpCode_CEE_STLOC_3{},
+        OpCode_CEE_BR_S{endLabel2},
+
+        // return
+        endLabel1,
+        endLabel2,
+        OpCode_CEE_LDLOC_3{},
+        OpCode_CEE_RET{}
+    };
+
+    // Act
+    MethodBody method(sourceBytes);
+
+    const InstructionStream actualSourceStream(method.Stream());
+    const std::vector<std::byte> actualRoundtripBytes(method.Compile());
+    const std::vector<ExceptionsSection> actualExceptionSections(method.ExceptionSections());
+
+    method.Insert(method.begin() + 27, OpCode_CEE_LDC_I4_2{});
+    method.Insert(method.begin() + 29, OpCode_CEE_MUL{});
+
+    const InstructionStream actualInjectionStream(method.Stream());
+    const std::vector<std::byte> actualInjectionBytes(method.Compile());
+
+    // Assert
+    EXPECT_EQ(expectedSourceStream, actualSourceStream);
+    EXPECT_EQ(expectedRoundtripBytes, actualRoundtripBytes);
+    EXPECT_EQ(0, actualExceptionSections.size());
+    EXPECT_EQ(expectedInjectionStream, actualInjectionStream);
+    EXPECT_EQ(expectedInjectionBytes, actualInjectionBytes);
+}
+
+// Checks this injection:
+// private static int MyInjectionTarget(int x, int y)
+// {
+//     switch (x)
+//     {
+//     case 0:
+//     {
+//         return x + y; // Will change to return -(x + y);
+//     }
+//     break;
+//     case 1:
+//     case 2:
+//     {
+//         return x * y; // Will change to return x * y * 3;
+//     }
+//     break;
+//     case 3:
+//     {
+//         return x - y; // Will change to return x - y + 42;
+//     }
+//     break;
+//     case 4:
+//     default:
+//     {
+//         return x / y; // Will change to return x / y / 5;
+//     }
+//     break;
+//     }
+// }
+TEST(MethodBodyTests, InsertFunctionWithSwitch)
+{
+    // Arrange
+    // Got these values from MS IL decompiler.
+    const std::vector<std::byte> sourceBytes {
+        std::byte { 0x13 }, std::byte { 0x30 }, std::byte { 0x02 }, std::byte { 0x00 },
+        std::byte { 0x3F }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x01 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x11 },
+        std::byte { 0x00 }, std::byte { 0x02 }, std::byte { 0x0B }, std::byte { 0x07 },
+        std::byte { 0x0A }, std::byte { 0x06 }, std::byte { 0x45 }, std::byte { 0x05 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x02 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x09 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x09 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x10 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x17 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x2B },
+        std::byte { 0x15 }, std::byte { 0x00 }, std::byte { 0x02 }, std::byte { 0x03 },
+        std::byte { 0x58 }, std::byte { 0x0C }, std::byte { 0x2B }, std::byte { 0x15 },
+        std::byte { 0x00 }, std::byte { 0x02 }, std::byte { 0x03 }, std::byte { 0x5A },
+        std::byte { 0x0C }, std::byte { 0x2B }, std::byte { 0x0E }, std::byte { 0x00 },
+        std::byte { 0x02 }, std::byte { 0x03 }, std::byte { 0x59 }, std::byte { 0x0C },
+        std::byte { 0x2B }, std::byte { 0x07 }, std::byte { 0x00 }, std::byte { 0x02 },
+        std::byte { 0x03 }, std::byte { 0x5B }, std::byte { 0x0C }, std::byte { 0x2B },
+        std::byte { 0x00 }, std::byte { 0x08 }, std::byte { 0x2A }
+    };
+
+    const std::vector<std::byte> expectedRoundtripBytes(sourceBytes);
+
+    // Recalculated sourceBytes manually to get this.
+    const std::vector<std::byte> expectedInjectionBytes{
+        std::byte { 0x13 }, std::byte { 0x30 }, std::byte { 0x02 }, std::byte { 0x00 },
+        std::byte { 0x4A }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x01 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x11 },
+        std::byte { 0x00 }, std::byte { 0x02 }, std::byte { 0x0B }, std::byte { 0x07 },
+        std::byte { 0x0A }, std::byte { 0x06 }, std::byte { 0x45 }, std::byte { 0x05 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x02 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x0A },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x0A },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x13 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x20 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x2B },
+        std::byte { 0x1E }, std::byte { 0x00 }, std::byte { 0x02 }, std::byte { 0x03 },
+        std::byte { 0x58 }, std::byte { 0x65 }, std::byte { 0x0C }, std::byte { 0x2B },
+        std::byte { 0x1F }, std::byte { 0x00 }, std::byte { 0x02 }, std::byte { 0x03 },
+        std::byte { 0x5A }, std::byte { 0x19 }, std::byte { 0x5A }, std::byte { 0x0C },
+        std::byte { 0x2B }, std::byte { 0x16 }, std::byte { 0x00 }, std::byte { 0x02 },
+        std::byte { 0x03 }, std::byte { 0x59 }, std::byte { 0x20 }, std::byte { 0x2A },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x58 },
+        std::byte { 0x0C }, std::byte { 0x2B }, std::byte { 0x09 }, std::byte { 0x00 },
+        std::byte { 0x02 }, std::byte { 0x03 }, std::byte { 0x5B }, std::byte { 0x1B },
+        std::byte { 0x5B }, std::byte { 0x0C }, std::byte { 0x2B }, std::byte { 0x00 },
+        std::byte { 0x08 }, std::byte { 0x2A }
+    };
+
+    LabelCreator sourceStreamLabelCreator{};
+    const Label case0Label{ sourceStreamLabelCreator.CreateLabel() };
+    const Label case1Label{ sourceStreamLabelCreator.CreateLabel() };
+    const Label case2Label{ sourceStreamLabelCreator.CreateLabel() };
+    const Label case3Label{ sourceStreamLabelCreator.CreateLabel() };
+    const Label defaultLabel{ sourceStreamLabelCreator.CreateLabel() };
+    const Label defaultLabel2{ sourceStreamLabelCreator.CreateLabel() };
+    const Label endLabel1{ sourceStreamLabelCreator.CreateLabel() };
+    const Label endLabel2{ sourceStreamLabelCreator.CreateLabel() };
+    const Label endLabel3{ sourceStreamLabelCreator.CreateLabel() };
+    const Label endLabel4{ sourceStreamLabelCreator.CreateLabel() };
+    // Got these values from MS IL decompiler.
+    const InstructionStream expectedSourceStream{
+        // switch (x)
+        OpCode_CEE_NOP{},
+        OpCode_CEE_LDARG_0{},
+        OpCode_CEE_STLOC_1{},
+        OpCode_CEE_LDLOC_1{},
+        OpCode_CEE_STLOC_0{},
+        OpCode_CEE_LDLOC_0{},
+        OpCode_CEE_SWITCH{{ case0Label, case1Label, case2Label, case3Label, defaultLabel }},
+        OpCode_CEE_BR_S{defaultLabel2},
+
+        // case 0:
+        case0Label,
+        // return x + y; // <- x + y
+        OpCode_CEE_NOP{},
+        OpCode_CEE_LDARG_0{},
+        OpCode_CEE_LDARG_1{},
+        OpCode_CEE_ADD{},
+        OpCode_CEE_STLOC_2{},
+
+        // break;
+        OpCode_CEE_BR_S{endLabel1},
+
+        // case 1:
+        // case 2:
+        case1Label,
+        case2Label,
+        // return x * y; // <- x * y
+        OpCode_CEE_NOP{},
+        OpCode_CEE_LDARG_0{},
+        OpCode_CEE_LDARG_1{},
+        OpCode_CEE_MUL{},
+        OpCode_CEE_STLOC_2{},
+
+        // break;
+        OpCode_CEE_BR_S{endLabel2},
+
+        // case 3:
+        case3Label,
+
+        // return x - y; // <- x - y
+        OpCode_CEE_NOP{},
+        OpCode_CEE_LDARG_0{},
+        OpCode_CEE_LDARG_1{},
+        OpCode_CEE_SUB{},
+        OpCode_CEE_STLOC_2{},
+
+        // break;
+        OpCode_CEE_BR_S{endLabel3},
+
+        // case 4:
+        // default:
+        defaultLabel,
+        defaultLabel2,
+
+        // return x / y; // <- x / y
+        OpCode_CEE_NOP{},
+        OpCode_CEE_LDARG_0{},
+        OpCode_CEE_LDARG_1{},
+        OpCode_CEE_DIV{},
+        OpCode_CEE_STLOC_2{},
+
+        // break;
+        OpCode_CEE_BR_S{endLabel4},
+
+        // return
+        endLabel1,
+        endLabel2,
+        endLabel3,
+        endLabel4,
+        OpCode_CEE_LDLOC_2{},
+        OpCode_CEE_RET{}
+    };
+
+    const InstructionStream expectedInjectionStream{
+        // switch (x)
+        OpCode_CEE_NOP{},
+        OpCode_CEE_LDARG_0{},
+        OpCode_CEE_STLOC_1{},
+        OpCode_CEE_LDLOC_1{},
+        OpCode_CEE_STLOC_0{},
+        OpCode_CEE_LDLOC_0{},
+        OpCode_CEE_SWITCH{{ case0Label, case1Label, case2Label, case3Label, defaultLabel }},
+        OpCode_CEE_BR_S{defaultLabel2},
+
+        // case 0:
+        case0Label,
+        // return -(x + y); // <- -(x + y)
+        OpCode_CEE_NOP{},
+        OpCode_CEE_LDARG_0{},
+        OpCode_CEE_LDARG_1{},
+        OpCode_CEE_ADD{},
+        OpCode_CEE_NEG{},
+        OpCode_CEE_STLOC_2{},
+
+        // break;
+        OpCode_CEE_BR_S{endLabel1},
+
+        // case 1:
+        // case 2:
+        case1Label,
+        case2Label,
+        // return x * y * 3; // <- x * y * 3
+        OpCode_CEE_NOP{},
+        OpCode_CEE_LDARG_0{},
+        OpCode_CEE_LDARG_1{},
+        OpCode_CEE_MUL{},
+        OpCode_CEE_LDC_I4_3{},
+        OpCode_CEE_MUL{},
+        OpCode_CEE_STLOC_2{},
+
+        // break;
+        OpCode_CEE_BR_S{endLabel2},
+
+        // case 3:
+        case3Label,
+
+        // return x - y + 42; // <- x - y + 42
+        OpCode_CEE_NOP{},
+        OpCode_CEE_LDARG_0{},
+        OpCode_CEE_LDARG_1{},
+        OpCode_CEE_SUB{},
+        OpCode_CEE_LDC_I4{42},
+        OpCode_CEE_ADD{},
+        OpCode_CEE_STLOC_2{},
+
+        // break;
+        OpCode_CEE_BR_S{endLabel3},
+
+        // case 4:
+        // default:
+        defaultLabel,
+        defaultLabel2,
+
+        // return x / y / 5; // <- x / y / 5
+        OpCode_CEE_NOP{},
+        OpCode_CEE_LDARG_0{},
+        OpCode_CEE_LDARG_1{},
+        OpCode_CEE_DIV{},
+        OpCode_CEE_LDC_I4_5{},
+        OpCode_CEE_DIV{},
+        OpCode_CEE_STLOC_2{},
+
+        // break;
+        OpCode_CEE_BR_S{endLabel4},
+
+        // return
+        endLabel1,
+        endLabel2,
+        endLabel3,
+        endLabel4,
+        OpCode_CEE_LDLOC_2{},
+        OpCode_CEE_RET{}
+    };
+
+    // Act
+    MethodBody method(sourceBytes);
+
+    const InstructionStream actualSourceStream(method.Stream());
+    const std::vector<std::byte> actualRoundtripBytes(method.Compile());
+    const std::vector<ExceptionsSection> actualExceptionSections(method.ExceptionSections());
+
+    method.Insert(method.begin() + 13, OpCode_CEE_NEG{});
+
+    method.Insert(method.begin() + 22, OpCode_CEE_LDC_I4_3{});
+    method.Insert(method.begin() + 23, OpCode_CEE_MUL{});
+
+    method.Insert(method.begin() + 31, OpCode_CEE_LDC_I4{42});
+    method.Insert(method.begin() + 32, OpCode_CEE_ADD{});
+
+    method.Insert(method.begin() + 41, OpCode_CEE_LDC_I4_5{});
+    method.Insert(method.begin() + 42, OpCode_CEE_DIV{});
+
+    const InstructionStream actualInjectionStream(method.Stream());
+    const std::vector<std::byte> actualInjectionBytes(method.Compile());
+
+    // Assert
+    EXPECT_EQ(expectedSourceStream, actualSourceStream);
+    EXPECT_EQ(expectedRoundtripBytes, actualRoundtripBytes);
+    EXPECT_EQ(0, actualExceptionSections.size());
+    EXPECT_EQ(expectedInjectionStream, actualInjectionStream);
+    EXPECT_EQ(expectedInjectionBytes, actualInjectionBytes);
+}
+
+// Checks this injection:
+// private static int MyInjectionTarget(int x, int y)
+// {
+//     try
+//     {
+//         return x / y;
+//     }
+//     catch (DivideByZeroException)
+//     {
+//         return x;
+//     }
+// }
+// Will replace
+//         return x / y;
+// with
+//         return x / (y + 1);
+TEST(MethodBodyTests, InsertFunctionWithTryCatch)
+{
+    // Arrange
+    // Got these values from MS IL decompiler.
+    const std::vector<std::byte> sourceBytes {
+        std::byte { 0x1B }, std::byte { 0x30 }, std::byte { 0x02 }, std::byte { 0x00 },
+        std::byte { 0x10 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x01 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x11 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x02 }, std::byte { 0x03 },
+        std::byte { 0x5B }, std::byte { 0x0A }, std::byte { 0xDE }, std::byte { 0x06 },
+        std::byte { 0x26 }, std::byte { 0x00 }, std::byte { 0x02 }, std::byte { 0x0A },
+        std::byte { 0xDE }, std::byte { 0x00 }, std::byte { 0x06 }, std::byte { 0x2A },
+        std::byte { 0x01 }, std::byte { 0x10 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x01 }, std::byte { 0x00 },
+        std::byte { 0x07 }, std::byte { 0x08 }, std::byte { 0x00 }, std::byte { 0x06 },
+        std::byte { 0x0D }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x01 }
+    };
+
+    const std::vector<std::byte> expectedRoundtripBytes(sourceBytes);
+
+    // Recalculated sourceBytes manually to get this.
+    const std::vector<std::byte> expectedInjectionBytes{
+        std::byte { 0x1B }, std::byte { 0x30 }, std::byte { 0x02 }, std::byte { 0x00 },
+        std::byte { 0x12 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x01 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x11 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x02 }, std::byte { 0x03 },
+        std::byte { 0x17 }, std::byte { 0x58 }, std::byte { 0x5B }, std::byte { 0x0A },
+        std::byte { 0xDE }, std::byte { 0x06 }, std::byte { 0x26 }, std::byte { 0x00 },
+        std::byte { 0x02 }, std::byte { 0x0A }, std::byte { 0xDE }, std::byte { 0x00 },
+        std::byte { 0x06 }, std::byte { 0x2A }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x01 }, std::byte { 0x10 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x01 }, std::byte { 0x00 },
+        std::byte { 0x09 }, std::byte { 0x0A }, std::byte { 0x00 }, std::byte { 0x06 },
+        std::byte { 0x0D }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x01 }
+    };
+
+    LabelCreator sourceStreamLabelCreator{};
+    const Label endLabel1{ sourceStreamLabelCreator.CreateLabel() };
+    const Label endLabel2{ sourceStreamLabelCreator.CreateLabel() };
+    const Label tryLabel{ sourceStreamLabelCreator.CreateLabel() };
+    const Label tryEndLabel{ sourceStreamLabelCreator.CreateLabel() };
+    const Label handlerLabel{ sourceStreamLabelCreator.CreateLabel() };
+    const Label handlerEndLabel{ sourceStreamLabelCreator.CreateLabel() };
+    // Got these values from MS IL decompiler.
+    const InstructionStream expectedSourceStream{
+        OpCode_CEE_NOP{},
+
+        // try 
+        // {
+        tryLabel,
+        OpCode_CEE_NOP{},
+        // return x / y; // <- x / y
+        OpCode_CEE_LDARG_0{},
+        OpCode_CEE_LDARG_1{},
+        OpCode_CEE_DIV{},
+        OpCode_CEE_STLOC_0{},
+
+        // } // end of try {
+        OpCode_CEE_LEAVE_S{endLabel1},
+        tryEndLabel,
+
+        // catch (DivideByZeroException)
+        // {
+        handlerLabel,
+        OpCode_CEE_POP{},
+        OpCode_CEE_NOP{},
+
+        // return x; // <- x
+        OpCode_CEE_LDARG_0{},
+        OpCode_CEE_STLOC_0{},
+
+        // }
+        OpCode_CEE_LEAVE_S{endLabel2},
+        handlerEndLabel,
+
+        // return
+        endLabel1,
+        endLabel2,
+        OpCode_CEE_LDLOC_0{},
+        OpCode_CEE_RET{}
+    };
+
+    const InstructionStream expectedInjectionStream{
+        OpCode_CEE_NOP{},
+
+        // try 
+        // {
+        tryLabel,
+        OpCode_CEE_NOP{},
+        // return x / (y + 1); // <- x / y
+        OpCode_CEE_LDARG_0{},
+        OpCode_CEE_LDARG_1{},
+        OpCode_CEE_LDC_I4_1{},
+        OpCode_CEE_ADD{},
+        OpCode_CEE_DIV{},
+        OpCode_CEE_STLOC_0{},
+
+        // } // end of try {
+        OpCode_CEE_LEAVE_S{endLabel1},
+        tryEndLabel,
+
+        // catch (DivideByZeroException)
+        // {
+        handlerLabel,
+        OpCode_CEE_POP{},
+        OpCode_CEE_NOP{},
+
+        // return x; // <- x
+        OpCode_CEE_LDARG_0{},
+        OpCode_CEE_STLOC_0{},
+
+        // }
+        OpCode_CEE_LEAVE_S{endLabel2},
+        handlerEndLabel,
+
+        // return
+        endLabel1,
+        endLabel2,
+        OpCode_CEE_LDLOC_0{},
+        OpCode_CEE_RET{}
+    };
+
+    // Act
+    MethodBody method(sourceBytes);
+
+    const InstructionStream actualSourceStream(method.Stream());
+    const std::vector<std::byte> actualRoundtripBytes(method.Compile());
+    const std::vector<ExceptionsSection> actualExceptionSections(method.ExceptionSections());
+
+    method.Insert(method.begin() + 5, OpCode_CEE_LDC_I4_1{});
+    method.Insert(method.begin() + 6, OpCode_CEE_ADD{});
+
+    const InstructionStream actualInjectionStream(method.Stream());
+    const std::vector<std::byte> actualInjectionBytes(method.Compile());
+
+    // Assert
+    EXPECT_EQ(expectedSourceStream, actualSourceStream);
+    EXPECT_EQ(expectedRoundtripBytes, actualRoundtripBytes);
+    EXPECT_EQ(1, actualExceptionSections.size());
+    EXPECT_EQ(expectedInjectionStream, actualInjectionStream);
+    EXPECT_EQ(expectedInjectionBytes, actualInjectionBytes);
+}
+
+// Checks this injection:
+// private static int MyInjectionTarget(int x, int y)
+// {
+//     int z = 0;
+//     try
+//     {
+//         z = x / y;
+//     }
+//     finally
+//     {
+//         y = 42;
+//         // Will inject
+//         // x = 0;
+//     }
+//
+//     return z + y;
+// }
+TEST(MethodBodyTests, InsertFunctionWithTryFinally)
+{
+    // Arrange
+    // Got these values from MS IL decompiler.
+    const std::vector<std::byte> sourceBytes {
+        std::byte { 0x1B }, std::byte { 0x30 }, std::byte { 0x02 }, std::byte { 0x00 },
+        std::byte { 0x1A }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x01 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x11 },
+        std::byte { 0x00 }, std::byte { 0x16 }, std::byte { 0x0A }, std::byte { 0x00 },
+        std::byte { 0x02 }, std::byte { 0x03 }, std::byte { 0x5B }, std::byte { 0x0A },
+        std::byte { 0x00 }, std::byte { 0xDE }, std::byte { 0x07 }, std::byte { 0x00 },
+        std::byte { 0x1F }, std::byte { 0x2A }, std::byte { 0x10 }, std::byte { 0x01 },
+        std::byte { 0x00 }, std::byte { 0xDC }, std::byte { 0x06 }, std::byte { 0x03 },
+        std::byte { 0x58 }, std::byte { 0x0B }, std::byte { 0x2B }, std::byte { 0x00 },
+        std::byte { 0x07 }, std::byte { 0x2A }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x01 }, std::byte { 0x10 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x02 }, std::byte { 0x00 }, std::byte { 0x03 }, std::byte { 0x00 },
+        std::byte { 0x08 }, std::byte { 0x0B }, std::byte { 0x00 }, std::byte { 0x07 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }
+    };
+
+    const std::vector<std::byte> expectedRoundtripBytes(sourceBytes);
+
+    // Recalculated sourceBytes manually to get this.
+    const std::vector<std::byte> expectedInjectionBytes{
+        std::byte { 0x1B }, std::byte { 0x30 }, std::byte { 0x02 }, std::byte { 0x00 },
+        std::byte { 0x1D }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x01 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x11 },
+        std::byte { 0x00 }, std::byte { 0x16 }, std::byte { 0x0A }, std::byte { 0x00 },
+        std::byte { 0x02 }, std::byte { 0x03 }, std::byte { 0x5B }, std::byte { 0x0A },
+        std::byte { 0x00 }, std::byte { 0xDE }, std::byte { 0x0A }, std::byte { 0x00 },
+        std::byte { 0x1F }, std::byte { 0x2A }, std::byte { 0x10 }, std::byte { 0x01 },
+        std::byte { 0x16 }, std::byte { 0x10 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0xDC }, std::byte { 0x06 }, std::byte { 0x03 }, std::byte { 0x58 },
+        std::byte { 0x0B }, std::byte { 0x2B }, std::byte { 0x00 }, std::byte { 0x07 },
+        std::byte { 0x2A }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x01 }, std::byte { 0x10 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x02 }, std::byte { 0x00 }, std::byte { 0x03 }, std::byte { 0x00 },
+        std::byte { 0x08 }, std::byte { 0x0B }, std::byte { 0x00 }, std::byte { 0x0A },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }
+    };
+
+    LabelCreator sourceStreamLabelCreator{};
+    const Label endLabel{ sourceStreamLabelCreator.CreateLabel() };
+    const Label retLabel{ sourceStreamLabelCreator.CreateLabel() };
+    const Label tryLabel{ sourceStreamLabelCreator.CreateLabel() };
+    const Label tryEndLabel{ sourceStreamLabelCreator.CreateLabel() };
+    const Label handlerLabel{ sourceStreamLabelCreator.CreateLabel() };
+    const Label handlerEndLabel{ sourceStreamLabelCreator.CreateLabel() };
+    // Got these values from MS IL decompiler.
+    const InstructionStream expectedSourceStream{
+        // int z = 0;
+        OpCode_CEE_NOP{},
+        OpCode_CEE_LDC_I4_0{},
+        OpCode_CEE_STLOC_0{},
+
+        // try
+        // {
+        tryLabel,
+        OpCode_CEE_NOP{},
+
+        // z = x / y;
+        OpCode_CEE_LDARG_0{},
+        OpCode_CEE_LDARG_1{},
+        OpCode_CEE_DIV{},
+        OpCode_CEE_STLOC_0{},
+
+        // } // end of try {
+        OpCode_CEE_NOP{},
+        OpCode_CEE_LEAVE_S{endLabel},
+        tryEndLabel,
+
+        // finally
+        // {
+        handlerLabel,
+        OpCode_CEE_NOP{},
+
+        // y = 42;
+        OpCode_CEE_LDC_I4_S{42},
+        OpCode_CEE_STARG_S{1},
+
+        // } // end of finally {
+        OpCode_CEE_NOP{},
+        OpCode_CEE_ENDFINALLY{},
+        handlerEndLabel,
+
+        // return z + y; // <- z + y
+        endLabel,
+        OpCode_CEE_LDLOC_0{},
+        OpCode_CEE_LDARG_1{},
+        OpCode_CEE_ADD{},
+        OpCode_CEE_STLOC_1{},
+        OpCode_CEE_BR_S{retLabel},
+
+        // return z + y; // <- return
+        retLabel,
+        OpCode_CEE_LDLOC_1{},
+        OpCode_CEE_RET{}
+    };
+
+    const InstructionStream expectedInjectionStream{
+        // int z = 0;
+        OpCode_CEE_NOP{},
+        OpCode_CEE_LDC_I4_0{},
+        OpCode_CEE_STLOC_0{},
+
+        // try
+        // {
+        tryLabel,
+        OpCode_CEE_NOP{},
+
+        // z = x / y;
+        OpCode_CEE_LDARG_0{},
+        OpCode_CEE_LDARG_1{},
+        OpCode_CEE_DIV{},
+        OpCode_CEE_STLOC_0{},
+
+        // } // end of try {
+        OpCode_CEE_NOP{},
+        OpCode_CEE_LEAVE_S{endLabel},
+        tryEndLabel,
+
+        // finally
+        // {
+        handlerLabel,
+        OpCode_CEE_NOP{},
+
+        // y = 42;
+        OpCode_CEE_LDC_I4_S{42},
+        OpCode_CEE_STARG_S{1},
+
+        // x = 0;
+        OpCode_CEE_LDC_I4_0{},
+        OpCode_CEE_STARG_S{0},
+
+        // } // end of finally {
+        OpCode_CEE_NOP{},
+        OpCode_CEE_ENDFINALLY{},
+        handlerEndLabel,
+
+        // return z + y; // <- z + y
+        endLabel,
+        OpCode_CEE_LDLOC_0{},
+        OpCode_CEE_LDARG_1{},
+        OpCode_CEE_ADD{},
+        OpCode_CEE_STLOC_1{},
+        OpCode_CEE_BR_S{retLabel},
+
+        // return z + y; // <- return
+        retLabel,
+        OpCode_CEE_LDLOC_1{},
+        OpCode_CEE_RET{}
+    };
+
+    // Act
+    MethodBody method(sourceBytes);
+
+    const InstructionStream actualSourceStream(method.Stream());
+    const std::vector<std::byte> actualRoundtripBytes(method.Compile());
+    const std::vector<ExceptionsSection> actualExceptionSections(method.ExceptionSections());
+
+    method.Insert(method.begin() + 16, OpCode_CEE_LDC_I4_0{});
+    method.Insert(method.begin() + 17, OpCode_CEE_STARG_S{0});
+
+    const InstructionStream actualInjectionStream(method.Stream());
+    const std::vector<std::byte> actualInjectionBytes(method.Compile());
+
+    // Assert
+    EXPECT_EQ(expectedSourceStream, actualSourceStream);
+    EXPECT_EQ(expectedRoundtripBytes, actualRoundtripBytes);
+    EXPECT_EQ(1, actualExceptionSections.size());
+    EXPECT_EQ(expectedInjectionStream, actualInjectionStream);
+    EXPECT_EQ(expectedInjectionBytes, actualInjectionBytes);
+}
+
+// Checks this injection:
+// private static int MyInjectionTarget(int x, int y)
+// {
+//     int z = 0;
+//     try
+//     {
+//         z = x / y;
+//     }
+//     catch (DivideByZeroException e) when(e.Message.Length % 2 == 0)
+//     {
+//         y = 42;
+//     }
+//     
+//     return z + y;
+// }
+// Will replace
+// catch (DivideByZeroException e) when(e.Message.Length % 2 == 0)
+// with
+// catch (DivideByZeroException e) when(e.Message.Length % 2 == (0 + 1))
+TEST(MethodBodyTests, InsertFunctionWithTryCatchWhen)
+{
+    // Arrange
+    // Got these values from MS IL decompiler.
+    const std::vector<std::byte> sourceBytes {
+        std::byte { 0x1B }, std::byte { 0x30 }, std::byte { 0x02 }, std::byte { 0x00 },
+        std::byte { 0x40 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x01 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x11 },
+        std::byte { 0x00 }, std::byte { 0x16 }, std::byte { 0x0A }, std::byte { 0x00 },
+        std::byte { 0x02 }, std::byte { 0x03 }, std::byte { 0x5B }, std::byte { 0x0A },
+        std::byte { 0x00 }, std::byte { 0xDE }, std::byte { 0x2D }, std::byte { 0x75 },
+        std::byte { 0x0D }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x01 },
+        std::byte { 0x25 }, std::byte { 0x2D }, std::byte { 0x04 }, std::byte { 0x26 },
+        std::byte { 0x16 }, std::byte { 0x2B }, std::byte { 0x16 }, std::byte { 0x0B },
+        std::byte { 0x07 }, std::byte { 0x6F }, std::byte { 0x0C }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x0A }, std::byte { 0x6F }, std::byte { 0x0D },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x0A }, std::byte { 0x18 },
+        std::byte { 0x5D }, std::byte { 0x16 }, std::byte { 0xFE }, std::byte { 0x01 },
+        std::byte { 0x0C }, std::byte { 0x08 }, std::byte { 0x16 }, std::byte { 0xFE },
+        std::byte { 0x03 }, std::byte { 0xFE }, std::byte { 0x11 }, std::byte { 0x26 },
+        std::byte { 0x00 }, std::byte { 0x1F }, std::byte { 0x2A }, std::byte { 0x10 },
+        std::byte { 0x01 }, std::byte { 0x00 }, std::byte { 0xDE }, std::byte { 0x00 },
+        std::byte { 0x06 }, std::byte { 0x03 }, std::byte { 0x58 }, std::byte { 0x0D },
+        std::byte { 0x2B }, std::byte { 0x00 }, std::byte { 0x09 }, std::byte { 0x2A },
+        std::byte { 0x01 }, std::byte { 0x10 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x01 }, std::byte { 0x00 }, std::byte { 0x03 }, std::byte { 0x00 },
+        std::byte { 0x08 }, std::byte { 0x2F }, std::byte { 0x00 }, std::byte { 0x09 },
+        std::byte { 0x0B }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }
+    };
+
+    const std::vector<std::byte> expectedRoundtripBytes(sourceBytes);
+
+    // Recalculated sourceBytes manually to get this.
+    const std::vector<std::byte> expectedInjectionBytes{
+        std::byte { 0x1B }, std::byte { 0x30 }, std::byte { 0x02 }, std::byte { 0x00 },
+        std::byte { 0x42 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x01 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x11 },
+        std::byte { 0x00 }, std::byte { 0x16 }, std::byte { 0x0A }, std::byte { 0x00 },
+        std::byte { 0x02 }, std::byte { 0x03 }, std::byte { 0x5B }, std::byte { 0x0A },
+        std::byte { 0x00 }, std::byte { 0xDE }, std::byte { 0x2F }, std::byte { 0x75 },
+        std::byte { 0x0D }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x01 },
+        std::byte { 0x25 }, std::byte { 0x2D }, std::byte { 0x04 }, std::byte { 0x26 },
+        std::byte { 0x16 }, std::byte { 0x2B }, std::byte { 0x18 }, std::byte { 0x0B },
+        std::byte { 0x07 }, std::byte { 0x6F }, std::byte { 0x0C }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x0A }, std::byte { 0x6F }, std::byte { 0x0D },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x0A }, std::byte { 0x18 },
+        std::byte { 0x5D }, std::byte { 0x16 }, std::byte { 0x17 }, std::byte { 0x58 },
+        std::byte { 0xFE }, std::byte { 0x01 }, std::byte { 0x0C }, std::byte { 0x08 },
+        std::byte { 0x16 }, std::byte { 0xFE }, std::byte { 0x03 }, std::byte { 0xFE },
+        std::byte { 0x11 }, std::byte { 0x26 }, std::byte { 0x00 }, std::byte { 0x1F },
+        std::byte { 0x2A }, std::byte { 0x10 }, std::byte { 0x01 }, std::byte { 0x00 },
+        std::byte { 0xDE }, std::byte { 0x00 }, std::byte { 0x06 }, std::byte { 0x03 },
+        std::byte { 0x58 }, std::byte { 0x0D }, std::byte { 0x2B }, std::byte { 0x00 },
+        std::byte { 0x09 }, std::byte { 0x2A }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x01 }, std::byte { 0x10 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x01 }, std::byte { 0x00 }, std::byte { 0x03 }, std::byte { 0x00 },
+        std::byte { 0x08 }, std::byte { 0x31 }, std::byte { 0x00 }, std::byte { 0x09 },
+        std::byte { 0x0B }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }
+    };
+
+    LabelCreator sourceStreamLabelCreator{};
+    const Label endLabel{ sourceStreamLabelCreator.CreateLabel() };
+    const Label isInstanceLabel{ sourceStreamLabelCreator.CreateLabel() };
+    const Label endFilterLabel{ sourceStreamLabelCreator.CreateLabel() };
+    const Label endLabel2{ sourceStreamLabelCreator.CreateLabel() };
+    const Label retLabel{ sourceStreamLabelCreator.CreateLabel() };
+    const Label tryLabel{ sourceStreamLabelCreator.CreateLabel() };
+    const Label tryEndLabel{ sourceStreamLabelCreator.CreateLabel() };
+    const Label handlerLabel{ sourceStreamLabelCreator.CreateLabel() };
+    const Label handlerEndLabel{ sourceStreamLabelCreator.CreateLabel() };
+    const Label filterLabel{ sourceStreamLabelCreator.CreateLabel() };
+    // Got these values from MS IL decompiler.
+    const InstructionStream expectedSourceStream{
+        // int z = 0;
+        OpCode_CEE_NOP{},
+        OpCode_CEE_LDC_I4_0{},
+        OpCode_CEE_STLOC_0{},
+
+        // try
+        // {
+        tryLabel,
+        OpCode_CEE_NOP{},
+
+        // z = x / y;
+        OpCode_CEE_LDARG_0{},
+        OpCode_CEE_LDARG_1{},
+        OpCode_CEE_DIV{},
+        OpCode_CEE_STLOC_0{},
+
+        // } // end of try {
+        OpCode_CEE_NOP{},
+        OpCode_CEE_LEAVE_S{endLabel},
+        tryEndLabel,
+
+        // catch (DivideByZeroException e) when(e.Message.Length % 2 == 0) // <- when
+        filterLabel,
+
+        // catch (DivideByZeroException e) when(e.Message.Length % 2 == 0) // <- DivideByZeroException e
+        OpCode_CEE_ISINST{ 0x0100000D },
+        OpCode_CEE_DUP{},
+        OpCode_CEE_BRTRUE_S{ isInstanceLabel },
+        OpCode_CEE_POP{},
+        OpCode_CEE_LDC_I4_0{},
+        OpCode_CEE_BR_S{endFilterLabel},
+
+        // catch (DivideByZeroException e) when(e.Message.Length % 2 == 0) // <- e.Message.Length % 2 == 0
+        isInstanceLabel,
+        OpCode_CEE_STLOC_1{},
+        OpCode_CEE_LDLOC_1{},
+        OpCode_CEE_CALLVIRT{ 0x0A00000C },
+        OpCode_CEE_CALLVIRT{ 0x0A00000D },
+        OpCode_CEE_LDC_I4_2{},
+        OpCode_CEE_REM{},
+        OpCode_CEE_LDC_I4_0{},
+        OpCode_CEE_CEQ{},
+        OpCode_CEE_STLOC_2{},
+        OpCode_CEE_LDLOC_2{},
+        OpCode_CEE_LDC_I4_0{},
+        OpCode_CEE_CGT_UN{},
+        endFilterLabel,
+        OpCode_CEE_ENDFILTER{},
+
+        // catch (DivideByZeroException e) when(e.Message.Length % 2 == 0) // <- catch
+        // {
+        handlerLabel,
+        OpCode_CEE_POP{},
+        OpCode_CEE_NOP{},
+
+        // y = 42;
+        OpCode_CEE_LDC_I4_S{42},
+        OpCode_CEE_STARG_S{1},
+
+        // } // end of catch {
+        OpCode_CEE_NOP{},
+        OpCode_CEE_LEAVE_S{endLabel2},
+        handlerEndLabel,
+
+        // return z + y; // <- z + y
+        endLabel,
+        endLabel2,
+        OpCode_CEE_LDLOC_0{},
+        OpCode_CEE_LDARG_1{},
+        OpCode_CEE_ADD{},
+        OpCode_CEE_STLOC_3{},
+        OpCode_CEE_BR_S{retLabel},
+
+        // return z + y; // <- return
+        retLabel,
+        OpCode_CEE_LDLOC_3{},
+        OpCode_CEE_RET{}
+    };
+
+    const InstructionStream expectedInjectionStream{
+        // int z = 0;
+        OpCode_CEE_NOP{},
+        OpCode_CEE_LDC_I4_0{},
+        OpCode_CEE_STLOC_0{},
+
+        // try
+        // {
+        tryLabel,
+        OpCode_CEE_NOP{},
+
+        // z = x / y;
+        OpCode_CEE_LDARG_0{},
+        OpCode_CEE_LDARG_1{},
+        OpCode_CEE_DIV{},
+        OpCode_CEE_STLOC_0{},
+
+        // } // end of try {
+        OpCode_CEE_NOP{},
+        OpCode_CEE_LEAVE_S{endLabel},
+        tryEndLabel,
+
+        // catch (DivideByZeroException e) when(e.Message.Length % 2 == (0 + 1)) // <- when
+        filterLabel,
+
+        // catch (DivideByZeroException e) when(e.Message.Length % 2 == (0 + 1)) // <- DivideByZeroException e
+        OpCode_CEE_ISINST{ 0x0100000D },
+        OpCode_CEE_DUP{},
+        OpCode_CEE_BRTRUE_S{ isInstanceLabel },
+        OpCode_CEE_POP{},
+        OpCode_CEE_LDC_I4_0{},
+        OpCode_CEE_BR_S{endFilterLabel},
+
+        // catch (DivideByZeroException e) when(e.Message.Length % 2 == (0 + 1)) // <- e.Message.Length % 2 == (0 + 1)
+        isInstanceLabel,
+        OpCode_CEE_STLOC_1{},
+        OpCode_CEE_LDLOC_1{},
+        OpCode_CEE_CALLVIRT{ 0x0A00000C },
+        OpCode_CEE_CALLVIRT{ 0x0A00000D },
+        OpCode_CEE_LDC_I4_2{},
+        OpCode_CEE_REM{},
+        OpCode_CEE_LDC_I4_0{},
+        OpCode_CEE_LDC_I4_1{},
+        OpCode_CEE_ADD{},
+        OpCode_CEE_CEQ{},
+        OpCode_CEE_STLOC_2{},
+        OpCode_CEE_LDLOC_2{},
+        OpCode_CEE_LDC_I4_0{},
+        OpCode_CEE_CGT_UN{},
+        endFilterLabel,
+        OpCode_CEE_ENDFILTER{},
+
+        // catch (DivideByZeroException e) when(e.Message.Length % 2 == (0 + 1)) // <- catch
+        // {
+        handlerLabel,
+        OpCode_CEE_POP{},
+        OpCode_CEE_NOP{},
+
+        // y = 42;
+        OpCode_CEE_LDC_I4_S{42},
+        OpCode_CEE_STARG_S{1},
+
+        // } // end of catch {
+        OpCode_CEE_NOP{},
+        OpCode_CEE_LEAVE_S{endLabel2},
+        handlerEndLabel,
+
+        // return z + y; // <- z + y
+        endLabel,
+        endLabel2,
+        OpCode_CEE_LDLOC_0{},
+        OpCode_CEE_LDARG_1{},
+        OpCode_CEE_ADD{},
+        OpCode_CEE_STLOC_3{},
+        OpCode_CEE_BR_S{retLabel},
+
+        // return z + y; // <- return
+        retLabel,
+        OpCode_CEE_LDLOC_3{},
+        OpCode_CEE_RET{}
+    };
+
+    // Act
+    MethodBody method(sourceBytes);
+
+    const InstructionStream actualSourceStream(method.Stream());
+    const std::vector<std::byte> actualRoundtripBytes(method.Compile());
+    const std::vector<ExceptionsSection> actualExceptionSections(method.ExceptionSections());
+
+    method.Insert(method.begin() + 27, OpCode_CEE_LDC_I4_1{});
+    method.Insert(method.begin() + 28, OpCode_CEE_ADD{});
+
+    const InstructionStream actualInjectionStream(method.Stream());
+    const std::vector<std::byte> actualInjectionBytes(method.Compile());
+
+    // Assert
+    EXPECT_EQ(expectedSourceStream, actualSourceStream);
+    EXPECT_EQ(expectedRoundtripBytes, actualRoundtripBytes);
+    EXPECT_EQ(1, actualExceptionSections.size());
+    EXPECT_EQ(expectedInjectionStream, actualInjectionStream);
+    EXPECT_EQ(expectedInjectionBytes, actualInjectionBytes);
+}
+
+// Checks this injection:
+// private static int MyInjectionTarget(int x)
+// {
+//     if (x == 1)
+//     {
+//         return 42;
+//         // Will insert 128 No Operation instructions here
+//     }
+// 
+//     return 0;
+// }
+//
+// The branching instruction correnponding to if
+// must be converted from brfalse.s (short form)
+// to brfalse (long form).
+TEST(MethodBodyTests, TransformJumpToLongIfNeeded)
+{
+    // Arrange
+    const std::vector<std::byte> sourceBytes{
+        std::byte { 0x13 }, std::byte { 0x30 }, std::byte { 0x02 }, std::byte { 0x00 },
+        std::byte { 0x15 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x01 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x11 },
+        std::byte { 0x00 }, std::byte { 0x02 }, std::byte { 0x17 }, std::byte { 0xFE },
+        std::byte { 0x01 }, std::byte { 0x0A }, std::byte { 0x06 }, std::byte { 0x2C },
+        std::byte { 0x06 }, std::byte { 0x00 }, std::byte { 0x1F }, std::byte { 0x2A },
+        std::byte { 0x0B }, std::byte { 0x2B }, std::byte { 0x04 }, std::byte { 0x16 },
+        std::byte { 0x0B }, std::byte { 0x2B }, std::byte { 0x00 }, std::byte { 0x07 },
+        std::byte { 0x2A }
+    };
+
+    const std::vector<std::byte> expectedRoundtripBytes(sourceBytes);
+
+    const std::vector<std::byte> expectedInjectionBytes{
+        std::byte { 0x13 }, std::byte { 0x30 }, std::byte { 0x02 }, std::byte { 0x00 },
+        std::byte { 0x98 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x01 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x11 },
+        std::byte { 0x00 }, std::byte { 0x02 }, std::byte { 0x17 }, std::byte { 0xFE },
+        std::byte { 0x01 }, std::byte { 0x0A }, std::byte { 0x06 }, std::byte { 0x39 },
+        std::byte { 0x86 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x1F }, std::byte { 0x2A }, std::byte { 0x0B },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x2B }, std::byte { 0x04 }, std::byte { 0x16 }, std::byte { 0x0B },
+        std::byte { 0x2B }, std::byte { 0x00 }, std::byte { 0x07 }, std::byte { 0x2A }
+    };
+
+    LabelCreator sourceStreamLabelCreator{};
+    const Label elseLabel{ sourceStreamLabelCreator.CreateLabel() };
+    const Label endLabel1{ sourceStreamLabelCreator.CreateLabel() };
+    const Label endLabel2{ sourceStreamLabelCreator.CreateLabel() };
+    const InstructionStream expectedSourceStream{
+        // if (x == 1) // <- x == 1
+        OpCode_CEE_NOP{},
+        OpCode_CEE_LDARG_0{},
+        OpCode_CEE_LDC_I4_1{},
+        OpCode_CEE_CEQ{},
+        OpCode_CEE_STLOC_0{},
+        OpCode_CEE_LDLOC_0{},
+
+        // if (x == 1) // <- if
+        OpCode_CEE_BRFALSE_S{elseLabel},
+
+        // return 42; // <- 42
+        OpCode_CEE_NOP{},
+        OpCode_CEE_LDC_I4_S{42},
+        OpCode_CEE_STLOC_1{},
+        OpCode_CEE_BR_S{endLabel1},
+
+        // return 0; // <- 0
+        elseLabel,
+        OpCode_CEE_LDC_I4_0{},
+        OpCode_CEE_STLOC_1{},
+        OpCode_CEE_BR_S{endLabel2},
+
+        // return
+        endLabel1,
+        endLabel2,
+        OpCode_CEE_LDLOC_1{},
+        OpCode_CEE_RET{}
+    };
+
+    const size_t insertionLength{ 128 };
+    const ptrdiff_t insertionPosition{ 10 };
+    InstructionStream expectedInjectionStream(expectedSourceStream);
+    expectedInjectionStream[6] = OpCode_CEE_BRFALSE{ elseLabel };
+    expectedInjectionStream.insert(
+        expectedInjectionStream.cbegin() + insertionPosition,
+        insertionLength,
+        OpCode_CEE_NOP{});
+
+    // Act
+    MethodBody method(sourceBytes);
+
+    const InstructionStream actualSourceStream(method.Stream());
+    const std::vector<std::byte> actualRoundtripBytes(method.Compile());
+    const std::vector<ExceptionsSection> actualExceptionSections(method.ExceptionSections());
+
+    for (size_t i{ 0 }; i != insertionLength; ++i)
+    {
+        method.Insert(method.begin() + insertionPosition, OpCode_CEE_NOP{});
+    }
+
+    const InstructionStream actualInjectionStream(method.Stream());
+    const std::vector<std::byte> actualInjectionBytes(method.Compile());
+
+    // Assert
+    EXPECT_EQ(expectedSourceStream, actualSourceStream);
+    EXPECT_EQ(expectedRoundtripBytes, actualRoundtripBytes);
+    EXPECT_EQ(0, actualExceptionSections.size());
+    EXPECT_EQ(expectedInjectionStream, actualInjectionStream);
+    EXPECT_EQ(expectedInjectionBytes, actualInjectionBytes);
+}
+
+// Checks this injection:
+// private static int MyInjectionTarget(int x)
+// {
+//     // // Will insert
+//     //if (x == 1)
+//     //{
+//     //    return 42;
+//     //    // 128 No Operation instructions here
+//     //}
+// 
+//     return x + 1;
+// }
+//
+// We will inject brfalse.s (short form), but
+// the injection mechanism should be able to
+// convert it to the long form - brfalse.
+TEST(MethodBodyTests, InsertTransformJumpToLongIfNeeded)
+{
+    // Arrange
+    const std::vector<std::byte> sourceBytes{
+        std::byte { 0x13 }, std::byte { 0x30 }, std::byte { 0x02 }, std::byte { 0x00 },
+        std::byte { 0x09 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x01 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x11 },
+        std::byte { 0x00 }, std::byte { 0x02 }, std::byte { 0x17 }, std::byte { 0x58 },
+        std::byte { 0x0A }, std::byte { 0x2B }, std::byte { 0x00 }, std::byte { 0x06 },
+        std::byte { 0x2A }
+    };
+
+    const std::vector<std::byte> expectedRoundtripBytes(sourceBytes);
+
+    const std::vector<std::byte> expectedInjectionBytes{
+        std::byte { 0x13 }, std::byte { 0x30 }, std::byte { 0x02 }, std::byte { 0x00 },
+        std::byte { 0x9A }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x01 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x11 },
+        std::byte { 0x00 }, std::byte { 0x02 }, std::byte { 0x17 }, std::byte { 0xFE },
+        std::byte { 0x01 }, std::byte { 0x0B }, std::byte { 0x07 }, std::byte { 0x39 },
+        std::byte { 0x86 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x1F }, std::byte { 0x2A }, std::byte { 0x0A },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x2B }, std::byte { 0x06 }, std::byte { 0x02 }, std::byte { 0x17 },
+        std::byte { 0x58 }, std::byte { 0x0A }, std::byte { 0x2B }, std::byte { 0x00 },
+        std::byte { 0x06 }, std::byte { 0x2A }
+    };
+
+    LabelCreator sourceStreamLabelCreator{};
+    const Label endLabel{ sourceStreamLabelCreator.CreateLabel() };
+    const InstructionStream expectedSourceStream{
+        // return x + 1; // <- x + 1
+        OpCode_CEE_NOP{},
+        OpCode_CEE_LDARG_0{},
+        OpCode_CEE_LDC_I4_1{},
+        OpCode_CEE_ADD{},
+        OpCode_CEE_STLOC_0{},
+        OpCode_CEE_BR_S{endLabel},
+
+        // return x + 1; // <- return
+        endLabel,
+        OpCode_CEE_LDLOC_0{},
+        OpCode_CEE_RET{}
+    };
+
+    const Label elseLabel{ sourceStreamLabelCreator.CreateLabel() };
+    const size_t insertionLength{ 128 };
+    const ptrdiff_t insertionPosition{ 10 };
+    InstructionStream expectedInjectionStream{
+        // if (x == 1) // <- x == 1
+        OpCode_CEE_NOP{},
+        OpCode_CEE_LDARG_0{},
+        OpCode_CEE_LDC_I4_1{},
+        OpCode_CEE_CEQ{},
+        OpCode_CEE_STLOC_1{},
+        OpCode_CEE_LDLOC_1{},
+
+        // if (x == 1) // <- if
+        OpCode_CEE_BRFALSE{elseLabel},
+
+        // return 42; // <- 42
+        OpCode_CEE_NOP{},
+        OpCode_CEE_LDC_I4_S{42},
+        OpCode_CEE_STLOC_0{},
+        // 128 No Operation instruction will go here
+        OpCode_CEE_BR_S{endLabel},
+
+        // return x + 1; // <- x + 1
+        elseLabel,
+        OpCode_CEE_LDARG_0{},
+        OpCode_CEE_LDC_I4_1{},
+        OpCode_CEE_ADD{},
+        OpCode_CEE_STLOC_0{},
+        OpCode_CEE_BR_S{endLabel},
+
+        // return
+        endLabel,
+        OpCode_CEE_LDLOC_0{},
+        OpCode_CEE_RET{}
+    };
+
+    expectedInjectionStream.insert(
+        expectedInjectionStream.cbegin() + insertionPosition,
+        insertionLength,
+        OpCode_CEE_NOP{});
+
+    // Act
+    MethodBody method(sourceBytes);
+
+    const InstructionStream actualSourceStream(method.Stream());
+    const std::vector<std::byte> actualRoundtripBytes(method.Compile());
+    const std::vector<ExceptionsSection> actualExceptionSections(method.ExceptionSections());
+
+    // if (x == 1) // <- x == 1
+    method.Insert(method.begin() + 1, OpCode_CEE_LDARG_0{});
+    method.Insert(method.begin() + 2, OpCode_CEE_LDC_I4_1{});
+    method.Insert(method.begin() + 3, OpCode_CEE_CEQ{});
+    method.Insert(method.begin() + 4, OpCode_CEE_STLOC_1{});
+    method.Insert(method.begin() + 5, OpCode_CEE_LDLOC_1{});
+
+    // if (x == 1) // <- if
+    const Label actualElseLabel{ method.CreateLabel() };
+    method.Insert(method.begin() + 6, OpCode_CEE_BRFALSE_S{ actualElseLabel });
+
+    // return 42; // <- 42
+    method.Insert(method.begin() + 7, OpCode_CEE_NOP{});
+    method.Insert(method.begin() + 8, OpCode_CEE_LDC_I4_S{42});
+    method.Insert(method.begin() + 9, OpCode_CEE_STLOC_0{});
+
+    // 128 No Operation instructions
+    for (size_t i{ 0 }; i != insertionLength; ++i)
+    {
+        method.Insert(method.begin() + insertionPosition, OpCode_CEE_NOP{});
+    }
+
+    method.Insert(method.begin() + 138, OpCode_CEE_BR_S{ endLabel });
+    method.MarkLabel(method.begin() + 139, actualElseLabel);
+
+    const InstructionStream actualInjectionStream(method.Stream());
+    const std::vector<std::byte> actualInjectionBytes(method.Compile());
+
+    // Assert
+    EXPECT_EQ(expectedSourceStream, actualSourceStream);
+    EXPECT_EQ(expectedRoundtripBytes, actualRoundtripBytes);
+    EXPECT_EQ(0, actualExceptionSections.size());
+    EXPECT_EQ(expectedInjectionStream, actualInjectionStream);
+    EXPECT_EQ(expectedInjectionBytes, actualInjectionBytes);
+}
+
+// Checks injection containing branching:
+// private static int MyInjectionTarget(int x)
+// {
+//     // // Will insert
+//     //if (x == 1)
+//     //{
+//     //    return 42;
+//     //}
+// 
+//     return x + 1;
+// }
+//
+// Will use methods CreateLabel and MarkLabel
+// to add the new branching instruction.
+TEST(MethodBodyTests, ÑreateAndMarkLabel)
+{
+    // Arrange
+    const std::vector<std::byte> sourceBytes{
+        std::byte { 0x13 }, std::byte { 0x30 }, std::byte { 0x02 }, std::byte { 0x00 },
+        std::byte { 0x09 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x01 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x11 },
+        std::byte { 0x00 }, std::byte { 0x02 }, std::byte { 0x17 }, std::byte { 0x58 },
+        std::byte { 0x0A }, std::byte { 0x2B }, std::byte { 0x00 }, std::byte { 0x06 },
+        std::byte { 0x2A }
+    };
+
+    const std::vector<std::byte> expectedRoundtripBytes(sourceBytes);
+
+    const std::vector<std::byte> expectedInjectionBytes{
+        std::byte { 0x13 }, std::byte { 0x30 }, std::byte { 0x02 }, std::byte { 0x00 },
+        std::byte { 0x17 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x00 },
+        std::byte { 0x01 }, std::byte { 0x00 }, std::byte { 0x00 }, std::byte { 0x11 },
+        std::byte { 0x00 }, std::byte { 0x02 }, std::byte { 0x17 }, std::byte { 0xFE },
+        std::byte { 0x01 }, std::byte { 0x0B }, std::byte { 0x07 }, std::byte { 0x2C },
+        std::byte { 0x06 }, std::byte { 0x00 }, std::byte { 0x1F }, std::byte { 0x2A },
+        std::byte { 0x0A }, std::byte { 0x2B }, std::byte { 0x06 }, std::byte { 0x02 },
+        std::byte { 0x17 }, std::byte { 0x58 }, std::byte { 0x0A }, std::byte { 0x2B },
+        std::byte { 0x00 }, std::byte { 0x06 }, std::byte { 0x2A }
+    };
+
+    LabelCreator sourceStreamLabelCreator{};
+    const Label endLabel{ sourceStreamLabelCreator.CreateLabel() };
+    const InstructionStream expectedSourceStream{
+        // return x + 1; // <- x + 1
+        OpCode_CEE_NOP{},
+        OpCode_CEE_LDARG_0{},
+        OpCode_CEE_LDC_I4_1{},
+        OpCode_CEE_ADD{},
+        OpCode_CEE_STLOC_0{},
+        OpCode_CEE_BR_S{endLabel},
+
+        // return x + 1; // <- return
+        endLabel,
+        OpCode_CEE_LDLOC_0{},
+        OpCode_CEE_RET{}
+    };
+
+    const Label elseLabel{ sourceStreamLabelCreator.CreateLabel() };
+    InstructionStream expectedInjectionStream{
+        // if (x == 1) // <- x == 1
+        OpCode_CEE_NOP{},
+        OpCode_CEE_LDARG_0{},
+        OpCode_CEE_LDC_I4_1{},
+        OpCode_CEE_CEQ{},
+        OpCode_CEE_STLOC_1{},
+        OpCode_CEE_LDLOC_1{},
+
+        // if (x == 1) // <- if
+        OpCode_CEE_BRFALSE_S{elseLabel},
+
+        // return 42; // <- 42
+        OpCode_CEE_NOP{},
+        OpCode_CEE_LDC_I4_S{42},
+        OpCode_CEE_STLOC_0{},
+        OpCode_CEE_BR_S{endLabel},
+
+        // return x + 1; // <- x + 1
+        elseLabel,
+        OpCode_CEE_LDARG_0{},
+        OpCode_CEE_LDC_I4_1{},
+        OpCode_CEE_ADD{},
+        OpCode_CEE_STLOC_0{},
+        OpCode_CEE_BR_S{endLabel},
+
+        // return
+        endLabel,
+        OpCode_CEE_LDLOC_0{},
+        OpCode_CEE_RET{}
+    };
+
+    // Act
+    MethodBody method(sourceBytes);
+
+    const InstructionStream actualSourceStream(method.Stream());
+    const std::vector<std::byte> actualRoundtripBytes(method.Compile());
+    const std::vector<ExceptionsSection> actualExceptionSections(method.ExceptionSections());
+
+    // if (x == 1) // <- x == 1
+    method.Insert(method.begin() + 1, OpCode_CEE_LDARG_0{});
+    method.Insert(method.begin() + 2, OpCode_CEE_LDC_I4_1{});
+    method.Insert(method.begin() + 3, OpCode_CEE_CEQ{});
+    method.Insert(method.begin() + 4, OpCode_CEE_STLOC_1{});
+    method.Insert(method.begin() + 5, OpCode_CEE_LDLOC_1{});
+
+    // if (x == 1) // <- if
+    const Label actualElseLabel{ method.CreateLabel() };
+    method.Insert(method.begin() + 6, OpCode_CEE_BRFALSE_S{ actualElseLabel });
+
+    // return 42; // <- 42
+    method.Insert(method.begin() + 7, OpCode_CEE_NOP{});
+    method.Insert(method.begin() + 8, OpCode_CEE_LDC_I4_S{ 42 });
+    method.Insert(method.begin() + 9, OpCode_CEE_STLOC_0{});
+
+    method.Insert(method.begin() + 10, OpCode_CEE_BR_S{ endLabel });
+    method.MarkLabel(method.begin() + 11, actualElseLabel);
+
+    const InstructionStream actualInjectionStream(method.Stream());
+    const std::vector<std::byte> actualInjectionBytes(method.Compile());
+
+    // Assert
+    EXPECT_EQ(expectedSourceStream, actualSourceStream);
+    EXPECT_EQ(expectedRoundtripBytes, actualRoundtripBytes);
+    EXPECT_EQ(0, actualExceptionSections.size());
+    EXPECT_EQ(expectedInjectionStream, actualInjectionStream);
+    EXPECT_EQ(expectedInjectionBytes, actualInjectionBytes);
+}
+
+// Checks that method Compile() throws an
+// std::logic_error if there is a branching
+// instruction with some label, but MarkLabel()
+// was not used to define which instruction the
+// label points to.
+TEST(MethodBodyTests, CompileThrowsOnUnresolvedLabel)
+{
+    // Arrange
+    std::vector<std::byte> rawBytes(CreateSimpleFunction());
+    MethodBody method(rawBytes);
+
+    // Act
+    const Label label { method.CreateLabel() };
+    method.Insert(
+        method.begin() + 2,
+        OpCode_CEE_BR_S{ label });
+
+    // Assert
+    EXPECT_THROW(method.Compile(), std::logic_error);
+}
+
+// Checks that method MarkLabel() throws an
+// std::logic_error if it was called again for
+// the same MethodBody with the same label.
+TEST(MethodBodyTests, MarkLabelThrowsOnLabelMarkedTwice)
+{
+    // Arrange
+    std::vector<std::byte> rawBytes(CreateSimpleFunction());
+    MethodBody method(rawBytes);
+
+    // Act
+    const Label label { method.CreateLabel() };
+    method.MarkLabel(method.begin(), label);
+
+    // Assert
+    EXPECT_THROW(
+        method.MarkLabel(method.begin() + 2, label),
+        std::logic_error);
+}

--- a/Drill4dotNet/Drill4dotNet-Tests/MethodHeaderTests.cpp
+++ b/Drill4dotNet/Drill4dotNet-Tests/MethodHeaderTests.cpp
@@ -3,3 +3,209 @@
 #include "MethodHeader.h"
 
 using namespace Drill4dotNet;
+
+// Checks MethodHeader is created from a
+// tiny method header bytes.
+TEST(MethodHeaderTests, CreateFromSmallHeader)
+{
+    // Arrange
+    const int codeSize{ 0x30 };
+    // Header is 1 byte combining size and tiny header flag.
+    const std::vector<std::byte> headerBytes { std::byte { 0xC2 } };
+
+    // Act
+    const MethodHeader header(headerBytes);
+    std::vector<std::byte> serialized{};
+    header.AppendToBytes(serialized);
+
+    // Assert
+    EXPECT_EQ(1, header.Size());
+    EXPECT_EQ(codeSize, header.CodeSize());
+    EXPECT_EQ(headerBytes, serialized);
+    EXPECT_FALSE(header.HasExceptionsSections());
+}
+
+// Checks MethodHeader's constructor throws an
+// std::runtime_error if the input sequence of
+// bytes is empty.
+TEST(MethodHeaderTests, CreateThrowsEmptyInput)
+{
+    // Arrange
+    const std::vector<std::byte> headerBytes {};
+
+    // Assert
+    EXPECT_THROW(MethodHeader { headerBytes }, std::runtime_error);
+}
+
+// Checks that the SetCodeSize() updates the
+// CodeSize() and this change is properly reflected
+// in the tiny binary representation.
+TEST(MethodHeaderTests, SetCodeSizeAffectsSmallHeader)
+{
+    // Arrange
+    const int codeSize{ 0x30 };
+    const int newCodeSize { 0x39 };
+    // Header is 1 byte combining size and tiny header flag.
+    const std::vector<std::byte> headerBytes { std::byte { 0xC2 } };
+    const std::vector<std::byte> expectedSerialized { std::byte { 0xE6 } };
+
+    // Act
+    MethodHeader header(headerBytes);
+    header.SetCodeSize(newCodeSize);
+    std::vector<std::byte> serialized{};
+    header.AppendToBytes(serialized);
+
+    // Assert
+    EXPECT_EQ(1, header.Size());
+    EXPECT_EQ(newCodeSize, header.CodeSize());
+    EXPECT_EQ(expectedSerialized, serialized);
+    EXPECT_FALSE(header.HasExceptionsSections());
+}
+
+// Checks MethodHeader is created from a
+// fat method header bytes.
+TEST(MethodHeaderTests, CreateFromFatHeader)
+{
+    // Arrange
+    const const int codeSize { 0x5D18D4D7 };
+    const std::vector<std::byte> headerBytes
+    {
+        std::byte { 0x1B },
+        std::byte { 0x30 },
+        std::byte { 0x02 },
+        std::byte { 0x00 },
+        std::byte { 0xD7 },
+        std::byte { 0xD4 },
+        std::byte { 0x18 },
+        std::byte { 0x5D },
+        std::byte { 0x01 },
+        std::byte { 0x00 },
+        std::byte { 0x00 },
+        std::byte { 0x11 }
+    };
+
+    // Act
+    const MethodHeader header(headerBytes);
+    std::vector<std::byte> serialized{};
+    header.AppendToBytes(serialized);
+
+    // Assert
+    EXPECT_EQ(12, header.Size());
+    EXPECT_EQ(codeSize, header.CodeSize());
+    EXPECT_EQ(headerBytes, serialized);
+    EXPECT_TRUE(header.HasExceptionsSections());
+}
+
+// Checks MethodHeader's constructor throws an
+// std::runtime_error if the input sequence of
+// bytes ends unexpectedly.
+TEST(MethodHeaderTests, CreateThrowsInputUnexpectedEnd)
+{
+    // Arrange
+    // This header meant to be 12 bytes long, but
+    // has 5 bytes only
+    const std::vector<std::byte> headerBytes
+    {
+        std::byte { 0x1B },
+        std::byte { 0x30 },
+        std::byte { 0x02 },
+        std::byte { 0x00 },
+        std::byte { 0xD7 }
+    };
+
+    // Assert
+    EXPECT_THROW(MethodHeader{ headerBytes }, std::runtime_error);
+}
+
+// Checks that if we got method header with
+// some extra data, this data is saved and then
+// appended to the fat binary representation.
+TEST(MethodHeaderTests, CreateFromFatHeaderBiggerThanUsual)
+{
+    // Arrange
+    const std::vector<std::byte> headerBytes
+    {
+        std::byte { 0x1B },
+        std::byte { 0x40 },
+        std::byte { 0x02 },
+        std::byte { 0x00 },
+        std::byte { 0xD7 },
+        std::byte { 0xD4 },
+        std::byte { 0x18 },
+        std::byte { 0x5D },
+        std::byte { 0x01 },
+        std::byte { 0x00 },
+        std::byte { 0x00 },
+        std::byte { 0x11 },
+        std::byte { 0xFF },
+        std::byte { 0xFF },
+        std::byte { 0xFF },
+        std::byte { 0xFF }
+    };
+
+    // Act
+    const MethodHeader header(headerBytes);
+    std::vector<std::byte> serialized{};
+    header.AppendToBytes(serialized);
+
+    // Assert
+    EXPECT_EQ(16, header.Size());
+    EXPECT_EQ(headerBytes, serialized);
+}
+
+// Checks that the SetCodeSize() updates the
+// CodeSize() and this change is properly reflected
+// in the fat binary representation.
+TEST(MethodHeaderTests, SetCodeSizeAffectsFatHeader)
+{
+    // Arrange
+    const int codeSize { 0x5D18D4D7 };
+    const int newCodeSize { 0x5D19A959 };
+    const std::vector<std::byte> headerBytes
+    {
+        std::byte { 0x1B },
+        std::byte { 0x30 },
+        std::byte { 0x02 },
+        std::byte { 0x00 },
+        std::byte { 0xD7 },
+        std::byte { 0xD4 },
+        std::byte { 0x18 },
+        std::byte { 0x5D },
+        std::byte { 0x01 },
+        std::byte { 0x00 },
+        std::byte { 0x00 },
+        std::byte { 0x11 }
+    };
+
+    const std::vector<std::byte> expectedSerialized
+    {
+        std::byte { 0x1B },
+        std::byte { 0x30 },
+        std::byte { 0x02 },
+        std::byte { 0x00 },
+        std::byte { 0x59 },
+        std::byte { 0xA9 },
+        std::byte { 0x19 },
+        std::byte { 0x5D },
+        std::byte { 0x01 },
+        std::byte { 0x00 },
+        std::byte { 0x00 },
+        std::byte { 0x11 }
+    };
+
+    // Act
+    MethodHeader header(headerBytes);
+    header.SetCodeSize(newCodeSize);
+    std::vector<std::byte> serialized{};
+    header.AppendToBytes(serialized);
+
+    // Assert
+    EXPECT_EQ(newCodeSize, header.CodeSize());
+    EXPECT_TRUE(header.HasExceptionsSections());
+    EXPECT_EQ(expectedSerialized, serialized);
+}
+
+static_assert(MethodHeader::IsValidCodeSize(0x38));
+static_assert(MethodHeader::IsValidCodeSize(0x8D1C9D5E));
+static_assert(!MethodHeader::IsValidCodeSize(0x000000018D1C9D5E));
+static_assert(!MethodHeader::IsValidCodeSize(-1));

--- a/Drill4dotNet/Drill4dotNet-Tests/MethodHeaderTests.cpp
+++ b/Drill4dotNet/Drill4dotNet-Tests/MethodHeaderTests.cpp
@@ -1,0 +1,5 @@
+#include "pch.h"
+
+#include "MethodHeader.h"
+
+using namespace Drill4dotNet;

--- a/Drill4dotNet/Drill4dotNet-Tests/OpCodeVariantTests.cpp
+++ b/Drill4dotNet/Drill4dotNet-Tests/OpCodeVariantTests.cpp
@@ -1,0 +1,5 @@
+#include "pch.h"
+
+#include "OpCodes.h"
+
+using namespace Drill4dotNet;

--- a/Drill4dotNet/Drill4dotNet-Tests/OpCodeVariantTests.cpp
+++ b/Drill4dotNet/Drill4dotNet-Tests/OpCodeVariantTests.cpp
@@ -3,3 +3,71 @@
 #include "OpCodes.h"
 
 using namespace Drill4dotNet;
+
+// For the given variant, asserts methods
+// HoldsAlternative and Visit work with the
+// given TOpCode.
+template <typename TOpCode>
+static void AssertVariantHolds(const OpCodeVariant& variant)
+{
+    const bool holds { variant.HoldsAlternative<TOpCode>() };
+    bool visitCalledWith { false };
+    variant.Visit([&visitCalledWith](const auto& x)
+    {
+        visitCalledWith = std::is_same_v<TOpCode, std::decay_t<decltype(x)>>;
+    });
+
+    // Assert
+    EXPECT_TRUE(holds);
+    EXPECT_TRUE(visitCalledWith);
+}
+
+// Checks the default constructed OpCodeVariant
+// contains a No Operation instruction.
+TEST(OpCodeVariantTests, Create)
+{
+    // Arrange
+
+    // Act
+    const OpCodeVariant variant {};
+
+    // Assert
+    AssertVariantHolds<OpCode_CEE_NOP>(variant);
+    EXPECT_EQ(1, variant.SizeWithArgument());
+    EXPECT_TRUE(variant.GetIf<OpCode_CEE_NOP>().has_value());
+}
+
+// Checks OpCodeVariant is created with a specific
+// opcode without inline argument, and the opcode
+// is retrieved again from the OpCodeVariant.
+TEST(OpCodeVariantTests, CreateWithoutArgument)
+{
+    // Arrange
+
+    // Act
+    const OpCodeVariant variant { OpCode_CEE_ADD { } };
+
+    // Assert
+    AssertVariantHolds<OpCode_CEE_ADD>(variant);
+    EXPECT_EQ(1, variant.SizeWithArgument());
+    EXPECT_TRUE(variant.GetIf<OpCode_CEE_ADD>().has_value());
+}
+
+// Checks OpCodeVariant is created with a specific
+// opcode with inline argument, and the opcode and argument
+// are retrieved again from the OpCodeVariant.
+TEST(OpCodeVariantTests, CreateWithArgument)
+{
+    // Arrange
+    const OpCodeArgumentType::InlineI expectedConstant { 42 };
+
+    // Act
+    const OpCodeVariant variant { OpCode_CEE_LDC_I4 { expectedConstant } };
+    const std::optional<OpCode_CEE_LDC_I4> actualOpCode = variant.GetIf<OpCode_CEE_LDC_I4>();
+
+    // Assert
+    AssertVariantHolds<OpCode_CEE_LDC_I4>(variant);
+    EXPECT_EQ(5, variant.SizeWithArgument());
+    ASSERT_TRUE(variant.GetIf<OpCode_CEE_LDC_I4>().has_value());
+    EXPECT_EQ(expectedConstant, variant.GetIf<OpCode_CEE_LDC_I4>()->Argument());
+}


### PR DESCRIPTION
Tests for the main part of work from EPMDJ-2315 , merged as #22 .

- Tests for `MethodHeader`, `ExceptionClause`, and `ExceptionsSection` check how these models of .net entities are parsed and converted back to binary representation.
- Tests for `InstructionStream` check various methods responsible for search in instructions stream and calculation of byte offsets.
- Tests for `MethodBody` check injection into methods with various statements.