### PR TITLE
Fix test data for InsertSimpleFunction test from MethodBodyTests and error handling in MethodBody

### DIFF
--- a/Drill4dotNet/Drill4dotNet-Tests/MethodBodyTests.cpp
+++ b/Drill4dotNet/Drill4dotNet-Tests/MethodBodyTests.cpp
@@ -11,9 +11,9 @@ using namespace Drill4dotNet;
 // }
 static std::vector<std::byte> CreateSimpleFunction()
 {
-    // created manually
+    // Captured from compiled assembly
     return {
-        std::byte { 0x16 },
+        std::byte { 0x12 },
         std::byte { 0x02 },
         std::byte { 0x03 },
         std::byte { 0x58 },
@@ -41,7 +41,7 @@ TEST(MethodBodyTests, InsertSimpleFunction)
 
     // based on source bytes
     const std::vector<std::byte> expectedInjectionBytes{
-        std::byte { 0x1E }, // size updated
+        std::byte { 0x1A }, // size updated
         std::byte { 0x02 },
         std::byte { 0x03 },
         std::byte { 0x58 },

--- a/Drill4dotNet/Drill4dotNet-Tests/MethodBodyTests.cpp
+++ b/Drill4dotNet/Drill4dotNet-Tests/MethodBodyTests.cpp
@@ -4,6 +4,44 @@
 
 using namespace Drill4dotNet;
 
+// Checks that an std::runtime_error is thrown if
+// the method bytes end unexpectedly in the middle of
+// the instructions stream.
+TEST(MethodBodyTests, CreateThrowsOnUnexpectedEnd)
+{
+    // Arrange
+    const std::vector methodBytes {
+        std::byte { 0x12 },
+        std::byte { 0x02 },
+        std::byte { 0x03 }
+        // In a valid method body, there should be 2 more bytes
+    };
+
+    // Assert
+    EXPECT_THROW(
+        MethodBody { methodBytes },
+        std::runtime_error);
+}
+
+// Checks that an std::runtime_error is thrown if the
+// method body bytes contain an unknown instruction code.
+TEST(MethodBodyTests, CreateThrowsOnInvalidOpCode)
+{
+    // Arrange
+    const std::vector methodBytes {
+        std::byte { 0x12 },
+        std::byte { 0x02 },
+        std::byte { 0x03 },
+        std::byte { 0xFE }, // There is no OpCode these
+        std::byte { 0xFD }  // two bytes represent
+    };
+
+    // Assert
+    EXPECT_THROW(
+        MethodBody { methodBytes },
+        std::runtime_error);
+}
+
 // Creates method body representing
 // public static int Sum(int x, int y)
 // {

--- a/Drill4dotNet/Drill4dotNet/MethodBody.cpp
+++ b/Drill4dotNet/Drill4dotNet/MethodBody.cpp
@@ -159,6 +159,11 @@ namespace Drill4dotNet
     {
         // Uses
         // const BYTE* OpInfo::fetch(const BYTE * instrPtr, OpArgsVal * args)
+        if (bodyBytes.size() < size_t { m_header.CodeSize() } + m_header.Size())
+        {
+            throw std::runtime_error("Unexpected end of method body bytes.");
+        }
+
         OpInfo parser{};
         const auto begin = reinterpret_cast<const BYTE*>(bodyBytes.data() + m_header.Size());
         const auto end = begin + m_header.CodeSize();
@@ -196,6 +201,9 @@ namespace Drill4dotNet
 #include <opcode.def>
 #include "UnDefineOpCodesGeneratorSpecializations.h"
 #undef OPDEF_REAL_INSTRUCTION
+
+            default:
+                throw std::runtime_error("Unknown Intermediate Language instruction");
             }
         }
 


### PR DESCRIPTION
Fixup for EPMDJ-2315.

### The test data update

Previously, the test data was calculated manually, and it specified code size `5` instead of `4`.
Now, the test data is captured from compiler output, and it provides the right value.

### Error handling for `MethodBody`

The mistake in the test data revealed insufficient error handling in the `MethodBody` constructor.
In `Debug` builds, compiler initializes the newly allocated blocks of memory with pattern like `fd fd fd fd`. There is no such initialization in `Release` builds.

As a result, the `InsertSimpleFunction` was working in `Debug` configuration. The `MethodBody` saw that `CodeSize == 5`, and read values from after the end of the input sequence. Fortunately, because of the memory initialization pattern, the bytes `fd fd` did not correspond to any `OpCode`, and were silently ignored. These 2 mistakes compensated each other, and the test was green.

On the contrary, in the `Release` builds, the garbage was turned to an instruction. So we had got 4 expected instruction and 1 garbage "instruction", effectively failing the test.

To fix these:
- `MethodBody` now checks that the incoming `std::vector<std::byte>` really holds at least `CodeSize` bytes in the instructions stream part
- `MethodBody` now throws `std::runtime_error` if it encounters instruction code not corresponding to any known instruction
- Add tests for these two scenarios.