### PR TITLE
EPMDJ-2299/EPMDJ-2430: Profiler can load and get metadata from our .NET injection DLL and function

### DIFF
--- a/Drill4dotNet.sln
+++ b/Drill4dotNet.sln
@@ -18,6 +18,9 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HelloWorldFramework", "Hell
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Drill4dotNet", "Drill4dotNet\Drill4dotNet\Drill4dotNet.vcxproj", "{2AB82CE8-683B-4984-A566-9FFC579E3B47}"
+	ProjectSection(ProjectDependencies) = postProject
+		{2D761E31-20C2-47A6-B928-260C0F590A92} = {2D761E31-20C2-47A6-B928-260C0F590A92}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Drill4dotNetPS", "Drill4dotNet\Drill4dotNetPS\Drill4dotNetPS.vcxproj", "{5A2A665D-549C-4698-95BC-E5BCF70473D4}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -32,6 +35,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Drill4dotNet-Tests", "Drill4dotNet\Drill4dotNet-Tests\Drill4dotNet-Tests.vcxproj", "{CAB5EE21-B337-459B-998E-C6588620F35D}"
 	ProjectSection(ProjectDependencies) = postProject
+		{2D761E31-20C2-47A6-B928-260C0F590A92} = {2D761E31-20C2-47A6-B928-260C0F590A92}
 		{2AB82CE8-683B-4984-A566-9FFC579E3B47} = {2AB82CE8-683B-4984-A566-9FFC579E3B47}
 	EndProjectSection
 EndProject
@@ -39,6 +43,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Calculator", "HelloWorld\Ca
 	ProjectSection(ProjectDependencies) = postProject
 		{2AB82CE8-683B-4984-A566-9FFC579E3B47} = {2AB82CE8-683B-4984-A566-9FFC579E3B47}
 	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Injection", "Drill4dotNet\Injection\Injection.csproj", "{2D761E31-20C2-47A6-B928-260C0F590A92}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -68,6 +74,10 @@ Global
 		{FF353E74-9149-4160-82B2-2E6223743DA5}.Debug|x64.Build.0 = Debug|x64
 		{FF353E74-9149-4160-82B2-2E6223743DA5}.Release|x64.ActiveCfg = Release|x64
 		{FF353E74-9149-4160-82B2-2E6223743DA5}.Release|x64.Build.0 = Release|x64
+		{2D761E31-20C2-47A6-B928-260C0F590A92}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2D761E31-20C2-47A6-B928-260C0F590A92}.Debug|x64.Build.0 = Debug|Any CPU
+		{2D761E31-20C2-47A6-B928-260C0F590A92}.Release|x64.ActiveCfg = Release|Any CPU
+		{2D761E31-20C2-47A6-B928-260C0F590A92}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -79,6 +89,7 @@ Global
 		{5A2A665D-549C-4698-95BC-E5BCF70473D4} = {165F5CAF-C1CD-433E-9313-566EC89C8A2A}
 		{CAB5EE21-B337-459B-998E-C6588620F35D} = {165F5CAF-C1CD-433E-9313-566EC89C8A2A}
 		{FF353E74-9149-4160-82B2-2E6223743DA5} = {E621FC48-1856-4CE5-AF7C-1D6A902B0861}
+		{2D761E31-20C2-47A6-B928-260C0F590A92} = {165F5CAF-C1CD-433E-9313-566EC89C8A2A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {21899A74-A1ED-440D-8A6E-7136113832DA}

--- a/Drill4dotNet/Drill4dotNet-Tests/CProfilerCallbackTest.cpp
+++ b/Drill4dotNet/Drill4dotNet-Tests/CProfilerCallbackTest.cpp
@@ -15,6 +15,9 @@ public:
         coreInteractMock = std::make_unique<CoreInteractMock>();
         proClient = std::make_unique<ProClient>();
         profilerCallback = std::make_unique<CProfilerCallback>(*proClient.get());
+        WCHAR injectionFileName[_MAX_PATH];
+        ::GetModuleFileName(NULL, injectionFileName, _MAX_PATH);
+        Drill4dotNet::s_Drill4dotNetLibFilePath = injectionFileName;
     }
 
     void TearDown()

