### PR TITLE
OpCode::CEE_* classes now provide information about the stack and flow control behavior

### DIFF
--- a/Drill4dotNet/Drill4dotNet-Tests/ExceptionClauseTests.cpp
+++ b/Drill4dotNet/Drill4dotNet-Tests/ExceptionClauseTests.cpp
@@ -41,37 +41,37 @@ static RawExceptionClause<TRawClause> RawClause()
     // all instructions are 1 byte
     InstructionStream stream {
         // int x = 1;
-        OpCode_CEE_LDC_I4_1{},
-        OpCode_CEE_STLOC_0{},
+        OpCode::CEE_LDC_I4_1{},
+        OpCode::CEE_STLOC_0{},
 
         // int y = 2;
-        OpCode_CEE_LDC_I4_2{},
-        OpCode_CEE_STLOC_1{},
+        OpCode::CEE_LDC_I4_2{},
+        OpCode::CEE_STLOC_1{},
 
         // will have try { here
 
         // z = x + y;
-        OpCode_CEE_LDLOC_0{},
-        OpCode_CEE_LDLOC_1{},
-        OpCode_CEE_ADD{},
-        OpCode_CEE_STLOC_2{},
+        OpCode::CEE_LDLOC_0{},
+        OpCode::CEE_LDLOC_1{},
+        OpCode::CEE_ADD{},
+        OpCode::CEE_STLOC_2{},
 
-        OpCode_CEE_LEAVE{ exitLabel },
+        OpCode::CEE_LEAVE{ exitLabel },
         // will have
         // } // end of try
         // /* begin of handler */
         // {
 
         // z = 0;
-        OpCode_CEE_LDC_I4_0{},
-        OpCode_CEE_STLOC_2{},
-        OpCode_CEE_LEAVE_S{exitLabel},
+        OpCode::CEE_LDC_I4_0{},
+        OpCode::CEE_STLOC_2{},
+        OpCode::CEE_LEAVE_S{exitLabel},
         // here
         // Will have } here
 
         // return z;
         exitLabel,
-        OpCode_CEE_RET{}
+        OpCode::CEE_RET{}
     };
 
     TRawClause rawClause;
@@ -208,9 +208,9 @@ static RawExceptionClause<TRawClause> TryCatchWhen()
     auto result = RawClause<TRawClause>();
     result.Stream.insert(result.Stream.cbegin() + 9,
         {
-            OpCode_CEE_LDLOC_S{4},
-            OpCode_CEE_LDC_I4_3{},
-            OpCode_CEE_CEQ{}
+            OpCode::CEE_LDLOC_S{4},
+            OpCode::CEE_LDC_I4_3{},
+            OpCode::CEE_CEQ{}
         });
     result.RawClause.Flags = COR_ILEXCEPTION_CLAUSE_FILTER;
     result.RawClause.FilterOffset = result.RawClause.HandlerOffset;
@@ -504,7 +504,7 @@ static void CanPutToSmallHeaderFalse()
     stream.insert(
         stream.cbegin() + paddingPosition,
         paddingSize,
-        OpCode_CEE_NOP{});
+        OpCode::CEE_NOP{});
 
     // Assert
     EXPECT_FALSE(clause.CanPutToSmallHeader());
@@ -540,7 +540,7 @@ TEST(ExceptionClauseTests, CanPutToSmallHeaderFarCatch)
     stream.insert(
         stream.cbegin() + 13,
         padding,
-        OpCode_CEE_NOP{});
+        OpCode::CEE_NOP{});
 
     // Assert
     EXPECT_FALSE(clause.CanPutToSmallHeader());
@@ -576,9 +576,9 @@ TEST(ExceptionClauseTests, CanPutToSmallHeaderFarWhen)
         = RawClause<IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_SMALL>();
     stream.insert(stream.cend(),
         {
-            OpCode_CEE_LDLOC_S{4},
-            OpCode_CEE_LDC_I4_3{},
-            OpCode_CEE_CEQ{}
+            OpCode::CEE_LDLOC_S{4},
+            OpCode::CEE_LDC_I4_3{},
+            OpCode::CEE_CEQ{}
         });
     rawClause.Flags = COR_ILEXCEPTION_CLAUSE_FILTER;
     rawClause.FilterOffset = 18;
@@ -593,7 +593,7 @@ TEST(ExceptionClauseTests, CanPutToSmallHeaderFarWhen)
     stream.insert(
         stream.cbegin() + 18,
         paddingSize,
-        OpCode_CEE_NOP{});
+        OpCode::CEE_NOP{});
 
     // Assert
     EXPECT_TRUE(clause.CanPutToSmallHeader());

--- a/Drill4dotNet/Drill4dotNet-Tests/ExceptionsSectionTests.cpp
+++ b/Drill4dotNet/Drill4dotNet-Tests/ExceptionsSectionTests.cpp
@@ -8,7 +8,7 @@ using namespace Drill4dotNet;
 // four No Operation instructions.
 InstructionStream CreateStream()
 {
-    return InstructionStream(4, OpCode_CEE_NOP{});
+    return InstructionStream(4, OpCode::CEE_NOP{});
 }
 
 // Creates a small exception clause header,
@@ -333,7 +333,7 @@ TEST(ExceptionsSectionTests, ExtendSectionOfSmallClauses)
         secondClause
     ) };
 
-    InstructionStream stream(8, OpCode_CEE_NOP{});
+    InstructionStream stream(8, OpCode::CEE_NOP{});
     LabelCreator labelCreator{};
     std::vector<std::byte>::const_iterator iterator{ sectionData.cbegin() };
     ExceptionsSection section(
@@ -429,7 +429,7 @@ TEST(ExceptionsSectionTests, ExtendSectionOfSmallClauses)
     stream.insert(
         stream.cbegin() + 8,
         0x00010000,
-        OpCode_CEE_NOP{});
+        OpCode::CEE_NOP{});
 
     std::vector<std::byte> serialized{};
     section.AppendToBytes(serialized);

