### PR TITLE
EPMDJ-2348: Extracted `#include <corprof_i.cpp>` to common file

### DIFF
--- a/Drill4dotNet/Drill4dotNet-Tests/CProfilerCallbackTest.cpp
+++ b/Drill4dotNet/Drill4dotNet-Tests/CProfilerCallbackTest.cpp
@@ -80,6 +80,3 @@ TEST_F(CProfilerCallbackTest, Initialize_Shutdown)
     EXPECT_HRESULT_SUCCEEDED(profilerCallback->Shutdown());
     EXPECT_EQ(nullptr, &profilerCallback->GetCorProfilerInfo());
 }
-
-// Attach definitions of IID_ICorProfilerCallback, IID_ICorProfilerCallback2, IID_ICorProfilerInfo2, IID_ICorProfilerInfo3, etc.
-#include <corprof_i.cpp>

--- a/Drill4dotNet/Drill4dotNet-Tests/Drill4dotNet-Tests.vcxproj
+++ b/Drill4dotNet/Drill4dotNet-Tests/Drill4dotNet-Tests.vcxproj
@@ -44,6 +44,10 @@
     <ClInclude Include="pch.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\Drill4dotNet\CorGUIDs.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Use</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Use</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="..\Drill4dotNet\CProfilerCallback.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Use</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Use</PrecompiledHeader>

--- a/Drill4dotNet/Drill4dotNet-Tests/Drill4dotNet-Tests.vcxproj.filters
+++ b/Drill4dotNet/Drill4dotNet-Tests/Drill4dotNet-Tests.vcxproj.filters
@@ -29,6 +29,9 @@
     <ClCompile Include="CProfilerCallbackTest.cpp">
       <Filter>Unit Tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\Drill4dotNet\CorGUIDs.cpp">
+      <Filter>Tested Source</Filter>
+    </ClCompile>
     <ClCompile Include="..\Drill4dotNet\InstructionStream.cpp">
       <Filter>Tested Source</Filter>
     </ClCompile>

--- a/Drill4dotNet/Drill4dotNet/CDrillProfiler.cpp
+++ b/Drill4dotNet/Drill4dotNet/CDrillProfiler.cpp
@@ -22,6 +22,3 @@ namespace Drill4dotNet
     }
 
 }
-
-// Attach definitions of IID_ICorProfilerCallback, IID_ICorProfilerCallback2, IID_ICorProfilerInfo2, IID_ICorProfilerInfo3, etc.
-#include <corprof_i.cpp>

--- a/Drill4dotNet/Drill4dotNet/CorGUIDs.cpp
+++ b/Drill4dotNet/Drill4dotNet/CorGUIDs.cpp
@@ -1,0 +1,4 @@
+#include "pch.h"
+
+// Attach definitions of IID_ICorProfilerCallback, IID_ICorProfilerCallback2, IID_ICorProfilerInfo2, IID_ICorProfilerInfo3, etc.
+#include <corprof_i.cpp>

--- a/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj
+++ b/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj
@@ -264,6 +264,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="CDrillProfiler.cpp" />
+    <ClCompile Include="CorGUIDs.cpp" />
     <ClCompile Include="CorProfilerInfo.cpp" />
     <ClCompile Include="CProfilerCallback.cpp" />
     <ClCompile Include="dllmain.cpp" />

--- a/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj.filters
+++ b/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj.filters
@@ -135,6 +135,9 @@
     <ClCompile Include="CorProfilerInfo.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="CorGUIDs.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="InstructionStream.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
EPMDJ-2348: Extracted `#include <corprof_i.cpp>` (required to link IIDs) to common file `CorGUIDs.cpp`.
It is based on #28, essentially has 1 commit.