--- a/Drill4dotNet/Drill4dotNet-Tests/CProfilerCallbackTest.cpp
+++ b/Drill4dotNet/Drill4dotNet-Tests/CProfilerCallbackTest.cpp
@@ -80,6 +80,12 @@ TEST_F(CProfilerCallbackTest, Initialize_Shutdown)
     EXPECT_HRESULT_SUCCEEDED(profilerCallback->Initialize(p));
     EXPECT_EQ(typeid(CoreInteractMock), typeid(profilerCallback->GetCorProfilerInfo()) );
 
+    const InjectionMetaData emptyInjection;
+    const InjectionMetaData actualInjection = profilerCallback->GetInfoHandler().GetInjectionMetaData();
+    EXPECT_NE(emptyInjection.Assembly, actualInjection.Assembly);
+    EXPECT_NE(emptyInjection.Class, actualInjection.Class);
+    EXPECT_NE(emptyInjection.Function, actualInjection.Function);
+
     EXPECT_HRESULT_SUCCEEDED(profilerCallback->Shutdown());
     EXPECT_EQ(nullptr, &profilerCallback->GetCorProfilerInfo());
 }

--- a/Drill4dotNet/Drill4dotNet-Tests/Drill4dotNet-Tests.vcxproj
+++ b/Drill4dotNet/Drill4dotNet-Tests/Drill4dotNet-Tests.vcxproj
@@ -152,6 +152,7 @@
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
+      <AdditionalDependencies>Rometadata.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>copy "$(SolutionDir)bin\AnyCPU\$(Configuration)\Injection\netcoreapp3.1\Injection.dll" "$(OutDir)"</Command>
@@ -174,6 +175,7 @@
       <SubSystem>Console</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <AdditionalDependencies>Rometadata.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>copy "$(SolutionDir)bin\AnyCPU\$(Configuration)\Injection\netcoreapp3.1\Injection.dll" "$(OutDir)"</Command>

--- a/Drill4dotNet/Drill4dotNet-Tests/Drill4dotNet-Tests.vcxproj
+++ b/Drill4dotNet/Drill4dotNet-Tests/Drill4dotNet-Tests.vcxproj
@@ -153,6 +153,10 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
     </Link>
+    <PostBuildEvent>
+      <Command>copy "$(SolutionDir)bin\AnyCPU\$(Configuration)\Injection\netcoreapp3.1\Injection.dll" "$(OutDir)"</Command>
+      <Message>Copy injection.dll</Message>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -171,6 +175,10 @@
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
     </Link>