--- a/Drill4dotNet/Drill4dotNet-Tests/InstructionStreamTests.cpp
+++ b/Drill4dotNet/Drill4dotNet-Tests/InstructionStreamTests.cpp
@@ -7,12 +7,12 @@ using namespace Drill4dotNet;
 TEST(InstructionStreamTests, FindInstruction)
 {
     // Arrange
-    const InstructionStream stream { OpCode_CEE_BREAK{}, OpCode_CEE_ADD{} };
+    const InstructionStream stream { OpCode::CEE_BREAK{}, OpCode::CEE_ADD{} };
 
     // Act
-    const ConstStreamPosition first { FindInstruction<OpCode_CEE_BREAK>(stream.cbegin(), stream.cend()) };
-    const ConstStreamPosition second { FindInstruction<OpCode_CEE_ADD>(stream.cbegin(), stream.cend()) };
-    const ConstStreamPosition notFound { FindInstruction<OpCode_CEE_NOP>(stream.cbegin(), stream.cend()) };
+    const ConstStreamPosition first { FindInstruction<OpCode::CEE_BREAK>(stream.cbegin(), stream.cend()) };
+    const ConstStreamPosition second { FindInstruction<OpCode::CEE_ADD>(stream.cbegin(), stream.cend()) };
+    const ConstStreamPosition notFound { FindInstruction<OpCode::CEE_NOP>(stream.cbegin(), stream.cend()) };
 
     // Assert
     EXPECT_EQ(stream.cbegin(), first);
@@ -23,7 +23,7 @@ TEST(InstructionStreamTests, FindInstruction)
 TEST(InstructionStreamTests, ResolveJumpOffsetZero)
 {
     // Arrange
-    const InstructionStream stream(10, OpCode_CEE_NOP { });
+    const InstructionStream stream(10, OpCode::CEE_NOP { });
     const ConstStreamPosition firstPosition { stream.cbegin() };
     const ConstStreamPosition secondPosition { stream.cbegin() + 5 };
     const ConstStreamPosition thirdPosition { stream.cend() - 1 };
@@ -43,7 +43,7 @@ TEST(InstructionStreamTests, ResolveJumpOffsetZero)
 TEST(InstructionStreamTests, ResolveJumpOffsetPositive)
 {
     // Arrange
-    const InstructionStream stream(10, OpCode_CEE_NOP { });
+    const InstructionStream stream(10, OpCode::CEE_NOP { });
     const ConstStreamPosition firstPosition { stream.cbegin() };
     const ConstStreamPosition secondPosition { stream.cbegin() + 5 };
     const ConstStreamPosition thirdPosition { stream.cend() - 1 };
@@ -63,7 +63,7 @@ TEST(InstructionStreamTests, ResolveJumpOffsetPositive)
 TEST(InstructionStreamTests, ResolveJumpOffsetNegative)
 {
     // Arrange
-    const InstructionStream stream(10, OpCode_CEE_NOP { });
+    const InstructionStream stream(10, OpCode::CEE_NOP { });
     const ConstStreamPosition firstPosition { stream.cbegin() };
     const ConstStreamPosition secondPosition { stream.cbegin() + 5 };
     const ConstStreamPosition thirdPosition { stream.cend() - 1 };
@@ -82,7 +82,7 @@ TEST(InstructionStreamTests, ResolveJumpOffsetNegative)
 TEST(InstructionStreamTests, ResolveJumpOffsetOutOfStream)
 {
     // Arrange
-    const InstructionStream stream { OpCode_CEE_NOP { } };
+    const InstructionStream stream { OpCode::CEE_NOP { } };
     const ConstStreamPosition position { stream.cbegin() };
 
     // Act
@@ -117,11 +117,11 @@ TEST(InstructionStreamTests, ResolveJumpOffsetSkipsLabels)
     LabelCreator creator{};
     const InstructionStream stream {
         creator.CreateLabel(),
-        OpCode_CEE_NOP{},
+        OpCode::CEE_NOP{},
         creator.CreateLabel(),
-        OpCode_CEE_NOP{},
+        OpCode::CEE_NOP{},
         creator.CreateLabel(),
-        OpCode_CEE_NOP{}
+        OpCode::CEE_NOP{}
     };
 
     const ConstStreamPosition position { stream.cbegin() + 2 };
@@ -148,10 +148,10 @@ TEST(InstructionStreamTests, ResolveJumpOffsetIgnoresMiddleOfInstruction)
 {
     // Arrange
     const InstructionStream stream{
-        OpCode_CEE_LDARG{0},
-        OpCode_CEE_CEQ{},
-        OpCode_CEE_LDC_I4{42}, 
-        OpCode_CEE_BREAK{}
+        OpCode::CEE_LDARG{0},
+        OpCode::CEE_CEQ{},
+        OpCode::CEE_LDC_I4{42}, 
+        OpCode::CEE_BREAK{}
     };
     const ConstStreamPosition position { stream.cbegin() + 1 };
 
@@ -185,7 +185,7 @@ TEST(InstructionStreamTests, ResolveAbsoluteOffsetEmptyStream)
 TEST(InstructionStreamTests, ResolveAbsoluteOffsetOutOfStream)
 {
     // Arrange
-    const InstructionStream stream(10, OpCode_CEE_NOP { });
+    const InstructionStream stream(10, OpCode::CEE_NOP { });
 
     // Act
     const ConstStreamPosition position { ResolveAbsoluteOffset(stream, 100) };
@@ -197,7 +197,7 @@ TEST(InstructionStreamTests, ResolveAbsoluteOffsetOutOfStream)
 TEST(InstructionStreamTests, ResolveAbsoluteOffset)
 {
     // Arrange
-    const InstructionStream stream(10, OpCode_CEE_NOP { });
+    const InstructionStream stream(10, OpCode::CEE_NOP { });
     AbsoluteOffset firstPosition { 0 };
     AbsoluteOffset secondPosition { 4 };
     AbsoluteOffset thirdPosition { 9 };
@@ -228,9 +228,9 @@ TEST(InstructionStreamTests, ResolveAbsoluteOffsetVariousInstructions)
 {
     // Arrange
     const InstructionStream stream{
-        OpCode_CEE_CEQ{},
-        OpCode_CEE_LDC_I4{ 42 },
-        OpCode_CEE_ADD{}
+        OpCode::CEE_CEQ{},
+        OpCode::CEE_LDC_I4{ 42 },
+        OpCode::CEE_ADD{}
     };
     AbsoluteOffset firstPosition { 0 };
     AbsoluteOffset secondPosition { 2 };
@@ -242,9 +242,9 @@ TEST(InstructionStreamTests, ResolveAbsoluteOffsetVariousInstructions)
     const ConstStreamPosition third{ ResolveAbsoluteOffset(stream, thirdPosition) };
 
     // Assert
-    AssertHolds<OpCode_CEE_CEQ>(first, stream);
-    AssertHolds<OpCode_CEE_LDC_I4>(second, stream);
-    AssertHolds<OpCode_CEE_ADD>(third, stream);
+    AssertHolds<OpCode::CEE_CEQ>(first, stream);
+    AssertHolds<OpCode::CEE_LDC_I4>(second, stream);
+    AssertHolds<OpCode::CEE_ADD>(third, stream);
 }
 
 // In .net, an offset from the method beginning should point exactly to
@@ -256,10 +256,10 @@ TEST(InstructionStreamTests, ResolveAbsoluteOffsetIgnoresMiddleOfInstruction)
 {
     // Arrange
     const InstructionStream stream{
-        OpCode_CEE_LDARG{0},
-        OpCode_CEE_CEQ{},
-        OpCode_CEE_LDC_I4{42},
-        OpCode_CEE_BREAK{}
+        OpCode::CEE_LDARG{0},
+        OpCode::CEE_CEQ{},
+        OpCode::CEE_LDC_I4{42},
+        OpCode::CEE_BREAK{}
     };
 
     // Act
@@ -279,14 +279,14 @@ TEST(InstructionStreamTests, GetNthInstruction)
     LabelCreator creator{};
     const InstructionStream stream {
         creator.CreateLabel(),
-        OpCode_CEE_LDARG{0},
+        OpCode::CEE_LDARG{0},
         creator.CreateLabel(),
         creator.CreateLabel(),
-        OpCode_CEE_CEQ{},
+        OpCode::CEE_CEQ{},
         creator.CreateLabel(),
-        OpCode_CEE_LDC_I4{42},
+        OpCode::CEE_LDC_I4{42},
         creator.CreateLabel(),
-        OpCode_CEE_BREAK{} };
+        OpCode::CEE_BREAK{} };
 
     // Act
     const ConstStreamPosition first{ GetNthInstruction(stream, 0) };
@@ -295,16 +295,16 @@ TEST(InstructionStreamTests, GetNthInstruction)
     const ConstStreamPosition forth{ GetNthInstruction(stream, 3) };
 
     // Assert
-    AssertHolds<OpCode_CEE_LDARG>(first, stream);
-    AssertHolds<OpCode_CEE_CEQ>(second, stream);
-    AssertHolds<OpCode_CEE_LDC_I4>(third, stream);
-    AssertHolds<OpCode_CEE_BREAK>(forth, stream);
+    AssertHolds<OpCode::CEE_LDARG>(first, stream);
+    AssertHolds<OpCode::CEE_CEQ>(second, stream);
+    AssertHolds<OpCode::CEE_LDC_I4>(third, stream);
+    AssertHolds<OpCode::CEE_BREAK>(forth, stream);
 }
 
 TEST(InstructionStreamTests, CalculateJumpOffsetPositive)
 {
     // Arrange
-    const InstructionStream stream(10, OpCode_CEE_NOP{ });
+    const InstructionStream stream(10, OpCode::CEE_NOP{ });
     const ConstStreamPosition firstPosition{ stream.cbegin() };
     const ConstStreamPosition secondPosition{ stream.cbegin() + 5 };
     const ConstStreamPosition thirdPosition{ stream.cend() - 1 };
@@ -323,7 +323,7 @@ TEST(InstructionStreamTests, CalculateJumpOffsetPositive)
 TEST(InstructionStreamTests, CalculateJumpOffsetAtSameInstruction)
 {
     // Arrange
-    const InstructionStream stream(10, OpCode_CEE_NOP{ });
+    const InstructionStream stream(10, OpCode::CEE_NOP{ });
     const ConstStreamPosition firstPosition{ stream.cbegin() };
     const ConstStreamPosition secondPosition{ stream.cbegin() + 5 };
     const ConstStreamPosition thirdPosition{ stream.cend() - 1 };
@@ -342,7 +342,7 @@ TEST(InstructionStreamTests, CalculateJumpOffsetAtSameInstruction)
 TEST(InstructionStreamTests, CalculateJumpOffsetAtNextInstruction)
 {
     // Arrange
-    const InstructionStream stream(10, OpCode_CEE_NOP{ });
+    const InstructionStream stream(10, OpCode::CEE_NOP{ });
     const ConstStreamPosition firstPosition{ stream.cbegin() };
     const ConstStreamPosition secondPosition{ stream.cbegin() + 5 };
     const ConstStreamPosition thirdPosition{ stream.cend() - 1 };
@@ -361,7 +361,7 @@ TEST(InstructionStreamTests, CalculateJumpOffsetAtNextInstruction)
 TEST(InstructionStreamTests, CalculateJumpOffsetNegative)
 {
     // Arrange
-    const InstructionStream stream(10, OpCode_CEE_NOP{ });
+    const InstructionStream stream(10, OpCode::CEE_NOP{ });
     const ConstStreamPosition firstPosition{ stream.cbegin() };
     const ConstStreamPosition secondPosition{ stream.cbegin() + 5 };
     const ConstStreamPosition thirdPosition{ stream.cend() - 1 };
@@ -383,11 +383,11 @@ TEST(InstructionStreamTests, CalculateJumpOffsetSkipsLabels)
     LabelCreator creator{};
     const InstructionStream stream {
         creator.CreateLabel(),
-        OpCode_CEE_NOP{},
+        OpCode::CEE_NOP{},
         creator.CreateLabel(),
-        OpCode_CEE_NOP{},
+        OpCode::CEE_NOP{},
         creator.CreateLabel(),
-        OpCode_CEE_NOP{}
+        OpCode::CEE_NOP{}
     };
 
     const ConstStreamPosition first { stream.cbegin() };
@@ -409,10 +409,10 @@ TEST(InstructionStreamTests, CalculateJumpOffsetCalculatesSizesProperly)
 {
     // Arrange
     const InstructionStream stream{
-        OpCode_CEE_LDARG{0},
-        OpCode_CEE_CEQ{},
-        OpCode_CEE_LDC_I4{42},
-        OpCode_CEE_BREAK{} };
+        OpCode::CEE_LDARG{0},
+        OpCode::CEE_CEQ{},
+        OpCode::CEE_LDC_I4{42},
+        OpCode::CEE_BREAK{} };
 
     const ConstStreamPosition first { stream.cbegin() };
     const ConstStreamPosition second { stream.cbegin() + 1 };
@@ -433,7 +433,7 @@ TEST(InstructionStreamTests, CalculateJumpOffsetCalculatesSizesProperly)
 TEST(InstructionStreamTests, CalculateAbsoluteOffset)
 {
     // Arrange
-    const InstructionStream stream(10, OpCode_CEE_NOP{ });
+    const InstructionStream stream(10, OpCode::CEE_NOP{ });
     const ConstStreamPosition firstPosition{ stream.cbegin() };
     const ConstStreamPosition secondPosition{ stream.cbegin() + 5 };
     const ConstStreamPosition thirdPosition{ stream.cend() - 1 };
@@ -455,11 +455,11 @@ TEST(InstructionStreamTests, CalculateAbsoluteOffsetSkipsLabels)
     LabelCreator creator{};
     const InstructionStream stream {
         creator.CreateLabel(),
-        OpCode_CEE_NOP{},
+        OpCode::CEE_NOP{},
         creator.CreateLabel(),
-        OpCode_CEE_NOP{},
+        OpCode::CEE_NOP{},
         creator.CreateLabel(),
-        OpCode_CEE_NOP{}
+        OpCode::CEE_NOP{}
     };
 
     const ConstStreamPosition firstPosition{ stream.cbegin() };
@@ -481,10 +481,10 @@ TEST(InstructionStreamTests, CalculateAbsoluteOffsetCalculatesSizesProperly)
 {
     // Arrange
     const InstructionStream stream{
-        OpCode_CEE_LDARG{0},
-        OpCode_CEE_CEQ{},
-        OpCode_CEE_LDC_I4{42},
-        OpCode_CEE_BREAK{} };
+        OpCode::CEE_LDARG{0},
+        OpCode::CEE_CEQ{},
+        OpCode::CEE_LDC_I4{42},
+        OpCode::CEE_BREAK{} };
 
     const ConstStreamPosition firstPosition{ stream.cbegin() };
     const ConstStreamPosition secondPosition{ stream.cbegin() + 1 };
@@ -590,7 +590,7 @@ TEST(InstructionStreamTests, SkipLabelsInStreamWithOneLabel)
 TEST(InstructionStreamTests, SkipLabelsInStreamWithOneInstruction)
 {
     // Arrange
-    const InstructionStream stream{ OpCode_CEE_NOP{} };
+    const InstructionStream stream{ OpCode::CEE_NOP{} };
 
     // Act
     const ConstStreamPosition nearestInstruction { SkipLabels(stream.cbegin(), stream.cend()) };
@@ -603,7 +603,7 @@ TEST(InstructionStreamTests, SkipLabelsInStreamWithLabelAndInstruction)
 {
     // Arrange
     LabelCreator creator;
-    const InstructionStream stream{ creator.CreateLabel(), OpCode_CEE_NOP{} };
+    const InstructionStream stream{ creator.CreateLabel(), OpCode::CEE_NOP{} };
 
     // Act
     const ConstStreamPosition nearestInstruction { SkipLabels(stream.cbegin(), stream.cend()) };
@@ -616,7 +616,7 @@ TEST(InstructionStreamTests, SkipLabelsInStreamWithTwoLabelsAndInstruction)
 {
     // Arrange
     LabelCreator creator;
-    const InstructionStream stream{ creator.CreateLabel(), creator.CreateLabel(), OpCode_CEE_NOP{} };
+    const InstructionStream stream{ creator.CreateLabel(), creator.CreateLabel(), OpCode::CEE_NOP{} };
 
     // Act
     const ConstStreamPosition nearestInstruction { SkipLabels(stream.cbegin(), stream.cend()) };
@@ -640,7 +640,7 @@ TEST(InstructionStreamTests, FindNextInstructionInEmptyStream)
 TEST(InstructionStreamTests, FindNextInstructionInStreamWithOneInstruction)
 {
     // Arrange
-    const InstructionStream stream{ OpCode_CEE_NOP {} };
+    const InstructionStream stream{ OpCode::CEE_NOP {} };
 
     // Act
     const ConstStreamPosition nextInstruction { FindNextInstruction(stream.cbegin(), stream.cend()) };
@@ -653,7 +653,7 @@ TEST(InstructionStreamTests, FindNextInstructionInStreamWithOneInstructionAndOne
 {
     // Arrange
     LabelCreator creator;
-    const InstructionStream stream{ OpCode_CEE_NOP{}, creator.CreateLabel() };
+    const InstructionStream stream{ OpCode::CEE_NOP{}, creator.CreateLabel() };
 
     // Act
     const ConstStreamPosition nextInstruction{ FindNextInstruction(stream.cbegin(), stream.cend()) };
@@ -667,9 +667,9 @@ TEST(InstructionStreamTests, FindNextInstructionInStreamWithTwoInstructionsAndOn
     // Arrange
     LabelCreator creator;
     const InstructionStream stream{
-        OpCode_CEE_NOP{},
+        OpCode::CEE_NOP{},
         creator.CreateLabel(),
-        OpCode_CEE_NOP{}
+        OpCode::CEE_NOP{}
     };
 
     // Act
@@ -682,7 +682,7 @@ TEST(InstructionStreamTests, FindNextInstructionInStreamWithTwoInstructionsAndOn
 TEST(InstructionStreamTests, FindNextInstructionInStreamWithTwoInstructions)
 {
     // Arrange
-    const InstructionStream stream{ OpCode_CEE_NOP{}, OpCode_CEE_NOP{} };
+    const InstructionStream stream{ OpCode::CEE_NOP{}, OpCode::CEE_NOP{} };
 
     // Act
     const ConstStreamPosition nextInstruction{ FindNextInstruction(stream.cbegin(), stream.cend()) };
@@ -696,10 +696,10 @@ TEST(InstructionStreamTests, FindNextInstructionInStreamWithTwoLabelsAndTwoInstr
     // Arrange
     LabelCreator creator;
     const InstructionStream stream{
-        OpCode_CEE_NOP{},
+        OpCode::CEE_NOP{},
         creator.CreateLabel(),
         creator.CreateLabel(),
-        OpCode_CEE_NOP{} };
+        OpCode::CEE_NOP{} };
 
     // Act
     const ConstStreamPosition nextInstruction{ FindNextInstruction(stream.cbegin(), stream.cend()) };

--- a/Drill4dotNet/Drill4dotNet-Tests/MethodBodyTests.cpp
+++ b/Drill4dotNet/Drill4dotNet-Tests/MethodBodyTests.cpp
@@ -90,21 +90,21 @@ TEST(MethodBodyTests, InsertSimpleFunction)
 
     // MethodBody should turn sourceBytes to this
     const InstructionStream expectedSourceStream{
-        OpCode_CEE_LDARG_0{},
-        OpCode_CEE_LDARG_1{},
-        OpCode_CEE_ADD{},
-        OpCode_CEE_RET{}
+        OpCode::CEE_LDARG_0{},
+        OpCode::CEE_LDARG_1{},
+        OpCode::CEE_ADD{},
+        OpCode::CEE_RET{}
     };
 
     // MethodBody should have this instructions
     // stream after injection.
     const InstructionStream expectedInjectionStream{
-        OpCode_CEE_LDARG_0{},
-        OpCode_CEE_LDARG_1{},
-        OpCode_CEE_ADD{},
-        OpCode_CEE_LDC_I4_2{}, // injection
-        OpCode_CEE_MUL{}, // injection
-        OpCode_CEE_RET{}
+        OpCode::CEE_LDARG_0{},
+        OpCode::CEE_LDARG_1{},
+        OpCode::CEE_ADD{},
+        OpCode::CEE_LDC_I4_2{}, // injection
+        OpCode::CEE_MUL{}, // injection
+        OpCode::CEE_RET{}
     };
 
     // Act
@@ -114,8 +114,8 @@ TEST(MethodBodyTests, InsertSimpleFunction)
     const std::vector<std::byte> actualRoundtripBytes(method.Compile());
     const std::vector<ExceptionsSection> actualExceptionSections(method.ExceptionSections());
 
-    method.Insert(method.begin() + 3, OpCode_CEE_LDC_I4_2{});
-    method.Insert(method.begin() + 4, OpCode_CEE_MUL{});
+    method.Insert(method.begin() + 3, OpCode::CEE_LDC_I4_2{});
+    method.Insert(method.begin() + 4, OpCode::CEE_MUL{});
 
     const InstructionStream actualInjectionStream(method.Stream());
     const std::vector<std::byte> actualInjectionBytes(method.Compile());
@@ -184,66 +184,66 @@ TEST(MethodBodyTests, InsertFunctionWithIf)
     // Got these values from MS IL decompiler.
     const InstructionStream expectedSourceStream{
         // if (a)
-        OpCode_CEE_NOP{},
-        OpCode_CEE_LDARG_0{},
-        OpCode_CEE_STLOC_0{},
-        OpCode_CEE_LDLOC_0{},
-        OpCode_CEE_BRFALSE_S{elseLabel},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_LDARG_0{},
+        OpCode::CEE_STLOC_0{},
+        OpCode::CEE_LDLOC_0{},
+        OpCode::CEE_BRFALSE_S{elseLabel},
 
         // return x * y; // <- x * y
-        OpCode_CEE_NOP{},
-        OpCode_CEE_LDARG_1{},
-        OpCode_CEE_LDARG_2{},
-        OpCode_CEE_MUL{},
-        OpCode_CEE_STLOC_1{},
-        OpCode_CEE_BR_S{endLabel1},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_LDARG_1{},
+        OpCode::CEE_LDARG_2{},
+        OpCode::CEE_MUL{},
+        OpCode::CEE_STLOC_1{},
+        OpCode::CEE_BR_S{endLabel1},
 
         // return 0; // <- 0;
         elseLabel,
-        OpCode_CEE_NOP{},
-        OpCode_CEE_LDC_I4_0{},
-        OpCode_CEE_STLOC_1{},
-        OpCode_CEE_BR_S{endLabel2},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_LDC_I4_0{},
+        OpCode::CEE_STLOC_1{},
+        OpCode::CEE_BR_S{endLabel2},
 
         // return
         endLabel1,
         endLabel2,
-        OpCode_CEE_LDLOC_1{},
-        OpCode_CEE_RET{}
+        OpCode::CEE_LDLOC_1{},
+        OpCode::CEE_RET{}
     };
 
     const InstructionStream expectedInjectionStream{
         // if (a)
-        OpCode_CEE_NOP{},
-        OpCode_CEE_LDARG_0{},
-        OpCode_CEE_STLOC_0{},
-        OpCode_CEE_LDLOC_0{},
-        OpCode_CEE_BRFALSE_S{elseLabel},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_LDARG_0{},
+        OpCode::CEE_STLOC_0{},
+        OpCode::CEE_LDLOC_0{},
+        OpCode::CEE_BRFALSE_S{elseLabel},
 
         // return x * y; // <- x * y
-        OpCode_CEE_NOP{},
-        OpCode_CEE_LDARG_1{},
-        OpCode_CEE_LDARG_2{},
-        OpCode_CEE_MUL{},
-        OpCode_CEE_STLOC_1{},
-        OpCode_CEE_BR_S{endLabel1},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_LDARG_1{},
+        OpCode::CEE_LDARG_2{},
+        OpCode::CEE_MUL{},
+        OpCode::CEE_STLOC_1{},
+        OpCode::CEE_BR_S{endLabel1},
 
         // return 0 + x + y; // <- 0 + x + y;
         elseLabel,
-        OpCode_CEE_NOP{},
-        OpCode_CEE_LDC_I4_0{},
-        OpCode_CEE_LDARG_1{},
-        OpCode_CEE_ADD{},
-        OpCode_CEE_LDARG_2{},
-        OpCode_CEE_ADD{},
-        OpCode_CEE_STLOC_1{},
-        OpCode_CEE_BR_S{endLabel2},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_LDC_I4_0{},
+        OpCode::CEE_LDARG_1{},
+        OpCode::CEE_ADD{},
+        OpCode::CEE_LDARG_2{},
+        OpCode::CEE_ADD{},
+        OpCode::CEE_STLOC_1{},
+        OpCode::CEE_BR_S{endLabel2},
 
         // return
         endLabel1,
         endLabel2,
-        OpCode_CEE_LDLOC_1{},
-        OpCode_CEE_RET{}
+        OpCode::CEE_LDLOC_1{},
+        OpCode::CEE_RET{}
     };
 
     // Act
@@ -253,10 +253,10 @@ TEST(MethodBodyTests, InsertFunctionWithIf)
     const std::vector<std::byte> actualRoundtripBytes(method.Compile());
     const std::vector<ExceptionsSection> actualExceptionSections(method.ExceptionSections());
 
-    method.Insert(method.begin() + 14, OpCode_CEE_LDARG_1{});
-    method.Insert(method.begin() + 15, OpCode_CEE_ADD{});
-    method.Insert(method.begin() + 16, OpCode_CEE_LDARG_2{});
-    method.Insert(method.begin() + 17, OpCode_CEE_ADD{});
+    method.Insert(method.begin() + 14, OpCode::CEE_LDARG_1{});
+    method.Insert(method.begin() + 15, OpCode::CEE_ADD{});
+    method.Insert(method.begin() + 16, OpCode::CEE_LDARG_2{});
+    method.Insert(method.begin() + 17, OpCode::CEE_ADD{});
 
     const InstructionStream actualInjectionStream(method.Stream());
     const std::vector<std::byte> actualInjectionBytes(method.Compile());
@@ -353,156 +353,156 @@ TEST(MethodBodyTests, InsertFunctionWithLoop)
     // Got these values from MS IL decompiler.
     const InstructionStream expectedSourceStream{
         // if (x < 2)
-        OpCode_CEE_NOP{},
-        OpCode_CEE_LDARG_0{},
-        OpCode_CEE_LDC_I4_2{},
-        OpCode_CEE_CLT{},
-        OpCode_CEE_STLOC_2{},
-        OpCode_CEE_LDLOC_2{},
-        OpCode_CEE_BRFALSE_S{elseLabel},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_LDARG_0{},
+        OpCode::CEE_LDC_I4_2{},
+        OpCode::CEE_CLT{},
+        OpCode::CEE_STLOC_2{},
+        OpCode::CEE_LDLOC_2{},
+        OpCode::CEE_BRFALSE_S{elseLabel},
 
         // return x; // <- x
-        OpCode_CEE_NOP{},
-        OpCode_CEE_LDARG_0{},
-        OpCode_CEE_STLOC_3{},
-        OpCode_CEE_BR_S{endLabel1},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_LDARG_0{},
+        OpCode::CEE_STLOC_3{},
+        OpCode::CEE_BR_S{endLabel1},
 
         // int previous = 0;
         elseLabel,
-        OpCode_CEE_LDC_I4_0{},
-        OpCode_CEE_STLOC_0{},
+        OpCode::CEE_LDC_I4_0{},
+        OpCode::CEE_STLOC_0{},
 
         // int current = 1;
-        OpCode_CEE_LDC_I4_1{},
-        OpCode_CEE_STLOC_1{},
+        OpCode::CEE_LDC_I4_1{},
+        OpCode::CEE_STLOC_1{},
 
         // for (int i = 2; i <= x; i++) // <- int i = 2
-        OpCode_CEE_LDC_I4_2{},
-        OpCode_CEE_STLOC_S{4},
-        OpCode_CEE_BR_S{loopConditionLabel},
+        OpCode::CEE_LDC_I4_2{},
+        OpCode::CEE_STLOC_S{4},
+        OpCode::CEE_BR_S{loopConditionLabel},
 
         // int newCurrent = current + previous;
         loopBodyLabel,
-        OpCode_CEE_NOP{},
-        OpCode_CEE_LDLOC_1{},
-        OpCode_CEE_LDLOC_0{},
-        OpCode_CEE_ADD{},
-        OpCode_CEE_STLOC_S{5},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_LDLOC_1{},
+        OpCode::CEE_LDLOC_0{},
+        OpCode::CEE_ADD{},
+        OpCode::CEE_STLOC_S{5},
 
         // previous = current;
-        OpCode_CEE_LDLOC_1{},
-        OpCode_CEE_STLOC_0{},
+        OpCode::CEE_LDLOC_1{},
+        OpCode::CEE_STLOC_0{},
 
         // current = newCurrent;
-        OpCode_CEE_LDLOC_S{5},
-        OpCode_CEE_STLOC_1{},
+        OpCode::CEE_LDLOC_S{5},
+        OpCode::CEE_STLOC_1{},
 
         // for (int i = 2; i <= x; i++) // <- i++
-        OpCode_CEE_NOP{},
-        OpCode_CEE_LDLOC_S{4},
-        OpCode_CEE_LDC_I4_1{},
-        OpCode_CEE_ADD{},
-        OpCode_CEE_STLOC_S{4},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_LDLOC_S{4},
+        OpCode::CEE_LDC_I4_1{},
+        OpCode::CEE_ADD{},
+        OpCode::CEE_STLOC_S{4},
 
         // for (int i = 2; i <= x; i++) // <- i <= x
         loopConditionLabel,
-        OpCode_CEE_LDLOC_S{4},
-        OpCode_CEE_LDARG_0{},
-        OpCode_CEE_CGT{},
-        OpCode_CEE_LDC_I4_0{},
-        OpCode_CEE_CEQ{},
-        OpCode_CEE_STLOC_S{6},
-        OpCode_CEE_LDLOC_S{6},
-        OpCode_CEE_BRTRUE_S{loopBodyLabel},
+        OpCode::CEE_LDLOC_S{4},
+        OpCode::CEE_LDARG_0{},
+        OpCode::CEE_CGT{},
+        OpCode::CEE_LDC_I4_0{},
+        OpCode::CEE_CEQ{},
+        OpCode::CEE_STLOC_S{6},
+        OpCode::CEE_LDLOC_S{6},
+        OpCode::CEE_BRTRUE_S{loopBodyLabel},
 
         // return current; // <- current
-        OpCode_CEE_LDLOC_1{},
-        OpCode_CEE_STLOC_3{},
-        OpCode_CEE_BR_S{endLabel2},
+        OpCode::CEE_LDLOC_1{},
+        OpCode::CEE_STLOC_3{},
+        OpCode::CEE_BR_S{endLabel2},
 
         // return
         endLabel1,
         endLabel2,
-        OpCode_CEE_LDLOC_3{},
-        OpCode_CEE_RET{}
+        OpCode::CEE_LDLOC_3{},
+        OpCode::CEE_RET{}
     };
 
     const InstructionStream expectedInjectionStream{
         // if (x < 2)
-        OpCode_CEE_NOP{},
-        OpCode_CEE_LDARG_0{},
-        OpCode_CEE_LDC_I4_2{},
-        OpCode_CEE_CLT{},
-        OpCode_CEE_STLOC_2{},
-        OpCode_CEE_LDLOC_2{},
-        OpCode_CEE_BRFALSE_S{elseLabel},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_LDARG_0{},
+        OpCode::CEE_LDC_I4_2{},
+        OpCode::CEE_CLT{},
+        OpCode::CEE_STLOC_2{},
+        OpCode::CEE_LDLOC_2{},
+        OpCode::CEE_BRFALSE_S{elseLabel},
 
         // return x; // <- x
-        OpCode_CEE_NOP{},
-        OpCode_CEE_LDARG_0{},
-        OpCode_CEE_STLOC_3{},
-        OpCode_CEE_BR_S{endLabel1},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_LDARG_0{},
+        OpCode::CEE_STLOC_3{},
+        OpCode::CEE_BR_S{endLabel1},
 
         // int previous = 0;
         elseLabel,
-        OpCode_CEE_LDC_I4_0{},
-        OpCode_CEE_STLOC_0{},
+        OpCode::CEE_LDC_I4_0{},
+        OpCode::CEE_STLOC_0{},
 
         // int current = 1;
-        OpCode_CEE_LDC_I4_1{},
-        OpCode_CEE_STLOC_1{},
+        OpCode::CEE_LDC_I4_1{},
+        OpCode::CEE_STLOC_1{},
 
         // for (int i = 2; i <= x; i++) // <- int i = 2
-        OpCode_CEE_LDC_I4_2{},
-        OpCode_CEE_STLOC_S{4},
-        OpCode_CEE_BR_S{loopConditionLabel},
+        OpCode::CEE_LDC_I4_2{},
+        OpCode::CEE_STLOC_S{4},
+        OpCode::CEE_BR_S{loopConditionLabel},
 
         // int newCurrent = current + previous;
         loopBodyLabel,
-        OpCode_CEE_NOP{},
-        OpCode_CEE_LDLOC_1{},
-        OpCode_CEE_LDLOC_0{},
-        OpCode_CEE_ADD{},
-        OpCode_CEE_STLOC_S{5},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_LDLOC_1{},
+        OpCode::CEE_LDLOC_0{},
+        OpCode::CEE_ADD{},
+        OpCode::CEE_STLOC_S{5},
 
         // previous = current;
-        OpCode_CEE_LDLOC_1{},
-        OpCode_CEE_STLOC_0{},
+        OpCode::CEE_LDLOC_1{},
+        OpCode::CEE_STLOC_0{},
 
         // current = 2 * newCurrent;
-        OpCode_CEE_LDC_I4_2{},
-        OpCode_CEE_LDLOC_S{5},
-        OpCode_CEE_MUL{},
-        OpCode_CEE_STLOC_1{},
+        OpCode::CEE_LDC_I4_2{},
+        OpCode::CEE_LDLOC_S{5},
+        OpCode::CEE_MUL{},
+        OpCode::CEE_STLOC_1{},
 
         // for (int i = 2; i <= x; i++) // <- i++
-        OpCode_CEE_NOP{},
-        OpCode_CEE_LDLOC_S{4},
-        OpCode_CEE_LDC_I4_1{},
-        OpCode_CEE_ADD{},
-        OpCode_CEE_STLOC_S{4},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_LDLOC_S{4},
+        OpCode::CEE_LDC_I4_1{},
+        OpCode::CEE_ADD{},
+        OpCode::CEE_STLOC_S{4},
 
         // for (int i = 2; i <= x; i++) // <- i <= x
         loopConditionLabel,
-        OpCode_CEE_LDLOC_S{4},
-        OpCode_CEE_LDARG_0{},
-        OpCode_CEE_CGT{},
-        OpCode_CEE_LDC_I4_0{},
-        OpCode_CEE_CEQ{},
-        OpCode_CEE_STLOC_S{6},
-        OpCode_CEE_LDLOC_S{6},
-        OpCode_CEE_BRTRUE_S{loopBodyLabel},
+        OpCode::CEE_LDLOC_S{4},
+        OpCode::CEE_LDARG_0{},
+        OpCode::CEE_CGT{},
+        OpCode::CEE_LDC_I4_0{},
+        OpCode::CEE_CEQ{},
+        OpCode::CEE_STLOC_S{6},
+        OpCode::CEE_LDLOC_S{6},
+        OpCode::CEE_BRTRUE_S{loopBodyLabel},
 
         // return current; // <- current
-        OpCode_CEE_LDLOC_1{},
-        OpCode_CEE_STLOC_3{},
-        OpCode_CEE_BR_S{endLabel2},
+        OpCode::CEE_LDLOC_1{},
+        OpCode::CEE_STLOC_3{},
+        OpCode::CEE_BR_S{endLabel2},
 
         // return
         endLabel1,
         endLabel2,
-        OpCode_CEE_LDLOC_3{},
-        OpCode_CEE_RET{}
+        OpCode::CEE_LDLOC_3{},
+        OpCode::CEE_RET{}
     };
 
     // Act
@@ -512,8 +512,8 @@ TEST(MethodBodyTests, InsertFunctionWithLoop)
     const std::vector<std::byte> actualRoundtripBytes(method.Compile());
     const std::vector<ExceptionsSection> actualExceptionSections(method.ExceptionSections());
 
-    method.Insert(method.begin() + 27, OpCode_CEE_LDC_I4_2{});
-    method.Insert(method.begin() + 29, OpCode_CEE_MUL{});
+    method.Insert(method.begin() + 27, OpCode::CEE_LDC_I4_2{});
+    method.Insert(method.begin() + 29, OpCode::CEE_MUL{});
 
     const InstructionStream actualInjectionStream(method.Stream());
     const std::vector<std::byte> actualInjectionBytes(method.Compile());
@@ -623,53 +623,53 @@ TEST(MethodBodyTests, InsertFunctionWithSwitch)
     // Got these values from MS IL decompiler.
     const InstructionStream expectedSourceStream{
         // switch (x)
-        OpCode_CEE_NOP{},
-        OpCode_CEE_LDARG_0{},
-        OpCode_CEE_STLOC_1{},
-        OpCode_CEE_LDLOC_1{},
-        OpCode_CEE_STLOC_0{},
-        OpCode_CEE_LDLOC_0{},
-        OpCode_CEE_SWITCH{{ case0Label, case1Label, case2Label, case3Label, defaultLabel }},
-        OpCode_CEE_BR_S{defaultLabel2},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_LDARG_0{},
+        OpCode::CEE_STLOC_1{},
+        OpCode::CEE_LDLOC_1{},
+        OpCode::CEE_STLOC_0{},
+        OpCode::CEE_LDLOC_0{},
+        OpCode::CEE_SWITCH{{ case0Label, case1Label, case2Label, case3Label, defaultLabel }},
+        OpCode::CEE_BR_S{defaultLabel2},
 
         // case 0:
         case0Label,
         // return x + y; // <- x + y
-        OpCode_CEE_NOP{},
-        OpCode_CEE_LDARG_0{},
-        OpCode_CEE_LDARG_1{},
-        OpCode_CEE_ADD{},
-        OpCode_CEE_STLOC_2{},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_LDARG_0{},
+        OpCode::CEE_LDARG_1{},
+        OpCode::CEE_ADD{},
+        OpCode::CEE_STLOC_2{},
 
         // break;
-        OpCode_CEE_BR_S{endLabel1},
+        OpCode::CEE_BR_S{endLabel1},
 
         // case 1:
         // case 2:
         case1Label,
         case2Label,
         // return x * y; // <- x * y
-        OpCode_CEE_NOP{},
-        OpCode_CEE_LDARG_0{},
-        OpCode_CEE_LDARG_1{},
-        OpCode_CEE_MUL{},
-        OpCode_CEE_STLOC_2{},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_LDARG_0{},
+        OpCode::CEE_LDARG_1{},
+        OpCode::CEE_MUL{},
+        OpCode::CEE_STLOC_2{},
 
         // break;
-        OpCode_CEE_BR_S{endLabel2},
+        OpCode::CEE_BR_S{endLabel2},
 
         // case 3:
         case3Label,
 
         // return x - y; // <- x - y
-        OpCode_CEE_NOP{},
-        OpCode_CEE_LDARG_0{},
-        OpCode_CEE_LDARG_1{},
-        OpCode_CEE_SUB{},
-        OpCode_CEE_STLOC_2{},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_LDARG_0{},
+        OpCode::CEE_LDARG_1{},
+        OpCode::CEE_SUB{},
+        OpCode::CEE_STLOC_2{},
 
         // break;
-        OpCode_CEE_BR_S{endLabel3},
+        OpCode::CEE_BR_S{endLabel3},
 
         // case 4:
         // default:
@@ -677,78 +677,78 @@ TEST(MethodBodyTests, InsertFunctionWithSwitch)
         defaultLabel2,
 
         // return x / y; // <- x / y
-        OpCode_CEE_NOP{},
-        OpCode_CEE_LDARG_0{},
-        OpCode_CEE_LDARG_1{},
-        OpCode_CEE_DIV{},
-        OpCode_CEE_STLOC_2{},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_LDARG_0{},
+        OpCode::CEE_LDARG_1{},
+        OpCode::CEE_DIV{},
+        OpCode::CEE_STLOC_2{},
 
         // break;
-        OpCode_CEE_BR_S{endLabel4},
+        OpCode::CEE_BR_S{endLabel4},
 
         // return
         endLabel1,
         endLabel2,
         endLabel3,
         endLabel4,
-        OpCode_CEE_LDLOC_2{},
-        OpCode_CEE_RET{}
+        OpCode::CEE_LDLOC_2{},
+        OpCode::CEE_RET{}
     };
 
     const InstructionStream expectedInjectionStream{
         // switch (x)
-        OpCode_CEE_NOP{},
-        OpCode_CEE_LDARG_0{},
-        OpCode_CEE_STLOC_1{},
-        OpCode_CEE_LDLOC_1{},
-        OpCode_CEE_STLOC_0{},
-        OpCode_CEE_LDLOC_0{},
-        OpCode_CEE_SWITCH{{ case0Label, case1Label, case2Label, case3Label, defaultLabel }},
-        OpCode_CEE_BR_S{defaultLabel2},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_LDARG_0{},
+        OpCode::CEE_STLOC_1{},
+        OpCode::CEE_LDLOC_1{},
+        OpCode::CEE_STLOC_0{},
+        OpCode::CEE_LDLOC_0{},
+        OpCode::CEE_SWITCH{{ case0Label, case1Label, case2Label, case3Label, defaultLabel }},
+        OpCode::CEE_BR_S{defaultLabel2},
 
         // case 0:
         case0Label,
         // return -(x + y); // <- -(x + y)
-        OpCode_CEE_NOP{},
-        OpCode_CEE_LDARG_0{},
-        OpCode_CEE_LDARG_1{},
-        OpCode_CEE_ADD{},
-        OpCode_CEE_NEG{},
-        OpCode_CEE_STLOC_2{},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_LDARG_0{},
+        OpCode::CEE_LDARG_1{},
+        OpCode::CEE_ADD{},
+        OpCode::CEE_NEG{},
+        OpCode::CEE_STLOC_2{},
 
         // break;
-        OpCode_CEE_BR_S{endLabel1},
+        OpCode::CEE_BR_S{endLabel1},
 
         // case 1:
         // case 2:
         case1Label,
         case2Label,
         // return x * y * 3; // <- x * y * 3
-        OpCode_CEE_NOP{},
-        OpCode_CEE_LDARG_0{},
-        OpCode_CEE_LDARG_1{},
-        OpCode_CEE_MUL{},
-        OpCode_CEE_LDC_I4_3{},
-        OpCode_CEE_MUL{},
-        OpCode_CEE_STLOC_2{},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_LDARG_0{},
+        OpCode::CEE_LDARG_1{},
+        OpCode::CEE_MUL{},
+        OpCode::CEE_LDC_I4_3{},
+        OpCode::CEE_MUL{},
+        OpCode::CEE_STLOC_2{},
 
         // break;
-        OpCode_CEE_BR_S{endLabel2},
+        OpCode::CEE_BR_S{endLabel2},
 
         // case 3:
         case3Label,
 
         // return x - y + 42; // <- x - y + 42
-        OpCode_CEE_NOP{},
-        OpCode_CEE_LDARG_0{},
-        OpCode_CEE_LDARG_1{},
-        OpCode_CEE_SUB{},
-        OpCode_CEE_LDC_I4{42},
-        OpCode_CEE_ADD{},
-        OpCode_CEE_STLOC_2{},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_LDARG_0{},
+        OpCode::CEE_LDARG_1{},
+        OpCode::CEE_SUB{},
+        OpCode::CEE_LDC_I4{42},
+        OpCode::CEE_ADD{},
+        OpCode::CEE_STLOC_2{},
 
         // break;
-        OpCode_CEE_BR_S{endLabel3},
+        OpCode::CEE_BR_S{endLabel3},
 
         // case 4:
         // default:
@@ -756,24 +756,24 @@ TEST(MethodBodyTests, InsertFunctionWithSwitch)
         defaultLabel2,
 
         // return x / y / 5; // <- x / y / 5
-        OpCode_CEE_NOP{},
-        OpCode_CEE_LDARG_0{},
-        OpCode_CEE_LDARG_1{},
-        OpCode_CEE_DIV{},
-        OpCode_CEE_LDC_I4_5{},
-        OpCode_CEE_DIV{},
-        OpCode_CEE_STLOC_2{},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_LDARG_0{},
+        OpCode::CEE_LDARG_1{},
+        OpCode::CEE_DIV{},
+        OpCode::CEE_LDC_I4_5{},
+        OpCode::CEE_DIV{},
+        OpCode::CEE_STLOC_2{},
 
         // break;
-        OpCode_CEE_BR_S{endLabel4},
+        OpCode::CEE_BR_S{endLabel4},
 
         // return
         endLabel1,
         endLabel2,
         endLabel3,
         endLabel4,
-        OpCode_CEE_LDLOC_2{},
-        OpCode_CEE_RET{}
+        OpCode::CEE_LDLOC_2{},
+        OpCode::CEE_RET{}
     };
 
     // Act
@@ -783,16 +783,16 @@ TEST(MethodBodyTests, InsertFunctionWithSwitch)
     const std::vector<std::byte> actualRoundtripBytes(method.Compile());
     const std::vector<ExceptionsSection> actualExceptionSections(method.ExceptionSections());
 
-    method.Insert(method.begin() + 13, OpCode_CEE_NEG{});
+    method.Insert(method.begin() + 13, OpCode::CEE_NEG{});
 
-    method.Insert(method.begin() + 22, OpCode_CEE_LDC_I4_3{});
-    method.Insert(method.begin() + 23, OpCode_CEE_MUL{});
+    method.Insert(method.begin() + 22, OpCode::CEE_LDC_I4_3{});
+    method.Insert(method.begin() + 23, OpCode::CEE_MUL{});
 
-    method.Insert(method.begin() + 31, OpCode_CEE_LDC_I4{42});
-    method.Insert(method.begin() + 32, OpCode_CEE_ADD{});
+    method.Insert(method.begin() + 31, OpCode::CEE_LDC_I4{42});
+    method.Insert(method.begin() + 32, OpCode::CEE_ADD{});
 
-    method.Insert(method.begin() + 41, OpCode_CEE_LDC_I4_5{});
-    method.Insert(method.begin() + 42, OpCode_CEE_DIV{});
+    method.Insert(method.begin() + 41, OpCode::CEE_LDC_I4_5{});
+    method.Insert(method.begin() + 42, OpCode::CEE_DIV{});
 
     const InstructionStream actualInjectionStream(method.Stream());
     const std::vector<std::byte> actualInjectionBytes(method.Compile());
@@ -866,81 +866,81 @@ TEST(MethodBodyTests, InsertFunctionWithTryCatch)
     const Label handlerEndLabel{ sourceStreamLabelCreator.CreateLabel() };
     // Got these values from MS IL decompiler.
     const InstructionStream expectedSourceStream{
-        OpCode_CEE_NOP{},
+        OpCode::CEE_NOP{},
 
         // try 
         // {
         tryLabel,
-        OpCode_CEE_NOP{},
+        OpCode::CEE_NOP{},
         // return x / y; // <- x / y
-        OpCode_CEE_LDARG_0{},
-        OpCode_CEE_LDARG_1{},
-        OpCode_CEE_DIV{},
-        OpCode_CEE_STLOC_0{},
+        OpCode::CEE_LDARG_0{},
+        OpCode::CEE_LDARG_1{},
+        OpCode::CEE_DIV{},
+        OpCode::CEE_STLOC_0{},
 
         // } // end of try {
-        OpCode_CEE_LEAVE_S{endLabel1},
+        OpCode::CEE_LEAVE_S{endLabel1},
         tryEndLabel,
 
         // catch (DivideByZeroException)
         // {
         handlerLabel,
-        OpCode_CEE_POP{},
-        OpCode_CEE_NOP{},
+        OpCode::CEE_POP{},
+        OpCode::CEE_NOP{},
 
         // return x; // <- x
-        OpCode_CEE_LDARG_0{},
-        OpCode_CEE_STLOC_0{},
+        OpCode::CEE_LDARG_0{},
+        OpCode::CEE_STLOC_0{},
 
         // }
-        OpCode_CEE_LEAVE_S{endLabel2},
+        OpCode::CEE_LEAVE_S{endLabel2},
         handlerEndLabel,
 
         // return
         endLabel1,
         endLabel2,
-        OpCode_CEE_LDLOC_0{},
-        OpCode_CEE_RET{}
+        OpCode::CEE_LDLOC_0{},
+        OpCode::CEE_RET{}
     };
 
     const InstructionStream expectedInjectionStream{
-        OpCode_CEE_NOP{},
+        OpCode::CEE_NOP{},
 
         // try 
         // {
         tryLabel,
-        OpCode_CEE_NOP{},
+        OpCode::CEE_NOP{},
         // return x / (y + 1); // <- x / y
-        OpCode_CEE_LDARG_0{},
-        OpCode_CEE_LDARG_1{},
-        OpCode_CEE_LDC_I4_1{},
-        OpCode_CEE_ADD{},
-        OpCode_CEE_DIV{},
-        OpCode_CEE_STLOC_0{},
+        OpCode::CEE_LDARG_0{},
+        OpCode::CEE_LDARG_1{},
+        OpCode::CEE_LDC_I4_1{},
+        OpCode::CEE_ADD{},
+        OpCode::CEE_DIV{},
+        OpCode::CEE_STLOC_0{},
 
         // } // end of try {
-        OpCode_CEE_LEAVE_S{endLabel1},
+        OpCode::CEE_LEAVE_S{endLabel1},
         tryEndLabel,
 
         // catch (DivideByZeroException)
         // {
         handlerLabel,
-        OpCode_CEE_POP{},
-        OpCode_CEE_NOP{},
+        OpCode::CEE_POP{},
+        OpCode::CEE_NOP{},
 
         // return x; // <- x
-        OpCode_CEE_LDARG_0{},
-        OpCode_CEE_STLOC_0{},
+        OpCode::CEE_LDARG_0{},
+        OpCode::CEE_STLOC_0{},
 
         // }
-        OpCode_CEE_LEAVE_S{endLabel2},
+        OpCode::CEE_LEAVE_S{endLabel2},
         handlerEndLabel,
 
         // return
         endLabel1,
         endLabel2,
-        OpCode_CEE_LDLOC_0{},
-        OpCode_CEE_RET{}
+        OpCode::CEE_LDLOC_0{},
+        OpCode::CEE_RET{}
     };
 
     // Act
@@ -950,8 +950,8 @@ TEST(MethodBodyTests, InsertFunctionWithTryCatch)
     const std::vector<std::byte> actualRoundtripBytes(method.Compile());
     const std::vector<ExceptionsSection> actualExceptionSections(method.ExceptionSections());
 
-    method.Insert(method.begin() + 5, OpCode_CEE_LDC_I4_1{});
-    method.Insert(method.begin() + 6, OpCode_CEE_ADD{});
+    method.Insert(method.begin() + 5, OpCode::CEE_LDC_I4_1{});
+    method.Insert(method.begin() + 6, OpCode::CEE_ADD{});
 
     const InstructionStream actualInjectionStream(method.Stream());
     const std::vector<std::byte> actualInjectionBytes(method.Compile());
@@ -1033,106 +1033,106 @@ TEST(MethodBodyTests, InsertFunctionWithTryFinally)
     // Got these values from MS IL decompiler.
     const InstructionStream expectedSourceStream{
         // int z = 0;
-        OpCode_CEE_NOP{},
-        OpCode_CEE_LDC_I4_0{},
-        OpCode_CEE_STLOC_0{},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_LDC_I4_0{},
+        OpCode::CEE_STLOC_0{},
 
         // try
         // {
         tryLabel,
-        OpCode_CEE_NOP{},
+        OpCode::CEE_NOP{},
 
         // z = x / y;
-        OpCode_CEE_LDARG_0{},
-        OpCode_CEE_LDARG_1{},
-        OpCode_CEE_DIV{},
-        OpCode_CEE_STLOC_0{},
+        OpCode::CEE_LDARG_0{},
+        OpCode::CEE_LDARG_1{},
+        OpCode::CEE_DIV{},
+        OpCode::CEE_STLOC_0{},
 
         // } // end of try {
-        OpCode_CEE_NOP{},
-        OpCode_CEE_LEAVE_S{endLabel},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_LEAVE_S{endLabel},
         tryEndLabel,
 
         // finally
         // {
         handlerLabel,
-        OpCode_CEE_NOP{},
+        OpCode::CEE_NOP{},
 
         // y = 42;
-        OpCode_CEE_LDC_I4_S{42},
-        OpCode_CEE_STARG_S{1},
+        OpCode::CEE_LDC_I4_S{42},
+        OpCode::CEE_STARG_S{1},
 
         // } // end of finally {
-        OpCode_CEE_NOP{},
-        OpCode_CEE_ENDFINALLY{},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_ENDFINALLY{},
         handlerEndLabel,
 
         // return z + y; // <- z + y
         endLabel,
-        OpCode_CEE_LDLOC_0{},
-        OpCode_CEE_LDARG_1{},
-        OpCode_CEE_ADD{},
-        OpCode_CEE_STLOC_1{},
-        OpCode_CEE_BR_S{retLabel},
+        OpCode::CEE_LDLOC_0{},
+        OpCode::CEE_LDARG_1{},
+        OpCode::CEE_ADD{},
+        OpCode::CEE_STLOC_1{},
+        OpCode::CEE_BR_S{retLabel},
 
         // return z + y; // <- return
         retLabel,
-        OpCode_CEE_LDLOC_1{},
-        OpCode_CEE_RET{}
+        OpCode::CEE_LDLOC_1{},
+        OpCode::CEE_RET{}
     };
 
     const InstructionStream expectedInjectionStream{
         // int z = 0;
-        OpCode_CEE_NOP{},
-        OpCode_CEE_LDC_I4_0{},
-        OpCode_CEE_STLOC_0{},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_LDC_I4_0{},
+        OpCode::CEE_STLOC_0{},
 
         // try
         // {
         tryLabel,
-        OpCode_CEE_NOP{},
+        OpCode::CEE_NOP{},
 
         // z = x / y;
-        OpCode_CEE_LDARG_0{},
-        OpCode_CEE_LDARG_1{},
-        OpCode_CEE_DIV{},
-        OpCode_CEE_STLOC_0{},
+        OpCode::CEE_LDARG_0{},
+        OpCode::CEE_LDARG_1{},
+        OpCode::CEE_DIV{},
+        OpCode::CEE_STLOC_0{},
 
         // } // end of try {
-        OpCode_CEE_NOP{},
-        OpCode_CEE_LEAVE_S{endLabel},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_LEAVE_S{endLabel},
         tryEndLabel,
 
         // finally
         // {
         handlerLabel,
-        OpCode_CEE_NOP{},
+        OpCode::CEE_NOP{},
 
         // y = 42;
-        OpCode_CEE_LDC_I4_S{42},
-        OpCode_CEE_STARG_S{1},
+        OpCode::CEE_LDC_I4_S{42},
+        OpCode::CEE_STARG_S{1},
 
         // x = 0;
-        OpCode_CEE_LDC_I4_0{},
-        OpCode_CEE_STARG_S{0},
+        OpCode::CEE_LDC_I4_0{},
+        OpCode::CEE_STARG_S{0},
 
         // } // end of finally {
-        OpCode_CEE_NOP{},
-        OpCode_CEE_ENDFINALLY{},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_ENDFINALLY{},
         handlerEndLabel,
 
         // return z + y; // <- z + y
         endLabel,
-        OpCode_CEE_LDLOC_0{},
-        OpCode_CEE_LDARG_1{},
-        OpCode_CEE_ADD{},
-        OpCode_CEE_STLOC_1{},
-        OpCode_CEE_BR_S{retLabel},
+        OpCode::CEE_LDLOC_0{},
+        OpCode::CEE_LDARG_1{},
+        OpCode::CEE_ADD{},
+        OpCode::CEE_STLOC_1{},
+        OpCode::CEE_BR_S{retLabel},
 
         // return z + y; // <- return
         retLabel,
-        OpCode_CEE_LDLOC_1{},
-        OpCode_CEE_RET{}
+        OpCode::CEE_LDLOC_1{},
+        OpCode::CEE_RET{}
     };
 
     // Act
@@ -1142,8 +1142,8 @@ TEST(MethodBodyTests, InsertFunctionWithTryFinally)
     const std::vector<std::byte> actualRoundtripBytes(method.Compile());
     const std::vector<ExceptionsSection> actualExceptionSections(method.ExceptionSections());
 
-    method.Insert(method.begin() + 16, OpCode_CEE_LDC_I4_0{});
-    method.Insert(method.begin() + 17, OpCode_CEE_STARG_S{0});
+    method.Insert(method.begin() + 16, OpCode::CEE_LDC_I4_0{});
+    method.Insert(method.begin() + 17, OpCode::CEE_STARG_S{0});
 
     const InstructionStream actualInjectionStream(method.Stream());
     const std::vector<std::byte> actualInjectionBytes(method.Compile());
@@ -1249,164 +1249,164 @@ TEST(MethodBodyTests, InsertFunctionWithTryCatchWhen)
     // Got these values from MS IL decompiler.
     const InstructionStream expectedSourceStream{
         // int z = 0;
-        OpCode_CEE_NOP{},
-        OpCode_CEE_LDC_I4_0{},
-        OpCode_CEE_STLOC_0{},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_LDC_I4_0{},
+        OpCode::CEE_STLOC_0{},
 
         // try
         // {
         tryLabel,
-        OpCode_CEE_NOP{},
+        OpCode::CEE_NOP{},
 
         // z = x / y;
-        OpCode_CEE_LDARG_0{},
-        OpCode_CEE_LDARG_1{},
-        OpCode_CEE_DIV{},
-        OpCode_CEE_STLOC_0{},
+        OpCode::CEE_LDARG_0{},
+        OpCode::CEE_LDARG_1{},
+        OpCode::CEE_DIV{},
+        OpCode::CEE_STLOC_0{},
 
         // } // end of try {
-        OpCode_CEE_NOP{},
-        OpCode_CEE_LEAVE_S{endLabel},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_LEAVE_S{endLabel},
         tryEndLabel,
 
         // catch (DivideByZeroException e) when(e.Message.Length % 2 == 0) // <- when
         filterLabel,
 
         // catch (DivideByZeroException e) when(e.Message.Length % 2 == 0) // <- DivideByZeroException e
-        OpCode_CEE_ISINST{ 0x0100000D },
-        OpCode_CEE_DUP{},
-        OpCode_CEE_BRTRUE_S{ isInstanceLabel },
-        OpCode_CEE_POP{},
-        OpCode_CEE_LDC_I4_0{},
-        OpCode_CEE_BR_S{endFilterLabel},
+        OpCode::CEE_ISINST{ 0x0100000D },
+        OpCode::CEE_DUP{},
+        OpCode::CEE_BRTRUE_S{ isInstanceLabel },
+        OpCode::CEE_POP{},
+        OpCode::CEE_LDC_I4_0{},
+        OpCode::CEE_BR_S{endFilterLabel},
 
         // catch (DivideByZeroException e) when(e.Message.Length % 2 == 0) // <- e.Message.Length % 2 == 0
         isInstanceLabel,
-        OpCode_CEE_STLOC_1{},
-        OpCode_CEE_LDLOC_1{},
-        OpCode_CEE_CALLVIRT{ 0x0A00000C },
-        OpCode_CEE_CALLVIRT{ 0x0A00000D },
-        OpCode_CEE_LDC_I4_2{},
-        OpCode_CEE_REM{},
-        OpCode_CEE_LDC_I4_0{},
-        OpCode_CEE_CEQ{},
-        OpCode_CEE_STLOC_2{},
-        OpCode_CEE_LDLOC_2{},
-        OpCode_CEE_LDC_I4_0{},
-        OpCode_CEE_CGT_UN{},
+        OpCode::CEE_STLOC_1{},
+        OpCode::CEE_LDLOC_1{},
+        OpCode::CEE_CALLVIRT{ 0x0A00000C },
+        OpCode::CEE_CALLVIRT{ 0x0A00000D },
+        OpCode::CEE_LDC_I4_2{},
+        OpCode::CEE_REM{},
+        OpCode::CEE_LDC_I4_0{},
+        OpCode::CEE_CEQ{},
+        OpCode::CEE_STLOC_2{},
+        OpCode::CEE_LDLOC_2{},
+        OpCode::CEE_LDC_I4_0{},
+        OpCode::CEE_CGT_UN{},
         endFilterLabel,
-        OpCode_CEE_ENDFILTER{},
+        OpCode::CEE_ENDFILTER{},
 
         // catch (DivideByZeroException e) when(e.Message.Length % 2 == 0) // <- catch
         // {
         handlerLabel,
-        OpCode_CEE_POP{},
-        OpCode_CEE_NOP{},
+        OpCode::CEE_POP{},
+        OpCode::CEE_NOP{},
 
         // y = 42;
-        OpCode_CEE_LDC_I4_S{42},
-        OpCode_CEE_STARG_S{1},
+        OpCode::CEE_LDC_I4_S{42},
+        OpCode::CEE_STARG_S{1},
 
         // } // end of catch {
-        OpCode_CEE_NOP{},
-        OpCode_CEE_LEAVE_S{endLabel2},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_LEAVE_S{endLabel2},
         handlerEndLabel,
 
         // return z + y; // <- z + y
         endLabel,
         endLabel2,
-        OpCode_CEE_LDLOC_0{},
-        OpCode_CEE_LDARG_1{},
-        OpCode_CEE_ADD{},
-        OpCode_CEE_STLOC_3{},
-        OpCode_CEE_BR_S{retLabel},
+        OpCode::CEE_LDLOC_0{},
+        OpCode::CEE_LDARG_1{},
+        OpCode::CEE_ADD{},
+        OpCode::CEE_STLOC_3{},
+        OpCode::CEE_BR_S{retLabel},
 
         // return z + y; // <- return
         retLabel,
-        OpCode_CEE_LDLOC_3{},
-        OpCode_CEE_RET{}
+        OpCode::CEE_LDLOC_3{},
+        OpCode::CEE_RET{}
     };
 
     const InstructionStream expectedInjectionStream{
         // int z = 0;
-        OpCode_CEE_NOP{},
-        OpCode_CEE_LDC_I4_0{},
-        OpCode_CEE_STLOC_0{},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_LDC_I4_0{},
+        OpCode::CEE_STLOC_0{},
 
         // try
         // {
         tryLabel,
-        OpCode_CEE_NOP{},
+        OpCode::CEE_NOP{},
 
         // z = x / y;
-        OpCode_CEE_LDARG_0{},
-        OpCode_CEE_LDARG_1{},
-        OpCode_CEE_DIV{},
-        OpCode_CEE_STLOC_0{},
+        OpCode::CEE_LDARG_0{},
+        OpCode::CEE_LDARG_1{},
+        OpCode::CEE_DIV{},
+        OpCode::CEE_STLOC_0{},
 
         // } // end of try {
-        OpCode_CEE_NOP{},
-        OpCode_CEE_LEAVE_S{endLabel},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_LEAVE_S{endLabel},
         tryEndLabel,
 
         // catch (DivideByZeroException e) when(e.Message.Length % 2 == (0 + 1)) // <- when
         filterLabel,
 
         // catch (DivideByZeroException e) when(e.Message.Length % 2 == (0 + 1)) // <- DivideByZeroException e
-        OpCode_CEE_ISINST{ 0x0100000D },
-        OpCode_CEE_DUP{},
-        OpCode_CEE_BRTRUE_S{ isInstanceLabel },
-        OpCode_CEE_POP{},
-        OpCode_CEE_LDC_I4_0{},
-        OpCode_CEE_BR_S{endFilterLabel},
+        OpCode::CEE_ISINST{ 0x0100000D },
+        OpCode::CEE_DUP{},
+        OpCode::CEE_BRTRUE_S{ isInstanceLabel },
+        OpCode::CEE_POP{},
+        OpCode::CEE_LDC_I4_0{},
+        OpCode::CEE_BR_S{endFilterLabel},
 
         // catch (DivideByZeroException e) when(e.Message.Length % 2 == (0 + 1)) // <- e.Message.Length % 2 == (0 + 1)
         isInstanceLabel,
-        OpCode_CEE_STLOC_1{},
-        OpCode_CEE_LDLOC_1{},
-        OpCode_CEE_CALLVIRT{ 0x0A00000C },
-        OpCode_CEE_CALLVIRT{ 0x0A00000D },
-        OpCode_CEE_LDC_I4_2{},
-        OpCode_CEE_REM{},
-        OpCode_CEE_LDC_I4_0{},
-        OpCode_CEE_LDC_I4_1{},
-        OpCode_CEE_ADD{},
-        OpCode_CEE_CEQ{},
-        OpCode_CEE_STLOC_2{},
-        OpCode_CEE_LDLOC_2{},
-        OpCode_CEE_LDC_I4_0{},
-        OpCode_CEE_CGT_UN{},
+        OpCode::CEE_STLOC_1{},
+        OpCode::CEE_LDLOC_1{},
+        OpCode::CEE_CALLVIRT{ 0x0A00000C },
+        OpCode::CEE_CALLVIRT{ 0x0A00000D },
+        OpCode::CEE_LDC_I4_2{},
+        OpCode::CEE_REM{},
+        OpCode::CEE_LDC_I4_0{},
+        OpCode::CEE_LDC_I4_1{},
+        OpCode::CEE_ADD{},
+        OpCode::CEE_CEQ{},
+        OpCode::CEE_STLOC_2{},
+        OpCode::CEE_LDLOC_2{},
+        OpCode::CEE_LDC_I4_0{},
+        OpCode::CEE_CGT_UN{},
         endFilterLabel,
-        OpCode_CEE_ENDFILTER{},
+        OpCode::CEE_ENDFILTER{},
 
         // catch (DivideByZeroException e) when(e.Message.Length % 2 == (0 + 1)) // <- catch
         // {
         handlerLabel,
-        OpCode_CEE_POP{},
-        OpCode_CEE_NOP{},
+        OpCode::CEE_POP{},
+        OpCode::CEE_NOP{},
 
         // y = 42;
-        OpCode_CEE_LDC_I4_S{42},
-        OpCode_CEE_STARG_S{1},
+        OpCode::CEE_LDC_I4_S{42},
+        OpCode::CEE_STARG_S{1},
 
         // } // end of catch {
-        OpCode_CEE_NOP{},
-        OpCode_CEE_LEAVE_S{endLabel2},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_LEAVE_S{endLabel2},
         handlerEndLabel,
 
         // return z + y; // <- z + y
         endLabel,
         endLabel2,
-        OpCode_CEE_LDLOC_0{},
-        OpCode_CEE_LDARG_1{},
-        OpCode_CEE_ADD{},
-        OpCode_CEE_STLOC_3{},
-        OpCode_CEE_BR_S{retLabel},
+        OpCode::CEE_LDLOC_0{},
+        OpCode::CEE_LDARG_1{},
+        OpCode::CEE_ADD{},
+        OpCode::CEE_STLOC_3{},
+        OpCode::CEE_BR_S{retLabel},
 
         // return z + y; // <- return
         retLabel,
-        OpCode_CEE_LDLOC_3{},
-        OpCode_CEE_RET{}
+        OpCode::CEE_LDLOC_3{},
+        OpCode::CEE_RET{}
     };
 
     // Act
@@ -1416,8 +1416,8 @@ TEST(MethodBodyTests, InsertFunctionWithTryCatchWhen)
     const std::vector<std::byte> actualRoundtripBytes(method.Compile());
     const std::vector<ExceptionsSection> actualExceptionSections(method.ExceptionSections());
 
-    method.Insert(method.begin() + 27, OpCode_CEE_LDC_I4_1{});
-    method.Insert(method.begin() + 28, OpCode_CEE_ADD{});
+    method.Insert(method.begin() + 27, OpCode::CEE_LDC_I4_1{});
+    method.Insert(method.begin() + 28, OpCode::CEE_ADD{});
 
     const InstructionStream actualInjectionStream(method.Stream());
     const std::vector<std::byte> actualInjectionBytes(method.Compile());
@@ -1512,43 +1512,43 @@ TEST(MethodBodyTests, TransformJumpToLongIfNeeded)
     const Label endLabel2{ sourceStreamLabelCreator.CreateLabel() };
     const InstructionStream expectedSourceStream{
         // if (x == 1) // <- x == 1
-        OpCode_CEE_NOP{},
-        OpCode_CEE_LDARG_0{},
-        OpCode_CEE_LDC_I4_1{},
-        OpCode_CEE_CEQ{},
-        OpCode_CEE_STLOC_0{},
-        OpCode_CEE_LDLOC_0{},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_LDARG_0{},
+        OpCode::CEE_LDC_I4_1{},
+        OpCode::CEE_CEQ{},
+        OpCode::CEE_STLOC_0{},
+        OpCode::CEE_LDLOC_0{},
 
         // if (x == 1) // <- if
-        OpCode_CEE_BRFALSE_S{elseLabel},
+        OpCode::CEE_BRFALSE_S{elseLabel},
 
         // return 42; // <- 42
-        OpCode_CEE_NOP{},
-        OpCode_CEE_LDC_I4_S{42},
-        OpCode_CEE_STLOC_1{},
-        OpCode_CEE_BR_S{endLabel1},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_LDC_I4_S{42},
+        OpCode::CEE_STLOC_1{},
+        OpCode::CEE_BR_S{endLabel1},
 
         // return 0; // <- 0
         elseLabel,
-        OpCode_CEE_LDC_I4_0{},
-        OpCode_CEE_STLOC_1{},
-        OpCode_CEE_BR_S{endLabel2},
+        OpCode::CEE_LDC_I4_0{},
+        OpCode::CEE_STLOC_1{},
+        OpCode::CEE_BR_S{endLabel2},
 
         // return
         endLabel1,
         endLabel2,
-        OpCode_CEE_LDLOC_1{},
-        OpCode_CEE_RET{}
+        OpCode::CEE_LDLOC_1{},
+        OpCode::CEE_RET{}
     };
 
     const size_t insertionLength{ 128 };
     const ptrdiff_t insertionPosition{ 10 };
     InstructionStream expectedInjectionStream(expectedSourceStream);
-    expectedInjectionStream[6] = OpCode_CEE_BRFALSE{ elseLabel };
+    expectedInjectionStream[6] = OpCode::CEE_BRFALSE{ elseLabel };
     expectedInjectionStream.insert(
         expectedInjectionStream.cbegin() + insertionPosition,
         insertionLength,
-        OpCode_CEE_NOP{});
+        OpCode::CEE_NOP{});
 
     // Act
     MethodBody method(sourceBytes);
@@ -1559,7 +1559,7 @@ TEST(MethodBodyTests, TransformJumpToLongIfNeeded)
 
     for (size_t i{ 0 }; i != insertionLength; ++i)
     {
-        method.Insert(method.begin() + insertionPosition, OpCode_CEE_NOP{});
+        method.Insert(method.begin() + insertionPosition, OpCode::CEE_NOP{});
     }
 
     const InstructionStream actualInjectionStream(method.Stream());
@@ -1652,17 +1652,17 @@ TEST(MethodBodyTests, InsertTransformJumpToLongIfNeeded)
     const Label endLabel{ sourceStreamLabelCreator.CreateLabel() };
     const InstructionStream expectedSourceStream{
         // return x + 1; // <- x + 1
-        OpCode_CEE_NOP{},
-        OpCode_CEE_LDARG_0{},
-        OpCode_CEE_LDC_I4_1{},
-        OpCode_CEE_ADD{},
-        OpCode_CEE_STLOC_0{},
-        OpCode_CEE_BR_S{endLabel},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_LDARG_0{},
+        OpCode::CEE_LDC_I4_1{},
+        OpCode::CEE_ADD{},
+        OpCode::CEE_STLOC_0{},
+        OpCode::CEE_BR_S{endLabel},
 
         // return x + 1; // <- return
         endLabel,
-        OpCode_CEE_LDLOC_0{},
-        OpCode_CEE_RET{}
+        OpCode::CEE_LDLOC_0{},
+        OpCode::CEE_RET{}
     };
 
     const Label elseLabel{ sourceStreamLabelCreator.CreateLabel() };
@@ -1670,41 +1670,41 @@ TEST(MethodBodyTests, InsertTransformJumpToLongIfNeeded)
     const ptrdiff_t insertionPosition{ 10 };
     InstructionStream expectedInjectionStream{
         // if (x == 1) // <- x == 1
-        OpCode_CEE_NOP{},
-        OpCode_CEE_LDARG_0{},
-        OpCode_CEE_LDC_I4_1{},
-        OpCode_CEE_CEQ{},
-        OpCode_CEE_STLOC_1{},
-        OpCode_CEE_LDLOC_1{},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_LDARG_0{},
+        OpCode::CEE_LDC_I4_1{},
+        OpCode::CEE_CEQ{},
+        OpCode::CEE_STLOC_1{},
+        OpCode::CEE_LDLOC_1{},
 
         // if (x == 1) // <- if
-        OpCode_CEE_BRFALSE{elseLabel},
+        OpCode::CEE_BRFALSE{elseLabel},
 
         // return 42; // <- 42
-        OpCode_CEE_NOP{},
-        OpCode_CEE_LDC_I4_S{42},
-        OpCode_CEE_STLOC_0{},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_LDC_I4_S{42},
+        OpCode::CEE_STLOC_0{},
         // 128 No Operation instruction will go here
-        OpCode_CEE_BR_S{endLabel},
+        OpCode::CEE_BR_S{endLabel},
 
         // return x + 1; // <- x + 1
         elseLabel,
-        OpCode_CEE_LDARG_0{},
-        OpCode_CEE_LDC_I4_1{},
-        OpCode_CEE_ADD{},
-        OpCode_CEE_STLOC_0{},
-        OpCode_CEE_BR_S{endLabel},
+        OpCode::CEE_LDARG_0{},
+        OpCode::CEE_LDC_I4_1{},
+        OpCode::CEE_ADD{},
+        OpCode::CEE_STLOC_0{},
+        OpCode::CEE_BR_S{endLabel},
 
         // return
         endLabel,
-        OpCode_CEE_LDLOC_0{},
-        OpCode_CEE_RET{}
+        OpCode::CEE_LDLOC_0{},
+        OpCode::CEE_RET{}
     };
 
     expectedInjectionStream.insert(
         expectedInjectionStream.cbegin() + insertionPosition,
         insertionLength,
-        OpCode_CEE_NOP{});
+        OpCode::CEE_NOP{});
 
     // Act
     MethodBody method(sourceBytes);
@@ -1714,28 +1714,28 @@ TEST(MethodBodyTests, InsertTransformJumpToLongIfNeeded)
     const std::vector<ExceptionsSection> actualExceptionSections(method.ExceptionSections());
 
     // if (x == 1) // <- x == 1
-    method.Insert(method.begin() + 1, OpCode_CEE_LDARG_0{});
-    method.Insert(method.begin() + 2, OpCode_CEE_LDC_I4_1{});
-    method.Insert(method.begin() + 3, OpCode_CEE_CEQ{});
-    method.Insert(method.begin() + 4, OpCode_CEE_STLOC_1{});
-    method.Insert(method.begin() + 5, OpCode_CEE_LDLOC_1{});
+    method.Insert(method.begin() + 1, OpCode::CEE_LDARG_0{});
+    method.Insert(method.begin() + 2, OpCode::CEE_LDC_I4_1{});
+    method.Insert(method.begin() + 3, OpCode::CEE_CEQ{});
+    method.Insert(method.begin() + 4, OpCode::CEE_STLOC_1{});
+    method.Insert(method.begin() + 5, OpCode::CEE_LDLOC_1{});
 
     // if (x == 1) // <- if
     const Label actualElseLabel{ method.CreateLabel() };
-    method.Insert(method.begin() + 6, OpCode_CEE_BRFALSE_S{ actualElseLabel });
+    method.Insert(method.begin() + 6, OpCode::CEE_BRFALSE_S{ actualElseLabel });
 
     // return 42; // <- 42
-    method.Insert(method.begin() + 7, OpCode_CEE_NOP{});
-    method.Insert(method.begin() + 8, OpCode_CEE_LDC_I4_S{42});
-    method.Insert(method.begin() + 9, OpCode_CEE_STLOC_0{});
+    method.Insert(method.begin() + 7, OpCode::CEE_NOP{});
+    method.Insert(method.begin() + 8, OpCode::CEE_LDC_I4_S{42});
+    method.Insert(method.begin() + 9, OpCode::CEE_STLOC_0{});
 
     // 128 No Operation instructions
     for (size_t i{ 0 }; i != insertionLength; ++i)
     {
-        method.Insert(method.begin() + insertionPosition, OpCode_CEE_NOP{});
+        method.Insert(method.begin() + insertionPosition, OpCode::CEE_NOP{});
     }
 
-    method.Insert(method.begin() + 138, OpCode_CEE_BR_S{ endLabel });
+    method.Insert(method.begin() + 138, OpCode::CEE_BR_S{ endLabel });
     method.MarkLabel(method.begin() + 139, actualElseLabel);
 
     const InstructionStream actualInjectionStream(method.Stream());
@@ -1793,50 +1793,50 @@ TEST(MethodBodyTests, ÑreateAndMarkLabel)
     const Label endLabel{ sourceStreamLabelCreator.CreateLabel() };
     const InstructionStream expectedSourceStream{
         // return x + 1; // <- x + 1
-        OpCode_CEE_NOP{},
-        OpCode_CEE_LDARG_0{},
-        OpCode_CEE_LDC_I4_1{},
-        OpCode_CEE_ADD{},
-        OpCode_CEE_STLOC_0{},
-        OpCode_CEE_BR_S{endLabel},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_LDARG_0{},
+        OpCode::CEE_LDC_I4_1{},
+        OpCode::CEE_ADD{},
+        OpCode::CEE_STLOC_0{},
+        OpCode::CEE_BR_S{endLabel},
 
         // return x + 1; // <- return
         endLabel,
-        OpCode_CEE_LDLOC_0{},
-        OpCode_CEE_RET{}
+        OpCode::CEE_LDLOC_0{},
+        OpCode::CEE_RET{}
     };
 
     const Label elseLabel{ sourceStreamLabelCreator.CreateLabel() };
     InstructionStream expectedInjectionStream{
         // if (x == 1) // <- x == 1
-        OpCode_CEE_NOP{},
-        OpCode_CEE_LDARG_0{},
-        OpCode_CEE_LDC_I4_1{},
-        OpCode_CEE_CEQ{},
-        OpCode_CEE_STLOC_1{},
-        OpCode_CEE_LDLOC_1{},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_LDARG_0{},
+        OpCode::CEE_LDC_I4_1{},
+        OpCode::CEE_CEQ{},
+        OpCode::CEE_STLOC_1{},
+        OpCode::CEE_LDLOC_1{},
 
         // if (x == 1) // <- if
-        OpCode_CEE_BRFALSE_S{elseLabel},
+        OpCode::CEE_BRFALSE_S{elseLabel},
 
         // return 42; // <- 42
-        OpCode_CEE_NOP{},
-        OpCode_CEE_LDC_I4_S{42},
-        OpCode_CEE_STLOC_0{},
-        OpCode_CEE_BR_S{endLabel},
+        OpCode::CEE_NOP{},
+        OpCode::CEE_LDC_I4_S{42},
+        OpCode::CEE_STLOC_0{},
+        OpCode::CEE_BR_S{endLabel},
 
         // return x + 1; // <- x + 1
         elseLabel,
-        OpCode_CEE_LDARG_0{},
-        OpCode_CEE_LDC_I4_1{},
-        OpCode_CEE_ADD{},
-        OpCode_CEE_STLOC_0{},
-        OpCode_CEE_BR_S{endLabel},
+        OpCode::CEE_LDARG_0{},
+        OpCode::CEE_LDC_I4_1{},
+        OpCode::CEE_ADD{},
+        OpCode::CEE_STLOC_0{},
+        OpCode::CEE_BR_S{endLabel},
 
         // return
         endLabel,
-        OpCode_CEE_LDLOC_0{},
-        OpCode_CEE_RET{}
+        OpCode::CEE_LDLOC_0{},
+        OpCode::CEE_RET{}
     };
 
     // Act
@@ -1847,22 +1847,22 @@ TEST(MethodBodyTests, ÑreateAndMarkLabel)
     const std::vector<ExceptionsSection> actualExceptionSections(method.ExceptionSections());
 
     // if (x == 1) // <- x == 1
-    method.Insert(method.begin() + 1, OpCode_CEE_LDARG_0{});
-    method.Insert(method.begin() + 2, OpCode_CEE_LDC_I4_1{});
-    method.Insert(method.begin() + 3, OpCode_CEE_CEQ{});
-    method.Insert(method.begin() + 4, OpCode_CEE_STLOC_1{});
-    method.Insert(method.begin() + 5, OpCode_CEE_LDLOC_1{});
+    method.Insert(method.begin() + 1, OpCode::CEE_LDARG_0{});
+    method.Insert(method.begin() + 2, OpCode::CEE_LDC_I4_1{});
+    method.Insert(method.begin() + 3, OpCode::CEE_CEQ{});
+    method.Insert(method.begin() + 4, OpCode::CEE_STLOC_1{});
+    method.Insert(method.begin() + 5, OpCode::CEE_LDLOC_1{});
 
     // if (x == 1) // <- if
     const Label actualElseLabel{ method.CreateLabel() };
-    method.Insert(method.begin() + 6, OpCode_CEE_BRFALSE_S{ actualElseLabel });
+    method.Insert(method.begin() + 6, OpCode::CEE_BRFALSE_S{ actualElseLabel });
 
     // return 42; // <- 42
-    method.Insert(method.begin() + 7, OpCode_CEE_NOP{});
-    method.Insert(method.begin() + 8, OpCode_CEE_LDC_I4_S{ 42 });
-    method.Insert(method.begin() + 9, OpCode_CEE_STLOC_0{});
+    method.Insert(method.begin() + 7, OpCode::CEE_NOP{});
+    method.Insert(method.begin() + 8, OpCode::CEE_LDC_I4_S{ 42 });
+    method.Insert(method.begin() + 9, OpCode::CEE_STLOC_0{});
 
-    method.Insert(method.begin() + 10, OpCode_CEE_BR_S{ endLabel });
+    method.Insert(method.begin() + 10, OpCode::CEE_BR_S{ endLabel });
     method.MarkLabel(method.begin() + 11, actualElseLabel);
 
     const InstructionStream actualInjectionStream(method.Stream());
@@ -1891,7 +1891,7 @@ TEST(MethodBodyTests, CompileThrowsOnUnresolvedLabel)
     const Label label { method.CreateLabel() };
     method.Insert(
         method.begin() + 2,
-        OpCode_CEE_BR_S{ label });
+        OpCode::CEE_BR_S{ label });
 
     // Assert
     EXPECT_THROW(method.Compile(), std::logic_error);

--- a/Drill4dotNet/Drill4dotNet-Tests/OpCodeVariantTests.cpp
+++ b/Drill4dotNet/Drill4dotNet-Tests/OpCodeVariantTests.cpp
@@ -72,25 +72,29 @@ TEST(OpCodeVariantTests, CreateWithArgument)
     EXPECT_EQ(expectedConstant, variant.GetIf<OpCode::CEE_LDC_I4>()->Argument());
 }
 
-// Checks the aspects describing stack
+// Checks the aspects describing control flow and stack
 // behavior are properly added to OpCode::CEE_* classes.
 
+static_assert(OpCode::CEE_ADD::FlowBehavior == OpCodeFlowBehavior::Next);
 static_assert(OpCode::CEE_ADD::IsStackPushBehaviorKnown);
 static_assert(OpCode::CEE_ADD::ItemsPushedToStack == 1);
 static_assert(OpCode::CEE_ADD::IsStackPopBehaviorKnown);
 static_assert(OpCode::CEE_ADD::ItemsPoppedFromStack == 2);
 
+static_assert(OpCode::CEE_BRFALSE::FlowBehavior == OpCodeFlowBehavior::ConditionalBranch);
 static_assert(OpCode::CEE_BRFALSE::IsStackPushBehaviorKnown);
 static_assert(OpCode::CEE_BRFALSE::ItemsPushedToStack == 0);
 static_assert(OpCode::CEE_BRFALSE::IsStackPopBehaviorKnown);
 static_assert(OpCode::CEE_BRFALSE::ItemsPoppedFromStack == 1);
 
+static_assert(OpCode::CEE_CALL::FlowBehavior == OpCodeFlowBehavior::Call);
 static_assert(!OpCode::CEE_CALL::IsStackPushBehaviorKnown);
 static_assert(!OpCode::CEE_CALL::IsStackPopBehaviorKnown);
 // These will not even compile:
 // static_assert(OpCode::CEE_CALL::ItemsPushedToStack == 1);
 // static_assert(OpCode::CEE_CALL::ItemsPoppedFromStack == 2);
 
+static_assert(OpCode::CEE_RET::FlowBehavior == OpCodeFlowBehavior::Return);
 static_assert(OpCode::CEE_RET::IsStackPushBehaviorKnown);
 static_assert(OpCode::CEE_RET::ItemsPushedToStack == 0);
 static_assert(!OpCode::CEE_RET::IsStackPopBehaviorKnown);

--- a/Drill4dotNet/Drill4dotNet-Tests/OpCodeVariantTests.cpp
+++ b/Drill4dotNet/Drill4dotNet-Tests/OpCodeVariantTests.cpp
@@ -32,9 +32,9 @@ TEST(OpCodeVariantTests, Create)
     const OpCodeVariant variant {};
 
     // Assert
-    AssertVariantHolds<OpCode_CEE_NOP>(variant);
+    AssertVariantHolds<OpCode::CEE_NOP>(variant);
     EXPECT_EQ(1, variant.SizeWithArgument());
-    EXPECT_TRUE(variant.GetIf<OpCode_CEE_NOP>().has_value());
+    EXPECT_TRUE(variant.GetIf<OpCode::CEE_NOP>().has_value());
 }
 
 // Checks OpCodeVariant is created with a specific
@@ -45,12 +45,12 @@ TEST(OpCodeVariantTests, CreateWithoutArgument)
     // Arrange
 
     // Act
-    const OpCodeVariant variant { OpCode_CEE_ADD { } };
+    const OpCodeVariant variant { OpCode::CEE_ADD { } };
 
     // Assert
-    AssertVariantHolds<OpCode_CEE_ADD>(variant);
+    AssertVariantHolds<OpCode::CEE_ADD>(variant);
     EXPECT_EQ(1, variant.SizeWithArgument());
-    EXPECT_TRUE(variant.GetIf<OpCode_CEE_ADD>().has_value());
+    EXPECT_TRUE(variant.GetIf<OpCode::CEE_ADD>().has_value());
 }
 
 // Checks OpCodeVariant is created with a specific
@@ -62,12 +62,12 @@ TEST(OpCodeVariantTests, CreateWithArgument)
     const OpCodeArgumentType::InlineI expectedConstant { 42 };
 
     // Act
-    const OpCodeVariant variant { OpCode_CEE_LDC_I4 { expectedConstant } };
-    const std::optional<OpCode_CEE_LDC_I4> actualOpCode = variant.GetIf<OpCode_CEE_LDC_I4>();
+    const OpCodeVariant variant { OpCode::CEE_LDC_I4 { expectedConstant } };
+    const std::optional<OpCode::CEE_LDC_I4> actualOpCode = variant.GetIf<OpCode::CEE_LDC_I4>();
 
     // Assert
-    AssertVariantHolds<OpCode_CEE_LDC_I4>(variant);
+    AssertVariantHolds<OpCode::CEE_LDC_I4>(variant);
     EXPECT_EQ(5, variant.SizeWithArgument());
-    ASSERT_TRUE(variant.GetIf<OpCode_CEE_LDC_I4>().has_value());
-    EXPECT_EQ(expectedConstant, variant.GetIf<OpCode_CEE_LDC_I4>()->Argument());
+    ASSERT_TRUE(variant.GetIf<OpCode::CEE_LDC_I4>().has_value());
+    EXPECT_EQ(expectedConstant, variant.GetIf<OpCode::CEE_LDC_I4>()->Argument());
 }

--- a/Drill4dotNet/Drill4dotNet-Tests/OpCodeVariantTests.cpp
+++ b/Drill4dotNet/Drill4dotNet-Tests/OpCodeVariantTests.cpp
@@ -71,3 +71,29 @@ TEST(OpCodeVariantTests, CreateWithArgument)
     ASSERT_TRUE(variant.GetIf<OpCode::CEE_LDC_I4>().has_value());
     EXPECT_EQ(expectedConstant, variant.GetIf<OpCode::CEE_LDC_I4>()->Argument());
 }
+
+// Checks the aspects describing stack
+// behavior are properly added to OpCode::CEE_* classes.
+
+static_assert(OpCode::CEE_ADD::IsStackPushBehaviorKnown);
+static_assert(OpCode::CEE_ADD::ItemsPushedToStack == 1);
+static_assert(OpCode::CEE_ADD::IsStackPopBehaviorKnown);
+static_assert(OpCode::CEE_ADD::ItemsPoppedFromStack == 2);
+
+static_assert(OpCode::CEE_BRFALSE::IsStackPushBehaviorKnown);
+static_assert(OpCode::CEE_BRFALSE::ItemsPushedToStack == 0);
+static_assert(OpCode::CEE_BRFALSE::IsStackPopBehaviorKnown);
+static_assert(OpCode::CEE_BRFALSE::ItemsPoppedFromStack == 1);
+
+static_assert(!OpCode::CEE_CALL::IsStackPushBehaviorKnown);
+static_assert(!OpCode::CEE_CALL::IsStackPopBehaviorKnown);
+// These will not even compile:
+// static_assert(OpCode::CEE_CALL::ItemsPushedToStack == 1);
+// static_assert(OpCode::CEE_CALL::ItemsPoppedFromStack == 2);
+
+static_assert(OpCode::CEE_RET::IsStackPushBehaviorKnown);
+static_assert(OpCode::CEE_RET::ItemsPushedToStack == 0);
+static_assert(!OpCode::CEE_RET::IsStackPopBehaviorKnown);
+// This will not even compile:
+// static_assert(OpCode::CEE_RET::ItemsPoppedFromStack == 1);
+

--- a/Drill4dotNet/Drill4dotNet/CProfilerCallback.cpp
+++ b/Drill4dotNet/Drill4dotNet/CProfilerCallback.cpp
@@ -527,9 +527,9 @@ namespace Drill4dotNet
 
             const auto findSecondCall = [this, &body{ std::as_const(functionBody) }]()
             {
-                const auto result = FindInstruction<OpCode_CEE_CALL>(
+                const auto result = FindInstruction<OpCode::CEE_CALL>(
                     FindNextInstruction(
-                        FindInstruction<OpCode_CEE_CALL>(
+                        FindInstruction<OpCode::CEE_CALL>(
                             body.begin(),
                             body.end()),
                         body.end()),
@@ -545,21 +545,21 @@ namespace Drill4dotNet
 
             functionBody.Insert(
                 findSecondCall() + 1,
-                OpCode_CEE_LDLOC_0{});
+                OpCode::CEE_LDLOC_0{});
 
             functionBody.Insert(
                 findSecondCall() + 2,
-                OpCode_CEE_LDC_I4_1{});
+                OpCode::CEE_LDC_I4_1{});
 
             Label label = functionBody.CreateLabel();
 
             functionBody.Insert(
                 findSecondCall() + 3,
-                OpCode_CEE_BLT_S { ShortJump { label } });
+                OpCode::CEE_BLT_S { ShortJump { label } });
 
             functionBody.Insert(
                 findSecondCall() + 4,
-                OpCode_CEE_LDC_I4 { 42 });
+                OpCode::CEE_LDC_I4 { 42 });
 
             const auto callPosition = findSecondCall();
             functionBody.Insert(
@@ -570,14 +570,14 @@ namespace Drill4dotNet
             {
                 functionBody.Insert(
                     findSecondCall() + 6,
-                    OpCode_CEE_NOP{});
+                    OpCode::CEE_NOP{});
             }
 
             // Presense of stloc.3 instruction means that
             // MyInjectionTarget has been compiled in Debug.
             // This in turn means there is a string variable s,
             // and we can inject Console.WriteLine(s);
-            if (FindInstruction<OpCode_CEE_STLOC_3>(
+            if (FindInstruction<OpCode::CEE_STLOC_3>(
                 functionBody.begin(),
                 functionBody.end()) != functionBody.end())
             {
@@ -592,7 +592,7 @@ namespace Drill4dotNet
 
                         const auto& findEndFinally = [this, clause, &body{ std::as_const(functionBody) }]()
                         {
-                            return FindInstruction<OpCode_CEE_ENDFINALLY>(
+                            return FindInstruction<OpCode::CEE_ENDFINALLY>(
                                 FindLabel(
                                     body.Stream(),
                                     clause.HandlerOffset()),
@@ -606,7 +606,7 @@ namespace Drill4dotNet
                             const auto endTry = FindLabel(
                                 body.Stream(),
                                 clause.TryEndOffset());
-                            const auto result = FindInstruction<OpCode_CEE_CALL>(
+                            const auto result = FindInstruction<OpCode::CEE_CALL>(
                                 FindLabel(
                                     body.Stream(),
                                     clause.TryOffset()),
@@ -620,7 +620,7 @@ namespace Drill4dotNet
                             return result;
                         };
 
-                        functionBody.Insert(findEndFinally(), OpCode_CEE_LDLOC_3{});
+                        functionBody.Insert(findEndFinally(), OpCode::CEE_LDLOC_3{});
                         functionBody.Insert(
                             findEndFinally(),
                             std::get<OpCodeVariant>(*findCallInTry()));
@@ -629,7 +629,7 @@ namespace Drill4dotNet
             }
 
             functionBody.MarkLabel(
-                FindInstruction<OpCode_CEE_RET>(functionBody.begin(), functionBody.end()),
+                FindInstruction<OpCode::CEE_RET>(functionBody.begin(), functionBody.end()),
                 label);
 
             const std::vector<std::byte> afterInjection = functionBody.Compile();

--- a/Drill4dotNet/Drill4dotNet/MethodBody.cpp
+++ b/Drill4dotNet/Drill4dotNet/MethodBody.cpp
@@ -381,18 +381,18 @@ namespace Drill4dotNet
 
 #define DECLARE_TO_LONG_BRANCH_INSTRUCTION_SPECIALIZATION(longName) \
     template <> \
-    class ToLongBranchInstruction< OpCode_CEE_ ## longName ## _S> \
+    class ToLongBranchInstruction< OpCode::CEE_ ## longName ## _S> \
     { \
     static_assert(std::is_same_v< \
-        OpCode_CEE_ ## longName ## _S :: ArgumentType, \
+        OpCode::CEE_ ## longName ## _S :: ArgumentType, \
         OpCodeArgumentType::ShortInlineBrTarget>); \
 \
     static_assert(std::is_same_v< \
-        OpCode_CEE_ ## longName ## :: ArgumentType, \
+        OpCode::CEE_ ## longName ## :: ArgumentType, \
         OpCodeArgumentType::InlineBrTarget>); \
  \
    public: \
-        using LongInstruction = OpCode_CEE_ ## longName; \
+        using LongInstruction = OpCode::CEE_ ## longName; \
     };
 
     DECLARE_TO_LONG_BRANCH_INSTRUCTION_SPECIALIZATION(BR)
@@ -427,10 +427,10 @@ namespace Drill4dotNet
     controlBehavior) \
     static_assert( \
         !std::is_same_v< \
-            OpCode_ ## canonicalName ## ::ArgumentType, \
+            OpCode :: ## canonicalName ## ::ArgumentType, \
             OpCodeArgumentType::ShortInlineBrTarget> \
         || !std::is_same_v< \
-            ToLongBranchInstruction<OpCode_ ## canonicalName >::LongInstruction, \
+            ToLongBranchInstruction<OpCode :: ## canonicalName >::LongInstruction, \
             InstructionCannotMadeLong>);
 #include "DefineOpCodesGeneratorSpecializations.h"
 #include <opcode.def>

--- a/Drill4dotNet/Drill4dotNet/OpCodes.cpp
+++ b/Drill4dotNet/Drill4dotNet/OpCodes.cpp
@@ -12,7 +12,7 @@ namespace Drill4dotNet
     }
 
     OpCodeVariant::OpCodeVariant()
-        : m_code(OpCodeInstruction<OpCode_CEE_NOP>::Code),
+        : m_code(OpCodeInstruction<OpCode::CEE_NOP>::Code),
         m_argument {}
     {
     }

--- a/Drill4dotNet/Drill4dotNet/OpCodes.h
+++ b/Drill4dotNet/Drill4dotNet/OpCodes.h
@@ -287,6 +287,150 @@ namespace Drill4dotNet
             }
         };
 
+        // opcode.def will use these variables to define
+        // push stack behavior.
+        // 0 will mean nothing pushed to the method stack.
+        // 1 will mean 1 item is pushed to the method stack.
+        // Values can be combined, for example PushRef+PushI4
+        // will give 2, which means 2 items are pushed.
+        // nullptr will mean that the instruction pushes
+        // varying amount of items, determined by the usage context,
+        // for example the signature of the function being called.
+        // nullptr cannot be combined with other values.
+        // The value from opcode.def is then used with
+        // the StackPush base class. Different type for VarPush
+        // allows specialization for the VarPush case.
+        inline static constexpr int Push0{ 0 };
+        inline static constexpr int Push1{ 1 };
+        inline static constexpr int PushI{ 1 };
+        inline static constexpr int PushI4{ 1 };
+        inline static constexpr int PushR4{ 1 };
+        inline static constexpr int PushI8{ 1 };
+        inline static constexpr int PushR8{ 1 };
+        inline static constexpr int PushRef{ 1 };
+        inline static constexpr nullptr_t VarPush{ nullptr };
+
+        // As a base class, provides static values describing push
+        // stack behavior to the CEE_* classes.
+        // If the instruction always pushes the same amount of items,
+        // it will have static member constants IsStackPushBehaviorKnown,
+        // equal to true, and ItemsPushedToStack, equal to the amount
+        // of items. If the amount of items the instruction pushes
+        // is different for each usage, only static member constant
+        // IsStackPushBehaviorKnown, equal to false, is provided.
+        // stackPush : Combination of Push0, Push1, etc variables 
+        //     from opcode.def, or VarPush.
+        // T : type of stackPush.
+        template <typename T, T stackPush>
+        class StackPush;
+
+        // Specialization of StackPush for the VarPush case.
+        // In this case, T = nullptr_t, stackPush = VarPush.
+        // Only IsStackPushBehaviorKnown, equal to false, is provided.
+        template <>
+        class StackPush <nullptr_t, VarPush>
+        {
+        public:
+            // Value indicating the amount of items the instruction
+            // pushes onto the stack is different in each usage.
+            // The amount is then determined by the usage context,
+            // for example the signature of the function being called.
+            inline static constexpr bool IsStackPushBehaviorKnown { false };
+        };
+
+        // Specialization of StackPush for case when
+        // the count of items for specific instruction
+        // is always the same and known.
+        // In this case, T = int, and stackPush is a combination of
+        // Push0, Push1, etc variables from opcode.def.
+        // In this case, provides static member constants
+        // IsStackPushBehaviorKnown, equal to true, and
+        // ItemsPushedToStack, equal to the amount of items.
+        template <int stackPush>
+        class StackPush<int, stackPush>
+        {
+        public:
+            // The value indicating that the instruction
+            // always pushes the same amount of items onto the stack.
+            inline static constexpr bool IsStackPushBehaviorKnown { true };
+
+            // The amount of parameters the instruction
+            // pushes onto the stack.
+            inline static constexpr int ItemsPushedToStack { stackPush };
+        };
+
+        // opcode.def will use these variables to define
+        // pop stack behavior.
+        // 0 will mean nothing popped from the method stack.
+        // 1 will mean 1 item is popped from the method stack.
+        // Values can be combined, for example PopRef+PopI4
+        // will give 2, which means 2 items are popped.
+        // nullptr will mean that the instruction pops
+        // varying amount of items, determined by the usage context,
+        // for example the signature of the function being called.
+        // nullptr cannot be combined with other values.
+        // The value from opcode.def is then used with
+        // the StackPop base class. Different type for VarPop
+        // allows specialization for the VarPop case.
+        inline static constexpr int Pop0{ 0 };
+        inline static constexpr int Pop1{ 1 };
+        inline static constexpr int PopI{ 1 };
+        inline static constexpr int PopI4{ 1 };
+        inline static constexpr int PopR4{ 1 };
+        inline static constexpr int PopI8{ 1 };
+        inline static constexpr int PopR8{ 1 };
+        inline static constexpr int PopRef{ 1 };
+        inline static constexpr nullptr_t VarPop{ nullptr };
+
+        // As a base class, provides static values describing pop
+        // stack behavior to the CEE_* classes.
+        // If the instruction always pops the same amount of items,
+        // it will have static member constants IsStackPopBehaviorKnown,
+        // equal to true, and ItemsPoppedFromStack, equal to the amount
+        // of items. If the amount of items the instruction pops is
+        // different for each usage, only static member constant
+        // IsStackPopBehaviorKnown, equal to false, is provided.
+        // stackPop : Combination of Pop0, Pop1, etc variables 
+        //     from opcode.def, or VarPop.
+        // T : type of stackPop.
+        template <typename T, T stackPop>
+        class StackPop;
+
+        // Specialization of StackPop for the VarPop case.
+        // In this case, T = nullptr_t, stackPop = VarPop.
+        // Only IsStackPopBehaviorKnown, equal to false, is provided.
+        template <>
+        class StackPop <nullptr_t, VarPop>
+        {
+        public:
+            // Value indicating the amount of items the instruction
+            // pops from the stack is different in each usage.
+            // The amount is then determined by the usage context,
+            // for example the signature of the function being called.
+            inline static constexpr bool IsStackPopBehaviorKnown { false };
+        };
+
+        // Specialization of StackPop for case when
+        // the count of items for specific instruction
+        // is always the same and known.
+        // In this case, T = int, and stackPop is a combination of
+        // Pop0, Pop1, etc variables from opcode.def.
+        // In this case, provides static member constants
+        // IsStackPopBehaviorKnown, equal to true, and
+        // ItemsPoppedFromStack, equal to the amount of items.
+        template <int stackPop>
+        class StackPop<int, stackPop>
+        {
+        public:
+            // The value indicating that the instruction
+            // always pops the same amount of items from the stack.
+            inline static constexpr bool IsStackPopBehaviorKnown { true };
+
+            // The amount of parameters the instruction
+            // pops from the stack.
+            inline static constexpr int ItemsPoppedFromStack { stackPop };
+        };
+
     public:
 
         // Using the OPDEF_REAL_INSTRUCTION macro, the next invocation
@@ -308,7 +452,9 @@ namespace Drill4dotNet
         public OpCodeBase<\
             canonicalName , \
             OpCodeArgumentType:: ## inlineArgumentType >, \
-        public OpCodeArgument<OpCodeArgumentType:: ## inlineArgumentType > \
+        public OpCodeArgument<OpCodeArgumentType:: ## inlineArgumentType >, \
+        public StackPush<std::decay_t<decltype(stackPush)>, stackPush>, \
+        public StackPop<std::decay_t<decltype(stackPop)>, stackPop> \
     { \
     public: \
         inline static constexpr std::wstring_view CanonicalName { L ## stringName }; \


### PR DESCRIPTION
Preparatory stage of work related to EPMDJ-2316 .

### Wrap small `CEE_*` classes into `OpCode` class

Previously, `OpCodes.h` generated a set of free standing `OpCode_CEE_*` classes, each corresponding to a specific Intermediate Language instruction.
These classes had base class `OpCode`.

Now, all these classes are renamed from `OpCode_CEE_*` to `CEE_*`, and wrapped with a class `OpCode`.
The base class is renamed from `OpCode` to `OpCodeArgument` to free name `OpCode` for the wrapping class.

This way, usages of these small classes will look like `OpCode::CEE_NOP`, instead of `OpCode_CEE_NOP`.
The wrapping class allows to put some implementation details of the classes generator into private section.
This will prevent confusing users of `OpCodes.h` with definitions they are not intended to use directly.

### Refactor base classes for the set of `OpCode::CEE_*` classes

Previously, [`CRTP`](https://www.fluentcpp.com/2017/05/12/curiously-recurring-template-pattern/) base templates `OpCodeBase` and `OpCodeArgument` were located directly in the `Drill4dotNet` namespace.
This was confusing users of `OpCodes.h` with definitions they were not meant to use directly.

Now, the base classes are moved to the private section of the `OpCode` class.

Additionally:
- Noticed that `OpCodeArgument` actually does not use anything from `OpCodeBase`.
 Now, `OpCodeArgument` does not inherit from `OpCodeBase`.
 Instead, each `CEE_*` class now inherits both `OpCodeBase` for members common for all opcodes, and `OpCodeArgument` for argument handling methods.
- Added `constexpr` to `CEE_*::CanonicalName`.

### Provide stack behavior information for `OpCode::CEE_*` classes

If an instruction always pushes the same amount of parameters, its type will have
`static` value `IsStackPushBehaviorKnown`, equal to `true`, and `ItemsPushedToStack`,
equal to the amount of parameters. Otherwise, it will have just value `IsStackPushBehaviorKnown`, equal to `false`.

For example, these asserts will be OK:
```
static_assert(OpCode::CEE_ADD::IsStackPushBehaviorKnown);
static_assert(OpCode::CEE_ADD::ItemsPushedToStack == 1);
static_assert(!OpCode::CEE_CALL::IsStackPushBehaviorKnown);
```

But this one will not even compile:
```
static_assert(OpCode::CEE_CALL::ItemsPushedToStack == 0);
```

The same way with popping from stack. If an instruction always pops the same amount
of parameters, its type will have `static` value `IsStackPopBehaviorKnown`, equal to `true`,
and `ItemsPoppedFromStack`, equal to the amount of parameters. Otherwise, it will have just value `IsStackPopBehaviorKnown`, equal to `false`.

For example, these asserts will be OK:
```
static_assert(OpCode::CEE_ADD::IsStackPopBehaviorKnown);
static_assert(OpCode::CEE_ADD::ItemsPoppedFromStack == 2);
static_assert(!OpCode::CEE_RET::IsStackPopBehaviorKnown);
```

But this one will not even compile:
```
static_assert(OpCode::CEE_RET::ItemsPoppedFromStack == 0);
```
### Provide control flow information for `OpCode::CEE_*` classes

- Introduce `enum OpCodeFlowBehavior` with possible behaviors.
- Added `static` value `FlowBehavior` for the opcode classes,
 equal to one of `OpCodeFlowBehavior` values.