+    <PostBuildEvent>
+      <Command>copy "$(SolutionDir)bin\AnyCPU\$(Configuration)\Injection\netcoreapp3.1\Injection.dll" "$(OutDir)"</Command>
+      <Message>Copy injection.dll</Message>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/Drill4dotNet/Drill4dotNet/CProfilerCallback.cpp
+++ b/Drill4dotNet/Drill4dotNet/CProfilerCallback.cpp
@@ -172,13 +172,7 @@ namespace Drill4dotNet
         {
             m_corProfilerInfo = CreateCorProfilerInfo(pICorProfilerInfoUnk, LogToProClient(m_pImplClient));
 
-            struct InjectionMetaData
-            {
-                mdAssembly  Assembly = 0;
-                mdTypeDef   Class = 0;
-                mdMethodDef Function = 0;
-            } injection;
-
+            InjectionMetaData injection;
             HRESULT hr;
             ATL::CComQIPtr<IMetaDataDispenser, &IID_IMetaDataDispenser> metaDataDispenser;
             #pragma message("TODO: replace library function `MetaDataGetDispenser` with own implementation")
@@ -300,6 +294,7 @@ namespace Drill4dotNet
                 << L" Flags: " << HexOutput(dwImplFlags);
 
             metaDataImport->CloseEnum(hEnum2);
+            GetInfoHandler().SetInjectionMetaData(injection);
 
             if (auto runtimeInformation = m_corProfilerInfo->TryGetRuntimeInformation();
                 runtimeInformation)

--- a/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj
+++ b/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj
@@ -127,6 +127,7 @@
       <ModuleDefinitionFile>.\Drill4dotNet.def</ModuleDefinitionFile>
       <RegisterOutput>false</RegisterOutput>
       <AdditionalOptions>/ignore:4099 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalDependencies>Rometadata.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>copy "$(SolutionDir)bin\AnyCPU\$(Configuration)\Injection\netcoreapp3.1\Injection.dll" "$(OutDir)"
@@ -165,6 +166,7 @@
       <ModuleDefinitionFile>.\Drill4dotNet.def</ModuleDefinitionFile>
       <RegisterOutput>false</RegisterOutput>
       <AdditionalOptions>/ignore:4099 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalDependencies>Rometadata.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>copy "$(SolutionDir)bin\AnyCPU\$(Configuration)\Injection\netcoreapp3.1\Injection.dll" "$(OutDir)"
@@ -206,6 +208,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <RegisterOutput>false</RegisterOutput>
       <AdditionalOptions>/ignore:4099 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalDependencies>Rometadata.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>copy "$(SolutionDir)bin\AnyCPU\$(Configuration)\Injection\netcoreapp3.1\Injection.dll" "$(OutDir)"
@@ -246,6 +249,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <RegisterOutput>false</RegisterOutput>
       <AdditionalOptions>/ignore:4099 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalDependencies>Rometadata.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>copy "$(SolutionDir)bin\AnyCPU\$(Configuration)\Injection\netcoreapp3.1\Injection.dll" "$(OutDir)"

--- a/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj
+++ b/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj
@@ -128,6 +128,11 @@
       <RegisterOutput>false</RegisterOutput>
       <AdditionalOptions>/ignore:4099 %(AdditionalOptions)</AdditionalOptions>
     </Link>
+    <PostBuildEvent>
+      <Command>copy "$(SolutionDir)bin\AnyCPU\$(Configuration)\Injection\netcoreapp3.1\Injection.dll" "$(OutDir)"
+</Command>
+      <Message>Copy injection.dll</Message>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -161,6 +166,11 @@
       <RegisterOutput>false</RegisterOutput>
       <AdditionalOptions>/ignore:4099 %(AdditionalOptions)</AdditionalOptions>
     </Link>
+    <PostBuildEvent>
+      <Command>copy "$(SolutionDir)bin\AnyCPU\$(Configuration)\Injection\netcoreapp3.1\Injection.dll" "$(OutDir)"
+</Command>
+      <Message>Copy injection.dll</Message>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -197,6 +207,11 @@
       <RegisterOutput>false</RegisterOutput>
       <AdditionalOptions>/ignore:4099 %(AdditionalOptions)</AdditionalOptions>
     </Link>
+    <PostBuildEvent>
+      <Command>copy "$(SolutionDir)bin\AnyCPU\$(Configuration)\Injection\netcoreapp3.1\Injection.dll" "$(OutDir)"
+</Command>
+      <Message>Copy injection.dll</Message>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -232,6 +247,11 @@
       <RegisterOutput>false</RegisterOutput>
       <AdditionalOptions>/ignore:4099 %(AdditionalOptions)</AdditionalOptions>
     </Link>
+    <PostBuildEvent>
+      <Command>copy "$(SolutionDir)bin\AnyCPU\$(Configuration)\Injection\netcoreapp3.1\Injection.dll" "$(OutDir)"
+</Command>
+      <Message>Copy injection.dll</Message>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="ByteUtils.h" />

--- a/Drill4dotNet/Drill4dotNet/InfoHandler.cpp
+++ b/Drill4dotNet/Drill4dotNet/InfoHandler.cpp
@@ -7,6 +7,8 @@
 
 namespace Drill4dotNet
 {
+    std::filesystem::path s_Drill4dotNetLibFilePath;
+
     InfoHandler::InfoHandler(std::wostream& log)
         : m_ostream(log)
     {

--- a/Drill4dotNet/Drill4dotNet/InfoHandler.cpp
+++ b/Drill4dotNet/Drill4dotNet/InfoHandler.cpp
@@ -275,4 +275,14 @@ namespace Drill4dotNet
                 ;
         }
     }
+
+    InjectionMetaData InfoHandler::GetInjectionMetaData() const noexcept
+    {
+        return m_injectionMetaData;
+    }
+
+    void InfoHandler::SetInjectionMetaData(const InjectionMetaData& injection) noexcept
+    {
+        m_injectionMetaData = injection;
+    }
 }

--- a/Drill4dotNet/Drill4dotNet/InfoHandler.h
+++ b/Drill4dotNet/Drill4dotNet/InfoHandler.h
@@ -6,9 +6,12 @@
 #include <unordered_map>
 #include "LogBuffer.h"
 #include "CorDataStructures.h"
+#include <filesystem>
 
 namespace Drill4dotNet
 {
+    extern std::filesystem::path s_Drill4dotNetLibFilePath;
+
     struct FunctionRuntimeInfo
     {
         unsigned long callCount = 0UL;

--- a/Drill4dotNet/Drill4dotNet/InfoHandler.h
+++ b/Drill4dotNet/Drill4dotNet/InfoHandler.h
@@ -17,6 +17,13 @@ namespace Drill4dotNet
         unsigned long callCount = 0UL;
     };
 
+    struct InjectionMetaData
+    {
+        mdAssembly  Assembly = 0;
+        mdTypeDef   Class = 0;
+        mdMethodDef Function = 0;
+    };
+
     using TAppDomainInfoMap = std::unordered_map<AppDomainID, AppDomainInfo>;
     using TAssemblyInfoMap = std::unordered_map<AssemblyID, AssemblyInfo>;
     using TModuleInfoMap = std::unordered_map<ModuleID, ModuleInfo>;
@@ -45,6 +52,8 @@ namespace Drill4dotNet
         void MapClassInfo(const ClassID id, const ClassInfo& info) noexcept;
         std::optional<ClassInfo> TryGetClassInfo(const ClassID id) const noexcept;
         void OutputClassInfo(const ClassID id) const;
+        InjectionMetaData GetInjectionMetaData() const noexcept;
+        void SetInjectionMetaData(const InjectionMetaData& injection) noexcept;
     protected:
         using Logger = LogBuffer<std::wostream>;
         Logger Log() const;
@@ -55,5 +64,6 @@ namespace Drill4dotNet
         TAssemblyInfoMap m_assemblyInfos;
         TModuleInfoMap m_moduleInfos;
         TClassInfoMap m_classInfos;
+        InjectionMetaData m_injectionMetaData;
     };
 }

--- a/Drill4dotNet/Drill4dotNet/OutputUtils.h
+++ b/Drill4dotNet/Drill4dotNet/OutputUtils.h
@@ -305,4 +305,21 @@ namespace Drill4dotNet
             target.resize(newSize);
         }
     }
+
+    // If the given string has null characters at the end,
+    // removes them.
+    template<typename TChar>
+    std::basic_string<TChar>& TrimTrailingNulls(std::basic_string<TChar>& target)
+    {
+        using MyType = std::basic_string<TChar>;
+        if (target.size() > 0)
+        {
+            const auto newSize = target.find_last_not_of(L'\0');
+            if (newSize != MyType::npos)
+            {
+                target.resize(newSize+1);
+            }
+        }
+        return target;
+    }
 }

--- a/Drill4dotNet/Drill4dotNet/dllmain.cpp
+++ b/Drill4dotNet/Drill4dotNet/dllmain.cpp
@@ -6,6 +6,8 @@
 #include "Drill4dotNet_i.h"
 #include "dllmain.h"
 #include "LogBuffer.h"
+#include "OutputUtils.h"
+#include "InfoHandler.h"
 #include <iostream>
 
 CDrill4dotNetModule _AtlModule;
@@ -13,11 +15,21 @@ CDrill4dotNetModule _AtlModule;
 // DLL Entry Point
 extern "C" BOOL WINAPI DllMain(HINSTANCE hInstance, DWORD dwReason, LPVOID lpReserved)
 {
+    Drill4dotNet::LogStdout() << L"DllMain(" << hInstance << L", " << dwReason << L")";
     if (DLL_PROCESS_ATTACH == dwReason)
     {
         DisableThreadLibraryCalls(hInstance);
-    }
-    Drill4dotNet::LogStdout() << L"DllMain(" << hInstance << L", " << dwReason << L")";
 
+        DWORD rSize = _MAX_PATH;
+        std::wstring drill4dotNetModuleFileName(_MAX_PATH, L'\0');
+        do
+        {
+            drill4dotNetModuleFileName.resize(rSize, L'\0');
+            rSize = ::GetModuleFileName(hInstance, drill4dotNetModuleFileName.data(), static_cast<unsigned long>(drill4dotNetModuleFileName.size()));
+            rSize *= 2;
+        } while (::GetLastError() == ERROR_INSUFFICIENT_BUFFER);
+        Drill4dotNet::s_Drill4dotNetLibFilePath = Drill4dotNet::TrimTrailingNulls(drill4dotNetModuleFileName);
+        Drill4dotNet::LogStdout() << Drill4dotNet::s_Drill4dotNetLibFilePath.wstring();
+    }
     return _AtlModule.DllMain(dwReason, lpReserved);
 }

--- a/Drill4dotNet/Injection/Injection.csproj
+++ b/Drill4dotNet/Injection/Injection.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <ApplicationIcon />
+    <StartupObject />
+    <RootNamespace>Drill4dotNet</RootNamespace>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <PlatformTarget>x64</PlatformTarget>
+    <OutputPath>$(SolutionDir)bin\$(Platform)\$(Configuration)\Injection\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <PlatformTarget>x64</PlatformTarget>
+    <OutputPath>$(SolutionDir)bin\$(Platform)\$(Configuration)\Injection\</OutputPath>
+  </PropertyGroup>
+
+</Project>

--- a/Drill4dotNet/Injection/Program.cs
+++ b/Drill4dotNet/Injection/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Drill4dotNet
+{
+    public class CInjection
+    {
+        public static void FInjection()
+        {
+            Console.WriteLine("I am injected!");
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Visual Studio 2019 solution `Drill4dotNet.sln` in the top repository folder cons
     - `Drill4dotNetPS.vcxproj` proxy/stub DLL (not used);
     - `Drill4dotNet-Tests.vcxproj` unit tests for `Drill4dotNet.vcxproj`;
       - This project automatically downloads and installs NuGet package `gmock.v1.10.0` to `./packages` folder;
+    - `Injection.csproj` to build .NET `Injection.dll` to be injected to the target application by the profiler.
   - `HelloWorld` folder with a couple of sample C# projects:
     - `HelloWorld.csproj` to build an application to run in .NET Core 3.1 runtime;
     - `HelloWorldFramework.csproj` to build an application to run in .NET Framework 4.x CLR;
@@ -67,7 +68,9 @@ Note: You can run HelloWorld.csproj (set As StratUp Project) from the IDE and un
 
 # Running Drill dotNet agent
 
-Agent DLL binaries can be found under `./bin/$Platform/$Configuration/Drill4dotNet/Drill4dotNet.dll`, for example: `./bin/x64/Release/Drill4dotNet/Drill4dotNet.dll`
+Agent DLL binaries can be found under `./bin/$Platform/$Configuration/Drill4dotNet/` (for example: `./bin/x64/Release/Drill4dotNet/`):
+- `Drill4dotNet.dll`
+- `Injection.dll`
 
 Sample projects binaries can be found here:
 - `./bin/$Platform/$Configuration/HelloWorld/netcoreapp3.1/HelloWorld.exe`


### PR DESCRIPTION
EPMDJ-2430: Added Injection.dll stub project.

EPMDJ-2430: Load and get metadata from .NET module `Injection.dll` using IMetaDataDispenser::OpenScope().

EPMDJ-2430: Store Injection metadata in class `InfoHandler`
