### PR TITLE
Parsing of method signatures

### DIFF
--- a/Drill4dotNet/Drill4dotNet-Tests/Drill4dotNet-Tests.vcxproj
+++ b/Drill4dotNet/Drill4dotNet-Tests/Drill4dotNet-Tests.vcxproj
@@ -84,6 +84,10 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Use</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Use</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="..\Drill4dotNet\Signature.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Use</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Use</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="ByteUtilsTests.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Use</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Use</PrecompiledHeader>
@@ -129,6 +133,10 @@
     </ClCompile>
     <ClCompile Include="$(SolutionDir)dependencies\googletest\googlemock\src\gmock-all.cc">
       <PreprocessorDefinitions>;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="SignatureTests.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Use</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Use</PrecompiledHeader>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/Drill4dotNet/Drill4dotNet-Tests/Drill4dotNet-Tests.vcxproj.filters
+++ b/Drill4dotNet/Drill4dotNet-Tests/Drill4dotNet-Tests.vcxproj.filters
@@ -62,6 +62,12 @@
     <ClCompile Include="..\Drill4dotNet\CProfilerCallbackBase.cpp">
       <Filter>Tested Source</Filter>
     </ClCompile>
+    <ClCompile Include="..\Drill4dotNet\Signature.cpp">
+      <Filter>Tested Source</Filter>
+    </ClCompile>
+    <ClCompile Include="SignatureTests.cpp">
+      <Filter>Unit Tests</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />

--- a/Drill4dotNet/Drill4dotNet-Tests/MetadataImportMock.h
+++ b/Drill4dotNet/Drill4dotNet-Tests/MetadataImportMock.h
@@ -55,6 +55,10 @@ namespace Drill4dotNet
         MOCK_METHOD(std::optional<std::vector<mdMethodDef>>, TryEnumMethodsWithName, (const mdTypeDef enclosingType, const std::wstring& name), (const));
         MOCK_METHOD(mdTypeDef, FindTypeDefByName, (const std::wstring& name, const mdToken enclosingClass), (const));
         MOCK_METHOD(std::optional<mdTypeDef>, TryFindTypeDefByName, (const std::wstring& name, const mdTypeDef enclosingType), (const));
+        MOCK_METHOD(MemberReferenceProps, GetMemberReferenceProps, (const mdMemberRef memberToken), (const));
+        MOCK_METHOD(std::optional<MemberReferenceProps>, TryGetMemberReferenceProps, (const mdMemberRef memberToken), (const));
+        MOCK_METHOD(std::vector<std::byte>, GetSignatureBlob, (const mdSignature signatureToken), (const));
+        MOCK_METHOD(std::optional<std::vector<std::byte>>, TryGetSignatureBlob, (const mdSignature signatureToken), (const));
     };
 
     static_assert(IMetadataImport<MetadataImportMock>);

--- a/Drill4dotNet/Drill4dotNet-Tests/SignatureTests.cpp
+++ b/Drill4dotNet/Drill4dotNet-Tests/SignatureTests.cpp
@@ -1,5 +1,201 @@
 #include "pch.h"
 
 #include "Signature.h"
+#include <algorithm>
 
 using namespace Drill4dotNet;
+
+static const std::vector<int32_t> s_SignedValues {
+    3,
+    -3,
+    64,
+    -64,
+    8'192,
+    -8'192,
+    268'435'455,
+    -268'435'456
+};
+
+static const std::vector<std::vector<std::byte>> s_SignedBytes {
+    {
+        std::byte { 0x06 }
+    },
+    {
+        std::byte { 0x7B }
+    },
+    {
+        std::byte { 0x80 },
+        std::byte { 0x80 }
+    },
+    {
+        std::byte { 0x01 }
+    },
+    {
+        std::byte { 0xC0 },
+        std::byte { 0x00 },
+        std::byte { 0x40 },
+        std::byte { 0x00 }
+    },
+    {
+        std::byte { 0x80 },
+        std::byte { 0x01 }
+    },
+    {
+        std::byte { 0xDF },
+        std::byte { 0xFF },
+        std::byte { 0xFF },
+        std::byte { 0xFE }
+    },
+    {
+        std::byte { 0xC0 },
+        std::byte { 0x00 },
+        std::byte { 0x00 },
+        std::byte { 0x01 }
+    }
+};
+
+static const std::vector<uint32_t> s_UnsignedValues {
+    0x03,
+    0x7F,
+    0x80,
+    0x2E57,
+    0x3FFF,
+    0x4000,
+    0x1FFF'FFFF
+};
+
+static const std::vector<std::vector<std::byte>> s_UnsignedBytes {
+    {
+        std::byte { 0x03 }
+    },
+    {
+        std::byte { 0x7F }
+    },
+    {
+        std::byte { 0x80 },
+        std::byte { 0x80 }
+    },
+    {
+        std::byte { 0xAE },
+        std::byte { 0x57 }
+    },
+    {
+        std::byte { 0xBF },
+        std::byte { 0xFF }
+    },
+    {
+        std::byte { 0xC0 },
+        std::byte { 0x00 },
+        std::byte { 0x40 },
+        std::byte { 0x00 }
+    },
+    {
+        std::byte { 0xDF },
+        std::byte { 0xFF },
+        std::byte { 0xFF },
+        std::byte { 0xFF }
+    }
+};
+
+TEST(SignatureTests, CompressSignatureIntegerSigned)
+{
+    // Arrange
+    const std::vector<int32_t>& inputs { s_SignedValues };
+    const std::vector<std::vector<std::byte>>& expectedResults { s_SignedBytes };
+
+    // Act
+    std::vector results(inputs.size(), std::vector<std::byte>{});
+    std::transform(
+        inputs.cbegin(),
+        inputs.cend(),
+        results.begin(),
+        [](const int32_t input)
+        {
+            return CompressSignatureInteger(input);
+        });
+
+    // Assert
+    EXPECT_EQ(expectedResults, results);
+}
+
+TEST(SignatureTests, CompressSignatureIntegerUnsigned)
+{
+    // Arrange
+    const std::vector<uint32_t>& inputs { s_UnsignedValues };
+    const std::vector<std::vector<std::byte>>& expectedResults { s_UnsignedBytes };
+
+    // Act
+    std::vector results(inputs.size(), std::vector<std::byte>{});
+    std::transform(
+        inputs.cbegin(),
+        inputs.cend(),
+        results.begin(),
+        [](const uint32_t input)
+        {
+            return CompressSignatureInteger(input);
+        });
+
+    // Assert
+    EXPECT_EQ(expectedResults, results);
+}
+
+TEST(SignatureTests, DecompressSignatureSignedInteger)
+{
+    // Arrange
+    const std::vector<std::vector<std::byte>>& inputs { s_SignedBytes };
+
+    const std::vector<ParseResult<int32_t>> expectedResults {
+        { inputs[0].size(), s_SignedValues[0] },
+        { inputs[1].size(), s_SignedValues[1] },
+        { inputs[2].size(), s_SignedValues[2] },
+        { inputs[3].size(), s_SignedValues[3] },
+        { inputs[4].size(), s_SignedValues[4] },
+        { inputs[5].size(), s_SignedValues[5] },
+        { inputs[6].size(), s_SignedValues[6] },
+        { inputs[7].size(), s_SignedValues[7] }
+    };
+
+    // Act
+    std::vector<ParseResult<int32_t>> results{};
+    std::transform(
+        inputs.cbegin(),
+        inputs.cend(),
+        std::back_inserter(results),
+        [](const std::vector<std::byte>& input)
+        {
+            return DecompressSignatureSignedInteger(input.cbegin(), input.cend());
+        });
+
+    // Assert
+    EXPECT_EQ(expectedResults, results);
+}
+
+TEST(SignatureTests, DecompressSignatureUnsignedInteger)
+{
+    // Arrange
+    const std::vector<std::vector<std::byte>>& inputs { s_UnsignedBytes };
+
+    const std::vector<ParseResult<uint32_t>> expectedResults{
+        { inputs[0].size(), s_UnsignedValues[0] },
+        { inputs[1].size(), s_UnsignedValues[1] },
+        { inputs[2].size(), s_UnsignedValues[2] },
+        { inputs[3].size(), s_UnsignedValues[3] },
+        { inputs[4].size(), s_UnsignedValues[4] },
+        { inputs[5].size(), s_UnsignedValues[5] },
+        { inputs[6].size(), s_UnsignedValues[6] }
+    };
+
+    // Act
+    std::vector<ParseResult<uint32_t>> results{};
+    std::transform(
+        inputs.cbegin(),
+        inputs.cend(),
+        std::back_inserter(results),
+        [](const std::vector<std::byte>& input)
+    {
+        return DecompressSignatureUnsignedInteger(input.cbegin(), input.cend());
+    });
+
+    // Assert
+    EXPECT_EQ(expectedResults, results);
+}

--- a/Drill4dotNet/Drill4dotNet-Tests/SignatureTests.cpp
+++ b/Drill4dotNet/Drill4dotNet-Tests/SignatureTests.cpp
@@ -1,0 +1,5 @@
+#include "pch.h"
+
+#include "Signature.h"
+
+using namespace Drill4dotNet;

--- a/Drill4dotNet/Drill4dotNet/CProfilerCallback.h
+++ b/Drill4dotNet/Drill4dotNet/CProfilerCallback.h
@@ -13,6 +13,7 @@
 #include "IMetadataDispenser.h"
 #include "Connector.h"
 #include "ProClient.h"
+#include "Signature.h"
 
 namespace Drill4dotNet
 {
@@ -668,6 +669,13 @@ namespace Drill4dotNet
 
                 const FunctionInfo functionInfo { GetFunctionInfo(moduleMetaData, functionInfoWithoutName) };
 
+                const std::vector<std::byte> signatureBytes { moduleMetaData
+                    .GetMethodProps(functionInfo.token)
+                    .SignatureBlob };
+
+                const ParseResult<MethodSignature> signature {
+                    MethodSignature::Parse(signatureBytes.cbegin(), signatureBytes.cend()) };
+
                 const std::vector<std::byte> functionBytes {
                     m_corProfilerInfo->GetMethodIntermediateLanguageBody(functionInfo) };
 
@@ -675,7 +683,11 @@ namespace Drill4dotNet
                     << L"Compiling function "
                     << InSquareBrackets(functionId)
                     << L" "
+                    << signature.ParsedValue.WritePreamble()
+                    << L" "
                     << functionInfo.fullName()
+                    << L" "
+                    << signature.ParsedValue.WriteParameters()
                     << L" IL Body size: "
                     << functionBytes.size()
                     << L" bytes";

--- a/Drill4dotNet/Drill4dotNet/CorDataStructures.h
+++ b/Drill4dotNet/Drill4dotNet/CorDataStructures.h
@@ -113,5 +113,13 @@ namespace Drill4dotNet
         DWORD Attributes;
         ULONG CodeRelativeVirtualAddress;
         DWORD ImplementationFlags;
+        std::vector<std::byte> SignatureBlob;
+    };
+
+    struct MemberReferenceProps
+    {
+        mdToken EnclosingClass;
+        std::wstring Name;
+        std::vector<std::byte> SignatureBlob;
     };
 }

--- a/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj
+++ b/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj
@@ -158,6 +158,7 @@
     <ClInclude Include="pch.h" />
     <ClInclude Include="ProClient.h" />
     <ClInclude Include="Resource.h" />
+    <ClInclude Include="Signature.h" />
     <ClInclude Include="targetver.h" />
     <ClInclude Include="OutputUtils.h" />
     <ClInclude Include="UnDefineOpCodesGeneratorSpecializations.h" />
@@ -183,6 +184,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="Signature.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="Drill4dotNet.rc" />

--- a/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj.filters
+++ b/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj.filters
@@ -124,6 +124,9 @@
     <ClInclude Include="ComInitializer.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Signature.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Drill4dotNet.cpp">
@@ -166,6 +169,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="CProfilerCallbackBase.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Signature.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Drill4dotNet/Drill4dotNet/IMetadataImport.h
+++ b/Drill4dotNet/Drill4dotNet/IMetadataImport.h
@@ -57,5 +57,21 @@ namespace Drill4dotNet
         { x.TryFindTypeDefByName(
             std::declval<const std::wstring&>(),
             std::declval<const mdToken>()) } -> std::same_as<std::optional<mdTypeDef>>;
+
+        // Gets the properties of the referenced member.
+        // Throws _com_error on errors.
+        { x.GetMemberReferenceProps(std::declval<const mdMemberRef>()) } -> std::same_as<MemberReferenceProps>;
+
+        // Gets the properties of the referenced member.
+        // Returns std::nullopt on errors.
+        { x.TryGetMemberReferenceProps(std::declval<const mdMemberRef>()) } -> std::same_as<std::optional<MemberReferenceProps>>;
+
+        // Gets the raw bytes of the signature.
+        // Throws _com_error on errors.
+        { x.GetSignatureBlob(std::declval<const mdSignature>()) } -> std::same_as<std::vector<std::byte>>;
+
+        // Gets the raw bytes of the signature.
+        // Returns std::nullopt in case of errors.
+        { x.TryGetSignatureBlob(std::declval<const mdSignature>()) } -> std::same_as<std::optional<std::vector<std::byte>>>;
     };
 }

--- a/Drill4dotNet/Drill4dotNet/OutputUtils.h
+++ b/Drill4dotNet/Drill4dotNet/OutputUtils.h
@@ -120,7 +120,7 @@ namespace Drill4dotNet
                 << std::hex
                 << std::uppercase
                 << std::setw(width)
-                << std::setfill(L'0')
+                << std::setfill(TChar { '0' })
                 << value.m_value;
 
             return target;

--- a/Drill4dotNet/Drill4dotNet/Signature.cpp
+++ b/Drill4dotNet/Drill4dotNet/Signature.cpp
@@ -1,6 +1,1369 @@
 #include "pch.h"
 #include "Signature.h"
 
+#include <algorithm>
+#include <bitset>
+
 namespace Drill4dotNet
 {
+    static constexpr int32_t ReEncodeTwosComplement(
+        const int32_t value,
+        const uint32_t sourceBits,
+        const uint32_t resultBits)
+    {
+        std::bitset<32> valueBits(static_cast<uint32_t>(value));
+        const bool isPositive { std::as_const(valueBits)[sourceBits - 1] == false };
+        if (isPositive)
+        {
+            return value;
+        }
+
+        const auto [startFlip, endFlip] { std::minmax(sourceBits, resultBits) };
+        for (size_t i { startFlip }; i != endFlip; ++i)
+        {
+            valueBits.flip(i);
+        }
+
+        return static_cast<int32_t>(valueBits.to_ulong());
+    }
+
+    template <typename TUnsignedInteger>
+    static constexpr TUnsignedInteger RotateLeft(
+        const TUnsignedInteger value,
+        const uint32_t width,
+        const uint32_t bits)
+    {
+        return ~(0xFFFF'FFFF << width) & ((value << bits) | (value >> (width - bits)));
+    }
+
+    template <typename TUnsignedInteger>
+    static constexpr TUnsignedInteger RotateRight(
+        const TUnsignedInteger value,
+        const uint32_t width,
+        const uint32_t bits)
+    {
+        return ~(0xFFFF'FFFF << width) & ((value >> bits) | (value << (width - bits)));
+    }
+
+    static const std::byte s_TwoByteEncodingMarker { 0x80 };
+    static const std::byte s_FourByteEncodingMarker{ 0xC0 };
+
+    std::vector<std::byte> CompressSignatureInteger(const int32_t signedValue)
+    {
+        if (-(1 << 6) <= signedValue && signedValue <= (1 << 6) - 1)
+        {
+            const uint8_t value { RotateLeft(
+                static_cast<uint8_t>(ReEncodeTwosComplement(
+                    signedValue,
+                    32,
+                    7)),
+                7,
+                1) };
+
+            return {
+                std::byte { value }
+            };
+        }
+        else if (-(1 << 13) <= signedValue && signedValue <= (1 << 13) - 1)
+        {
+            const uint16_t value { RotateLeft(
+                static_cast<uint16_t>(ReEncodeTwosComplement(
+                    signedValue,
+                    32,
+                    14)),
+                14,
+                1) };
+
+            return {
+                s_TwoByteEncodingMarker | std::byte { value >> 8 },
+                std::byte { value }
+            };
+        }
+        else if (MinCompressedSignatureInteger <= signedValue && signedValue <= MaxCompressedSignatureInteger)
+        {
+            const uint32_t value { RotateLeft(
+                static_cast<uint32_t>(ReEncodeTwosComplement(
+                    signedValue,
+                    32,
+                    29)),
+                29,
+                1) };
+
+            return {
+                s_FourByteEncodingMarker | std::byte { value >> 24 },
+                std::byte { value >> 16 },
+                std::byte { value >> 8 },
+                std::byte { value }
+            };
+        }
+        else
+        {
+            throw std::range_error("The given integer cannot be encoded to be stored in a signature.");
+        }
+    }
+
+    std::vector<std::byte> CompressSignatureInteger(const uint32_t unsignedValue)
+    {
+        if (unsignedValue <= 0x7F)
+        {
+            return {
+                std::byte { unsignedValue }
+            };
+        }
+        else if (0x80 <= unsignedValue && unsignedValue <= 0x3FFF)
+        {
+            return {
+                s_TwoByteEncodingMarker | std::byte { unsignedValue >> 8 },
+                std::byte { unsignedValue }
+            };
+        }
+        else if (unsignedValue <= MaxCompressedSignatureUnsignedInteger)
+        {
+            return {
+                s_FourByteEncodingMarker | std::byte { unsignedValue >> 24 },
+                std::byte { unsignedValue >> 16 },
+                std::byte { unsignedValue >> 8 },
+                std::byte { unsignedValue }
+            };
+        }
+        else
+        {
+            throw std::range_error("The given integer cannot be encoded to be stored in a signature.");
+        }
+    }
+
+    class DecomplessIntegerCoreResult
+    {
+    public:
+        uint32_t Value;
+        uint32_t MeaningfulBits;
+        size_t BytesTaken;
+    };
+
+    DecomplessIntegerCoreResult DecomplessIntegerCore(
+        const std::vector<std::byte>::const_iterator integerPosition,
+        const std::vector<std::byte>::const_iterator sourceEnd)
+    {
+
+        if (integerPosition == sourceEnd)
+        {
+            throw std::runtime_error("Encoded integer value was expected");
+        }
+
+        const std::byte firstByte { *integerPosition };
+        const size_t size { (firstByte & s_FourByteEncodingMarker) == s_FourByteEncodingMarker
+            ? size_t { 4 }
+            : ((firstByte & s_TwoByteEncodingMarker) == s_TwoByteEncodingMarker
+                ? size_t { 2 }
+                : 1) };
+        if (sourceEnd - integerPosition < size)
+        {
+            throw std::runtime_error("Encoded integer value ended expectedly");
+        }
+
+        if (size == 1)
+        {
+            return {
+                static_cast<uint32_t>(firstByte),
+                7,
+                size
+            };
+        }
+
+        std::vector<std::byte>::const_iterator position { integerPosition };
+        ++position;
+        const std::byte secondByte { *position };
+        if (size == 2)
+        {
+            return {
+                (static_cast<uint32_t>(firstByte & ~s_TwoByteEncodingMarker) << 8)
+                    | static_cast<uint32_t>(secondByte),
+                14,
+                size
+            };
+        }
+
+        ++position;
+        const std::byte thirdByte { *position };
+
+        ++position;
+        const std::byte forthByte { *position };
+
+        return {
+            (static_cast<uint32_t>(firstByte & ~s_FourByteEncodingMarker) << 24)
+                | (static_cast<uint32_t>(secondByte) << 16)
+                | (static_cast<uint32_t>(thirdByte) << 8)
+                | static_cast<uint32_t>(forthByte),
+            29,
+            size
+        };
+    }
+
+    ParseResult<int32_t> DecompressSignatureSignedInteger(
+        const std::vector<std::byte>::const_iterator integerPosition,
+        const std::vector<std::byte>::const_iterator sourceEnd)
+    {
+        const auto result = DecomplessIntegerCore(integerPosition, sourceEnd);
+        return {
+            result.BytesTaken,
+            ReEncodeTwosComplement(
+                static_cast<int32_t>(
+                    RotateRight(
+                        result.Value,
+                        result.MeaningfulBits,
+                        1)),
+                result.MeaningfulBits,
+                32)
+        };
+    }
+
+    ParseResult<uint32_t> DecompressSignatureUnsignedInteger(
+        const std::vector<std::byte>::const_iterator integerPosition,
+        const std::vector<std::byte>::const_iterator sourceEnd)
+    {
+        const auto result = DecomplessIntegerCore(integerPosition, sourceEnd);
+        return {
+            result.BytesTaken,
+            result.Value
+        };
+    }
+
+    MethodSignature::MethodSignature(
+        const MethodSignatureKind kind,
+        const MethodThisUsage thisUsage,
+        const MethodCallingConvention callingConvention,
+        std::vector<ParameterType> parameterTypes,
+        Drill4dotNet::ReturnType returnType,
+        std::optional<size_t> genericParameters,
+        std::optional<VarArgDescription> varArg)
+        : m_kind { kind },
+        m_thisUsage { thisUsage },
+        m_callingConvention { callingConvention }
+    {
+        if (kind != MethodSignatureKind::FreeStandingSignature
+            && callingConvention != MethodCallingConvention::Default)
+        {
+            throw std::logic_error("Native calling conventions are only allowed for Free Standing signatures");
+        }
+
+        if (callingConvention != MethodCallingConvention::Default
+            && genericParameters.has_value())
+        {
+            throw std::logic_error("Method with unmanaged calling convention cannot be generic");
+        }
+
+        if (kind == MethodSignatureKind::MethodInSameAssembly
+            && varArg.has_value()
+            && varArg->OptionalParametersCount != 0)
+        {
+            throw std::logic_error("Method in the same assembly cannot have optional parameters info");
+        }
+
+        if (m_genericParameters.has_value()
+            && *m_genericParameters > MaxCompressedSignatureUnsignedInteger)
+        {
+            throw std::runtime_error("The signature contains too many generic parameters");
+        }
+
+        if (parameterTypes.size() > MaxCompressedSignatureUnsignedInteger)
+        {
+            throw std::runtime_error("The signature contains too many parameters");
+        }
+
+        m_parameterTypes = std::move(parameterTypes);
+        m_returnType = std::move(returnType);
+        m_genericParameters = std::move(genericParameters);
+        m_varArg = std::move(varArg);
+    }
+
+    ParseResult<MethodSignature> MethodSignature::Parse(
+        const std::vector<std::byte>::const_iterator position,
+        const std::vector<std::byte>::const_iterator end)
+    {
+        if (position == end)
+        {
+            throw std::runtime_error("MethodSignature bytes must not be empty");
+        }
+
+        std::optional<MethodSignatureKind> kind {};
+        MethodThisUsage thisUsage;
+        const CorCallingConvention flags {
+            static_cast<CorCallingConvention>(*position) };
+        if ((flags & IMAGE_CEE_CS_CALLCONV_EXPLICITTHIS) != 0)
+        {
+            thisUsage = MethodThisUsage::ExplicitThis;
+        }
+        else if ((flags & IMAGE_CEE_CS_CALLCONV_HASTHIS) != 0)
+        {
+            thisUsage = MethodThisUsage::This;
+        }
+        else
+        {
+            thisUsage = MethodThisUsage::NoThis;
+        }
+
+        MethodCallingConvention callingConvention;
+        const bool isVarArg { (flags & IMAGE_CEE_CS_CALLCONV_VARARG) != 0 };
+        const bool isGeneric { (flags & IMAGE_CEE_CS_CALLCONV_GENERIC) != 0 };
+        if ((flags & IMAGE_CEE_CS_CALLCONV_C) != 0)
+        {
+            callingConvention = MethodCallingConvention::C;
+            kind = MethodSignatureKind::FreeStandingSignature;
+        }
+        else if ((flags & IMAGE_CEE_CS_CALLCONV_STDCALL) != 0)
+        {
+            callingConvention = MethodCallingConvention::StdCall;
+            kind = MethodSignatureKind::FreeStandingSignature;
+        }
+        else if ((flags & IMAGE_CEE_CS_CALLCONV_THISCALL) != 0)
+        {
+            callingConvention = MethodCallingConvention::ThisCall;
+            kind = MethodSignatureKind::FreeStandingSignature;
+        }
+        else if ((flags & IMAGE_CEE_CS_CALLCONV_FASTCALL) != 0)
+        {
+            callingConvention = MethodCallingConvention::FastCall;
+            kind = MethodSignatureKind::FreeStandingSignature;
+        }
+        else
+        {
+            callingConvention = MethodCallingConvention::Default;
+        }
+
+        std::optional<size_t> genericParameters{};
+        size_t current { 1 };
+        if (isGeneric)
+        {
+            if (kind.has_value())
+            {
+                throw std::runtime_error("Method with unmanaged calling convention cannot be generic");
+            }
+
+            const auto genericParametersCount {
+                DecompressSignatureUnsignedInteger(
+                    position + current,
+                    end) };
+
+            genericParameters = genericParametersCount.ParsedValue;
+            current += genericParametersCount.BytesTaken;
+        }
+
+        const auto parametersCount{
+            DecompressSignatureUnsignedInteger(
+                position + current,
+                end) };
+        current += parametersCount.BytesTaken;
+
+        // parse RetType
+        auto returnType { ReturnType::Parse(position + current, end) };
+        current += returnType.BytesTaken;
+
+        // parse Parameters
+        std::optional<VarArgDescription> varArg{};
+        std::vector<ParameterType> parameterTypes{};
+        parameterTypes.reserve(parametersCount.ParsedValue);
+        for (uint32_t i { 0 }; i != parametersCount.ParsedValue; ++i)
+        {
+            if (isVarArg
+                && position + current != end
+                && *(position + current) == std::byte { CorElementType::ELEMENT_TYPE_SENTINEL })
+            {
+                if (kind.has_value() && *kind == MethodSignatureKind::MethodInSameAssembly)
+                {
+                    throw std::runtime_error("Method in the same assembly cannot have optional parameters info");
+                }
+
+                if (!kind.has_value())
+                {
+                    kind = MethodSignatureKind::MethodInDifferentAssembly;
+                }
+
+                varArg = VarArgDescription {
+                    i,
+                    parametersCount.ParsedValue - i };
+                ++current;
+            }
+
+            auto parameterType { ParameterType::Parse(position + current, end) };
+            current += parameterType.BytesTaken;
+            parameterTypes.push_back(std::move(parameterType.ParsedValue));
+        }
+
+        if (isVarArg)
+        {
+            varArg = VarArgDescription { parametersCount.ParsedValue, 0 };
+        }
+
+        if (!kind.has_value())
+        {
+            kind = MethodSignatureKind::MethodInSameAssembly;
+        }
+
+        return { current,
+            {
+                *kind,
+                thisUsage,
+                callingConvention,
+                std::move(parameterTypes),
+                std::move(returnType.ParsedValue),
+                genericParameters,
+                varArg } };
+    }
+
+    void MethodSignature::AppendToBytes(std::vector<std::byte>& target) const
+    {
+        std::byte firstByte;
+        switch (m_thisUsage)
+        {
+        case MethodThisUsage::NoThis:
+            firstByte = std::byte { 0 };
+            break;
+        case MethodThisUsage::This:
+            firstByte = std::byte { IMAGE_CEE_CS_CALLCONV_HASTHIS };
+            break;
+        case MethodThisUsage::ExplicitThis:
+            firstByte = std::byte { IMAGE_CEE_CS_CALLCONV_EXPLICITTHIS };
+            break;
+        default:
+            throw std::logic_error("Must handle this variant of this usage");
+        }
+
+        switch (m_callingConvention)
+        {
+        case MethodCallingConvention::Default:
+            firstByte |= std::byte { IMAGE_CEE_CS_CALLCONV_DEFAULT };
+            break;
+        case MethodCallingConvention::C:
+            firstByte |= std::byte { IMAGE_CEE_CS_CALLCONV_C };
+            break;
+        case MethodCallingConvention::StdCall:
+            firstByte |= std::byte { IMAGE_CEE_CS_CALLCONV_STDCALL };
+            break;
+        case MethodCallingConvention::FastCall:
+            firstByte |= std::byte { IMAGE_CEE_CS_CALLCONV_FASTCALL };
+            break;
+        case MethodCallingConvention::ThisCall:
+            firstByte |= std::byte { IMAGE_CEE_CS_CALLCONV_THISCALL };
+            break;
+        }
+
+        if (m_varArg.has_value())
+        {
+            firstByte |= std::byte { IMAGE_CEE_CS_CALLCONV_VARARG };
+        }
+
+        if (m_genericParameters.has_value())
+        {
+            firstByte |= std::byte { IMAGE_CEE_CS_CALLCONV_GENERIC };
+        }
+
+        target.push_back(firstByte);
+
+        if (m_genericParameters.has_value())
+        {
+            const std::vector<std::byte> genericParametersCount {
+                CompressSignatureInteger(static_cast<uint32_t>(*m_genericParameters)) };
+            std::copy(
+                genericParametersCount.cbegin(),
+                genericParametersCount.cend(),
+                std::back_inserter(target));
+        }
+
+        const std::vector<std::byte> parametersCount {
+            CompressSignatureInteger(static_cast<uint32_t>(m_parameterTypes.size())) };
+        std::copy(
+            parametersCount.cbegin(),
+            parametersCount.cend(),
+            std::back_inserter(target));
+
+        m_returnType.AppendToBytes(target);
+
+        for (size_t i { 0 }; i != m_parameterTypes.size(); ++i)
+        {
+            if (m_varArg.has_value()
+                && i == m_varArg->RequiredParametersCount
+                && m_varArg->OptionalParametersCount == 0)
+            {
+                target.push_back(std::byte { CorElementType::ELEMENT_TYPE_SENTINEL });
+            }
+
+            m_parameterTypes[i].AppendToBytes(target);
+        }
+    }
+
+    ParseResult<ArrayShape> ArrayShape::Parse(
+        const std::vector<std::byte>::const_iterator position,
+        const std::vector<std::byte>::const_iterator end)
+    {
+        std::vector<std::byte>::const_iterator current { position };
+        size_t bytesTaken { 0 };
+        const auto rank { DecompressSignatureUnsignedInteger(current, end) };
+        current += rank.BytesTaken;
+        bytesTaken += rank.BytesTaken;
+
+        ArrayShape result{};
+        result.Rank = rank.ParsedValue;
+
+        const auto numSizes { DecompressSignatureUnsignedInteger(current, end) };
+        current += numSizes.BytesTaken;
+        bytesTaken += numSizes.BytesTaken;
+
+        for (uint32_t i { 0 }; i != numSizes.ParsedValue; ++i)
+        {
+            const auto size { DecompressSignatureUnsignedInteger(current, end) };
+            current += size.BytesTaken;
+            bytesTaken += size.BytesTaken;
+            result.Sizes.push_back(size.ParsedValue);
+        }
+
+        const auto numLowerbounds { DecompressSignatureUnsignedInteger(current, end) };
+        current += numLowerbounds.BytesTaken;
+        bytesTaken += numLowerbounds.BytesTaken;
+
+        for (uint32_t i { 0 }; i != numLowerbounds.ParsedValue; ++i)
+        {
+            const auto lowerbound { DecompressSignatureSignedInteger(current, end) };
+            current += lowerbound.BytesTaken;
+            bytesTaken += lowerbound.BytesTaken;
+            result.LowerBounds.push_back(lowerbound.ParsedValue);
+        }
+
+        return { bytesTaken, result };
+    }
+
+    void ArrayShape::AppendToBytes(std::vector<std::byte>& target) const
+    {
+        const std::vector<std::byte> rankBytes { CompressSignatureInteger(Rank) };
+        target.insert(
+            target.cend(),
+            rankBytes.cbegin(),
+            rankBytes.cend());
+
+        if (Sizes.size() > MaxCompressedSignatureUnsignedInteger)
+        {
+            throw std::runtime_error("The Sizes vector contains too much elements to store in an ArrayShape");
+        }
+
+        const std::vector<std::byte> numSizesBytes { CompressSignatureInteger(static_cast<uint32_t>(Sizes.size())) };
+        target.insert(
+            target.cend(),
+            numSizesBytes.cbegin(),
+            numSizesBytes.cend());
+
+        for (const auto& size : Sizes)
+        {
+            const std::vector<std::byte> sizeBytes { CompressSignatureInteger(size) };
+            target.insert(
+                target.cend(),
+                sizeBytes.cbegin(),
+                sizeBytes.cend());
+        }
+
+        if (LowerBounds.size() > MaxCompressedSignatureUnsignedInteger)
+        {
+            throw std::runtime_error("The LowerBounds vector contains too much elements to store in an ArrayShape");
+        }
+
+        const std::vector<std::byte> lowerBoundsBytes { CompressSignatureInteger(static_cast<uint32_t>(LowerBounds.size())) };
+        target.insert(
+            target.cend(),
+            lowerBoundsBytes.cbegin(),
+            lowerBoundsBytes.cend());
+
+        for (const auto& bound : LowerBounds)
+        {
+            const std::vector<std::byte> boundBytes { CompressSignatureInteger(bound) };
+            target.insert(
+                target.cend(),
+                boundBytes.cbegin(),
+                boundBytes.cend());
+        }
+    }
+
+    ParseResult<mdToken> DecompressTypeDefOrRefOrSpecEncoded(
+        const std::vector<std::byte>::const_iterator position,
+        const std::vector<std::byte>::const_iterator end)
+    {
+        const auto intermediate { DecompressSignatureUnsignedInteger(position, end) };
+        mdToken kind;
+        switch (intermediate.ParsedValue & 0b11)
+        {
+        case 0b00:
+            kind = mdtTypeDef;
+            break;
+        case 0b01:
+            kind = mdtTypeRef;
+            break;
+        case 0b10:
+            kind = mdtTypeSpec;
+            break;
+        default:
+            throw std::runtime_error("The TypeDefOrRefOrSpecEncoded has invalid token type flag");
+        }
+
+        return { intermediate.BytesTaken, kind | (intermediate.ParsedValue >> 2) };
+    }
+
+    void CompressTypeDefOrRefOrSpecEncoded(
+        const mdToken typeToken,
+        std::vector<std::byte>& target)
+    {
+        uint32_t intermediate;
+        switch (typeToken & 0xFF00'0000)
+        {
+        case mdtTypeDef:
+            intermediate = 0;
+            break;
+        case mdtTypeRef:
+            intermediate = 1;
+            break;
+        case mdtTypeSpec:
+            intermediate = 1;
+            break;
+        default:
+            throw std::logic_error("This type of token is not expected here");
+        }
+
+        intermediate |= ((typeToken & 0x00FF'FFFF) << 2);
+        const std::vector<std::byte> tokenBytes { CompressSignatureInteger(intermediate) };
+        target.insert(
+            target.cend(),
+            tokenBytes.cbegin(),
+            tokenBytes.cend());
+    }
+
+    std::optional<ParseResult<CustomMod>> CustomMod::Parse(
+        const std::vector<std::byte>::const_iterator position,
+        const std::vector<std::byte>::const_iterator end)
+    {
+        if (position == end)
+        {
+            return std::nullopt;
+        }
+
+        const std::byte requiredByte { *position };
+        bool required;
+        switch (requiredByte)
+        {
+        case std::byte{ ELEMENT_TYPE_CMOD_OPT }:
+            required = false;
+            break;
+        case std::byte{ ELEMENT_TYPE_CMOD_REQD }:
+            required = true;
+            break;
+        default:
+            return std::nullopt;
+        };
+
+        const auto typeToken = DecompressTypeDefOrRefOrSpecEncoded(position + 1, end);
+        ParseResult<CustomMod> result;
+        result.BytesTaken = typeToken.BytesTaken + 1;
+        result.ParsedValue = CustomMod { required, typeToken.ParsedValue };
+        return result;
+    }
+
+    void CustomMod::AppendToBytes(std::vector<std::byte>& target) const
+    {
+        target.push_back(Required
+            ? std::byte { ELEMENT_TYPE_CMOD_REQD }
+            : std::byte { ELEMENT_TYPE_CMOD_OPT });
+
+        CompressTypeDefOrRefOrSpecEncoded(TypeToken, target);
+    }
+
+    ParseResult<std::vector<CustomMod>> CustomMod::ParseSeveral(
+        const std::vector<std::byte>::const_iterator position,
+        const std::vector<std::byte>::const_iterator end)
+    {
+        size_t bytesTaken { 0 };
+        std::vector<CustomMod> result{};
+        while (true)
+        {
+            auto customMod { CustomMod::Parse(position + bytesTaken, end) };
+            if (!customMod.has_value())
+            {
+                return { bytesTaken, std::move(result) };
+            }
+
+            bytesTaken += customMod->BytesTaken;
+            result.push_back(std::move(customMod->ParsedValue));
+        }
+    }
+
+    void CustomMod::AppendSeveral(
+        const std::vector<CustomMod> customMods,
+        std::vector<std::byte>& target)
+    {
+        for (const auto& customMod : customMods)
+        {
+            customMod.AppendToBytes(target);
+        }
+    }
+
+    ParseResult<ArrayType> ArrayType::Parse(
+        const std::vector<std::byte>::const_iterator position,
+        const std::vector<std::byte>::const_iterator end)
+    {
+        auto typeValue { ParseType(position, end) };
+        auto arrayShape { ArrayShape::Parse(position + typeValue.BytesTaken, end) };
+        return {
+            typeValue.BytesTaken + arrayShape.BytesTaken,
+            { std::move(typeValue.ParsedValue), std::move(arrayShape.ParsedValue) } };
+    }
+
+    void ArrayType::AppendToBytes(std::vector<std::byte>& target) const
+    {
+        AppendTypeToBytes(ElementType(), target);
+        Shape.AppendToBytes(target);
+    }
+
+    ParseResult<ClassType> ClassType::Parse(
+        const std::vector<std::byte>::const_iterator position,
+        const std::vector<std::byte>::const_iterator end)
+    {
+        const auto classToken { DecompressTypeDefOrRefOrSpecEncoded(position, end) };
+        return { classToken.BytesTaken, { classToken.ParsedValue } };
+    }
+
+    void ClassType::AppendToBytes(std::vector<std::byte>& target) const
+    {
+        CompressTypeDefOrRefOrSpecEncoded(Class, target);
+    }
+
+    ParseResult<StructType> StructType::Parse(
+        const std::vector<std::byte>::const_iterator position,
+        const std::vector<std::byte>::const_iterator end)
+    {
+        const auto structToken { DecompressTypeDefOrRefOrSpecEncoded(position, end) };
+        return { structToken.BytesTaken, { structToken.ParsedValue } };
+    }
+
+    void StructType::AppendToBytes(std::vector<std::byte>& target) const
+    {
+        CompressTypeDefOrRefOrSpecEncoded(Struct, target);
+    }
+
+    ParseResult<FunctionPointerType> FunctionPointerType::Parse(
+        const std::vector<std::byte>::const_iterator position,
+        const std::vector<std::byte>::const_iterator end)
+    {
+        auto signatureValue { MethodSignature::Parse(position, end) };
+        return { signatureValue.BytesTaken, { std::move(signatureValue.ParsedValue) } };
+    }
+
+    void FunctionPointerType::AppendToBytes(std::vector<std::byte>& target) const
+    {
+        // Check that only MethodRefSig or MethodDefSig is used
+        const MethodSignatureKind kind { m_targetSignature->Kind() };
+        if (kind != MethodSignatureKind::MethodInSameAssembly
+            && kind != MethodSignatureKind::MethodInDifferentAssembly)
+        {
+            throw std::logic_error("Free standing signatures are not allowed in Type definitions.");
+        }
+
+        m_targetSignature->AppendToBytes(target);
+    }
+
+    ParseResult<GenericInstanceType> GenericInstanceType::Parse(
+        const std::vector<std::byte>::const_iterator position,
+        const std::vector<std::byte>::const_iterator end)
+    {
+        if (position == end)
+        {
+            throw std::runtime_error("Generic type instance definition is expected");
+        }
+
+        const bool isValueType { static_cast<CorElementType>(*position)
+            == CorElementType::ELEMENT_TYPE_VALUETYPE };
+        size_t bytesTaken { 1 };
+
+        const auto genericType { DecompressTypeDefOrRefOrSpecEncoded(position + bytesTaken, end) };
+        bytesTaken += genericType.BytesTaken;
+        const auto genericParametersCount { DecompressSignatureUnsignedInteger(position + bytesTaken, end) };
+        bytesTaken += genericParametersCount.BytesTaken;
+
+        std::vector<Type> genericParameters{};
+        genericParameters.reserve(genericParametersCount.ParsedValue);
+        for (uint32_t i { 0 }; i != genericParametersCount.ParsedValue; ++i)
+        {
+            auto genericParameterValue { ParseType(position + bytesTaken, end) };
+            bytesTaken += genericParameterValue.BytesTaken;
+            genericParameters.push_back(std::move(genericParameterValue.ParsedValue));
+        }
+
+        return { bytesTaken, {
+            isValueType,
+            genericType.ParsedValue,
+            std::move(genericParameters) } };
+    }
+
+    void GenericInstanceType::AppendToBytes(std::vector<std::byte>& target) const
+    {
+        target.push_back(IsValueType
+            ? std::byte { CorElementType::ELEMENT_TYPE_VALUETYPE }
+            : std::byte { CorElementType::ELEMENT_TYPE_CLASS });
+
+        CompressTypeDefOrRefOrSpecEncoded(GenericType, target);
+        if (GenericParameters.size() > MaxCompressedSignatureUnsignedInteger)
+        {
+            throw std::runtime_error("The signature contains too many generic parameters to be stored");
+        }
+
+        const std::vector<std::byte> parametersCount { CompressSignatureInteger(static_cast<uint32_t>(GenericParameters.size())) };
+        std::copy(
+            parametersCount.cbegin(),
+            parametersCount.cend(),
+            std::back_inserter(target));
+
+        for (const auto& genericParameter : GenericParameters)
+        {
+            AppendTypeToBytes(genericParameter, target);
+        }
+    }
+
+    ParseResult<MethodGenericArgument> MethodGenericArgument::Parse(
+        const std::vector<std::byte>::const_iterator position,
+        const std::vector<std::byte>::const_iterator end)
+    {
+        const auto result { DecompressSignatureUnsignedInteger(position, end) };
+        return { result.BytesTaken, { result.ParsedValue } };
+    }
+
+    void MethodGenericArgument::AppendToBytes(std::vector<std::byte>& target) const
+    {
+        const std::vector<std::byte> compressed { CompressSignatureInteger(Index) };
+        std::copy(
+            compressed.cbegin(),
+            compressed.cend(),
+            std::back_inserter(target));
+    }
+
+    ParseResult<TypeGenericArgument> TypeGenericArgument::Parse(
+        const std::vector<std::byte>::const_iterator position,
+        const std::vector<std::byte>::const_iterator end)
+    {
+        const auto result { DecompressSignatureUnsignedInteger(position, end) };
+        return { result.BytesTaken, { result.ParsedValue } };
+    }
+
+    void TypeGenericArgument::AppendToBytes(std::vector<std::byte>& target) const
+    {
+        const std::vector<std::byte> compressed { CompressSignatureInteger(Index) };
+        std::copy(
+            compressed.cbegin(),
+            compressed.cend(),
+            std::back_inserter(target));
+    }
+
+    ParseResult<PointerType> PointerType::Parse(
+        const std::vector<std::byte>::const_iterator position,
+        const std::vector<std::byte>::const_iterator end)
+    {
+        auto customMods { CustomMod::ParseSeveral(position, end) };
+        const auto current = position + customMods.BytesTaken;
+        if (current == end)
+        {
+            throw std::runtime_error("Underlying type for pointer is expected");
+        }
+
+        if (*current == std::byte { CorElementType::ELEMENT_TYPE_VOID })
+        {
+            return {
+                customMods.BytesTaken + 1,
+                {
+                    std::unique_ptr<Type>{},
+                    std::move(customMods.ParsedValue) } };
+        }
+
+        auto valueType { ParseType(current, end) };
+        return {
+            customMods.BytesTaken + valueType.BytesTaken,
+            {
+                std::make_unique<Type>(std::move(valueType.ParsedValue)),
+                std::move(customMods.ParsedValue) } };
+    }
+
+    void PointerType::AppendToBytes(std::vector<std::byte>& target) const
+    {
+        CustomMod::AppendSeveral(CustomMods, target);
+        if (ValueType == nullptr)
+        {
+            target.push_back(std::byte { CorElementType::ELEMENT_TYPE_VOID });
+        }
+        else
+        {
+            AppendTypeToBytes(*ValueType, target);
+        }
+    }
+
+    ParseResult<ZeroBasedArrayType> ZeroBasedArrayType::Parse(
+        const std::vector<std::byte>::const_iterator position,
+        const std::vector<std::byte>::const_iterator end)
+    {
+        auto customMods { CustomMod::ParseSeveral(position, end) };
+        const auto current = position + customMods.BytesTaken;
+        auto elementType { ParseType(current, end) };
+        return {
+            customMods.BytesTaken + elementType.BytesTaken,
+            {
+                std::move(elementType.ParsedValue),
+                std::move(customMods.ParsedValue) } };
+
+    }
+
+    void ZeroBasedArrayType::AppendToBytes(std::vector<std::byte>& target) const
+    {
+        CustomMod::AppendSeveral(CustomMods, target);
+        AppendTypeToBytes(*m_elementType, target);
+    }
+
+    ParseResult<Type> ParseType(
+        const std::vector<std::byte>::const_iterator position,
+        const std::vector<std::byte>::const_iterator end)
+    {
+        if (position == end)
+        {
+            throw std::runtime_error("Type is expected here");
+        }
+
+        const CorElementType type { static_cast<CorElementType>(*position) };
+        const auto next { position + 1 };
+        Type result { PrimitiveType { CorElementType::ELEMENT_TYPE_OBJECT } };
+        size_t bytesTaken { 1 };
+        switch (type)
+        {
+        case ELEMENT_TYPE_BOOLEAN:
+        case ELEMENT_TYPE_CHAR:
+        case ELEMENT_TYPE_I1:
+        case ELEMENT_TYPE_U1:
+        case ELEMENT_TYPE_I2:
+        case ELEMENT_TYPE_U2:
+        case ELEMENT_TYPE_I4:
+        case ELEMENT_TYPE_U4:
+        case ELEMENT_TYPE_I8:
+        case ELEMENT_TYPE_U8:
+        case ELEMENT_TYPE_R4:
+        case ELEMENT_TYPE_R8:
+        case ELEMENT_TYPE_I:
+        case ELEMENT_TYPE_U:
+        case ELEMENT_TYPE_OBJECT:
+        case ELEMENT_TYPE_STRING:
+        {
+            result = PrimitiveType { type };
+        }
+        break;
+
+        case ELEMENT_TYPE_PTR:
+        {
+            auto pointer { PointerType::Parse(next, end) };
+            bytesTaken += pointer.BytesTaken;
+
+            result = std::move(pointer.ParsedValue);
+        }
+        break;
+
+        case ELEMENT_TYPE_VALUETYPE:
+        {
+            auto structType { StructType::Parse(next, end) };
+            bytesTaken += structType.BytesTaken;
+
+            result = std::move(structType.ParsedValue);
+        }
+        break;
+
+        case ELEMENT_TYPE_CLASS:
+        {
+            auto classType { ClassType::Parse(next, end) };
+            bytesTaken += classType.BytesTaken;
+
+            result = std::move(classType.ParsedValue);
+        }
+        break;
+
+        case ELEMENT_TYPE_VAR:
+        {
+            auto var { TypeGenericArgument::Parse(next, end) };
+            bytesTaken += var.BytesTaken;
+
+            result = std::move(var.ParsedValue);
+        }
+        break;
+
+        case ELEMENT_TYPE_ARRAY:
+        {
+            auto arrayType { ArrayType::Parse(next, end) };
+            bytesTaken += arrayType.BytesTaken;
+
+            result = std::move(arrayType.ParsedValue);
+        }
+        break;
+
+        case ELEMENT_TYPE_GENERICINST:
+        {
+            auto genericInstance { GenericInstanceType::Parse(next, end) };
+            bytesTaken += genericInstance.BytesTaken;
+
+            result = std::move(genericInstance.ParsedValue);
+        }
+        break;
+
+        case ELEMENT_TYPE_FNPTR:
+        {
+            auto functionPointer { FunctionPointerType::Parse(next, end) };
+            bytesTaken += functionPointer.BytesTaken;
+
+            result = std::move(functionPointer.ParsedValue);
+        }
+        break;
+
+        case ELEMENT_TYPE_SZARRAY:
+        {
+            auto arrayType { ZeroBasedArrayType::Parse(next, end) };
+            bytesTaken += arrayType.BytesTaken;
+
+            result = std::move(arrayType.ParsedValue);
+        }
+        break;
+
+        case ELEMENT_TYPE_MVAR:
+        {
+            auto var { MethodGenericArgument::Parse(next, end) };
+            bytesTaken += var.BytesTaken;
+
+            result = std::move(var.ParsedValue);
+        }
+        break;
+
+        default:
+            throw std::runtime_error("Unexpected discriminator for Type");
+        }
+
+        return { bytesTaken, std::move(result) };
+    }
+
+    void AppendTypeToBytes(const Type& type, std::vector<std::byte>& target)
+    {
+        std::visit(
+            [&target](const auto& option)
+            {
+                using T = std::decay_t<decltype(option)>;
+                if constexpr (std::is_same_v<T, PrimitiveType>)
+                {
+                    target.push_back(std::byte { option.Type() });
+                    return;
+                }
+                else if constexpr (std::is_same_v<T, ArrayType>)
+                {
+                    target.push_back(std::byte { CorElementType::ELEMENT_TYPE_ARRAY });
+                }
+                else if constexpr (std::is_same_v<T, ClassType>)
+                {
+                    target.push_back(std::byte { CorElementType::ELEMENT_TYPE_CLASS });
+                }
+                else if constexpr (std::is_same_v<T, StructType>)
+                {
+                    target.push_back(std::byte { CorElementType::ELEMENT_TYPE_VALUETYPE });
+                }
+                else if constexpr (std::is_same_v<T, FunctionPointerType>)
+                {
+                    target.push_back(std::byte { CorElementType::ELEMENT_TYPE_FNPTR });
+                }
+                else if constexpr (std::is_same_v<T, GenericInstanceType>)
+                {
+                    target.push_back(std::byte { CorElementType::ELEMENT_TYPE_GENERICINST });
+                }
+                else if constexpr (std::is_same_v<T, MethodGenericArgument>)
+                {
+                    target.push_back(std::byte { CorElementType::ELEMENT_TYPE_MVAR });
+                }
+                else if constexpr (std::is_same_v<T, TypeGenericArgument>)
+                {
+                    target.push_back(std::byte { CorElementType::ELEMENT_TYPE_VAR });
+                }
+                else if constexpr (std::is_same_v<T, PointerType>)
+                {
+                    target.push_back(std::byte { CorElementType::ELEMENT_TYPE_PTR });
+                }
+                else if constexpr (std::is_same_v<T, ZeroBasedArrayType>)
+                {
+                    target.push_back(std::byte { CorElementType::ELEMENT_TYPE_SZARRAY });
+                }
+                else
+                {
+                    throw std::logic_error("Not ready to serialize this kind of Type");
+                }
+
+                if constexpr (!std::is_same_v<T, PrimitiveType>)
+                {
+                    option.AppendToBytes(target);
+                }
+            },
+            type);
+    }
+
+    ParseResult<ParameterType> ParameterType::Parse(
+        const std::vector<std::byte>::const_iterator position,
+        const std::vector<std::byte>::const_iterator end)
+    {
+        auto returnType { ReturnType::Parse(position, end) };
+        if (!returnType.ParsedValue.PassDescription.has_value())
+        {
+            throw std::runtime_error("Void is not allowed in parameter types");
+        }
+
+        return { returnType.BytesTaken,
+            {
+                std::move(returnType.ParsedValue.CustomMods),
+                std::move(*returnType.ParsedValue.PassDescription)
+            } };
+    }
+
+    void AppendPassDescriptionToBytes(
+        const std::variant<ModernParameterPassed, ObsoleteParameterPassed>& passDescription,
+        std::vector<std::byte>& target)
+    {
+        std::visit(
+            [&target](const auto& parameter)
+            {
+                if constexpr (std::is_same_v<std::decay_t<decltype(parameter)>, ObsoleteParameterPassed>)
+                {
+                    target.push_back(std::byte { CorElementType::ELEMENT_TYPE_TYPEDBYREF });
+                }
+                else
+                {
+                    if (parameter.IsPassedByReference)
+                    {
+                        target.push_back(std::byte { CorElementType::ELEMENT_TYPE_BYREF });
+                    }
+
+                    AppendTypeToBytes(parameter.ParameterType, target);
+                }
+            },
+            passDescription);
+    }
+
+    void ParameterType::AppendToBytes(std::vector<std::byte>& target) const
+    {
+        CustomMod::AppendSeveral(CustomMods, target);
+        AppendPassDescriptionToBytes(PassDescription, target);
+    }
+
+    ParseResult<ReturnType> ReturnType::Parse(
+        const std::vector<std::byte>::const_iterator position,
+        const std::vector<std::byte>::const_iterator end)
+    {
+        auto customMods = CustomMod::ParseSeveral(position, end);
+        size_t bytesTaken { customMods.BytesTaken };
+        auto current = position + bytesTaken;
+        if (current == end)
+        {
+            throw std::runtime_error("Parameter type was expected");
+        }
+
+        const std::byte firstByte { *(position + bytesTaken) };
+        if (firstByte == std::byte { CorElementType::ELEMENT_TYPE_VOID })
+        {
+            return {
+                bytesTaken + 1,
+                {
+                    std::move(customMods.ParsedValue),
+                    std::nullopt } };
+        }
+
+        if (firstByte == std::byte { CorElementType::ELEMENT_TYPE_TYPEDBYREF })
+        {
+            return {
+                bytesTaken + 1,
+                {
+                    std::move(customMods.ParsedValue),
+                    { { ObsoleteParameterPassed {} } } } };
+        }
+
+        const bool isPassedByReference { firstByte == std::byte { CorElementType::ELEMENT_TYPE_BYREF } };
+        if (isPassedByReference)
+        {
+            ++bytesTaken;
+        }
+
+        auto type { ParseType(position + bytesTaken, end) };
+        return {
+            bytesTaken + type.BytesTaken,
+            {
+                std::move(customMods.ParsedValue),
+                { {
+                    ModernParameterPassed {
+                        std::move(type.ParsedValue),
+                        isPassedByReference
+                    }
+                } }
+            } };
+    }
+
+    void ReturnType::AppendToBytes(std::vector<std::byte>& target) const
+    {
+        CustomMod::AppendSeveral(CustomMods, target);
+        if (!PassDescription.has_value())
+        {
+            target.push_back(std::byte { CorElementType::ELEMENT_TYPE_VOID });
+        }
+        else
+        {
+            AppendPassDescriptionToBytes(*PassDescription, target);
+        }
+    }
+
+    void ArrayType::Assign(const ArrayType& other)
+    {
+        m_elementType = std::make_unique<Type>(*other.m_elementType);
+        Shape = other.Shape;
+    }
+
+    void FunctionPointerType::Assign(const FunctionPointerType& other)
+    {
+        m_targetSignature = std::make_unique<MethodSignature>(*other.m_targetSignature);
+    }
+
+    void GenericInstanceType::Assign(const GenericInstanceType& other)
+    {
+        IsValueType = other.IsValueType;
+        GenericType = other.GenericType;
+        GenericParameters.clear();
+        GenericParameters.reserve(other.GenericParameters.size());
+        std::copy(
+            other.GenericParameters.cbegin(),
+            other.GenericParameters.cend(),
+            std::back_inserter(GenericParameters));
+    }
+
+    void PointerType::Assign(const PointerType& other)
+    {
+        CustomMods = other.CustomMods;
+        if (other.ValueType == nullptr)
+        {
+            ValueType = nullptr;
+        }
+        else
+        {
+            ValueType = std::make_unique<Type>(*other.ValueType);
+        }
+    }
+
+    void ZeroBasedArrayType::Assign(const ZeroBasedArrayType& other)
+    {
+        CustomMods = other.CustomMods;
+        m_elementType = std::make_unique<Type>(*other.m_elementType);
+    }
+
+    ArrayType::ArrayType(
+        const Type& type,
+        const ArrayShape& shape)
+        : m_elementType { std::make_unique<Type>(type) },
+        Shape{ shape }
+    {
+    }
+
+    ArrayType::ArrayType(
+        Type&& type,
+        ArrayShape&& shape)
+        : m_elementType { std::make_unique<Type>(type) },
+        Shape { std::move(shape) }
+    {
+    }
+
+    const Type& ArrayType::ElementType() const
+    {
+        return *m_elementType;
+    }
+
+    Type& ArrayType::ElementType()
+    {
+        return *m_elementType;
+    }
+
+    FunctionPointerType::FunctionPointerType(const MethodSignature& signature)
+        : m_targetSignature { std::make_unique<MethodSignature>(signature) }
+    {
+    }
+
+    FunctionPointerType::FunctionPointerType(MethodSignature&& signature)
+        : m_targetSignature { std::make_unique<MethodSignature>(signature) }
+    {
+    }
+
+    const MethodSignature& FunctionPointerType::TargetSignature() const
+    {
+        return *m_targetSignature;
+    }
+
+    MethodSignature& FunctionPointerType::TargetSignature()
+    {
+        return *m_targetSignature;
+    }
+
+    GenericInstanceType::GenericInstanceType(
+        const bool isValueType,
+        const mdToken genericType,
+        const std::vector<Type>& genericParameters)
+        : IsValueType { isValueType },
+        GenericType { GenericType },
+        GenericParameters { genericParameters }
+    {
+    }
+
+    GenericInstanceType::GenericInstanceType(
+        const bool isValueType,
+        const mdToken genericType,
+        std::vector<Type>&& genericParameters)
+        : IsValueType { isValueType },
+        GenericType { GenericType },
+        GenericParameters { genericParameters }
+    {
+    }
+
+    PointerType::PointerType(
+        const std::unique_ptr<Type>& valueType,
+        const std::vector<CustomMod>& customMods)
+        : ValueType {},
+        CustomMods { customMods }
+    {
+        if (valueType != nullptr)
+        {
+            ValueType = std::make_unique<Type>(*valueType);
+        }
+    }
+
+    PointerType::PointerType(
+        std::unique_ptr<Type>&& valueType,
+        std::vector<CustomMod>&& customMods)
+        : ValueType { std::move(valueType) },
+        CustomMods { customMods }
+    {
+    }
+
+    ZeroBasedArrayType::ZeroBasedArrayType(
+        const Type& elementType,
+        const std::vector<CustomMod>& customMods)
+        : m_elementType { std::make_unique<Type>(elementType) },
+        CustomMods { customMods }
+    {
+    }
+
+    ZeroBasedArrayType::ZeroBasedArrayType(
+        Type&& elementType,
+        std::vector<CustomMod>&& customMods)
+        : m_elementType { std::make_unique<Type>(std::move(elementType)) },
+        CustomMods { customMods }
+    {
+    }
+
+    const Type& ZeroBasedArrayType::ElementType() const
+    {
+        return *m_elementType;
+    }
+
+
+    Type& ZeroBasedArrayType::ElementType()
+    {
+        return *m_elementType;
+    }
 }

--- a/Drill4dotNet/Drill4dotNet/Signature.cpp
+++ b/Drill4dotNet/Drill4dotNet/Signature.cpp
@@ -1,0 +1,6 @@
+#include "pch.h"
+#include "Signature.h"
+
+namespace Drill4dotNet
+{
+}

--- a/Drill4dotNet/Drill4dotNet/Signature.h
+++ b/Drill4dotNet/Drill4dotNet/Signature.h
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace Drill4dotNet
+{
+}

--- a/Drill4dotNet/Drill4dotNet/Signature.h
+++ b/Drill4dotNet/Drill4dotNet/Signature.h
@@ -1,5 +1,1724 @@
 #pragma once
 
+#include <cstddef>
+#include <optional>
+#include <ostream>
+#include <variant>
+#include <vector>
+#include "OutputUtils.h"
+
 namespace Drill4dotNet
 {
+    // The definitions in this file follow
+    // ECMA-335, Common Language Infrastructure,
+    // part II.23.2 Blobs and signatures
+    // https://www.ecma-international.org/publications/files/ECMA-ST/ECMA-335.pdf
+
+    // The minimum signed value allowed to use with CompressSignatureInteger.
+    inline static const int32_t MinCompressedSignatureInteger { -(1 << 28) };
+
+    // The maximum signed value allowed to use with CompressSignatureInteger.
+    inline static const int32_t MaxCompressedSignatureInteger { (1 << 28) - 1 };
+
+    // The maximum unsigned value allowed to use with CompressSignatureInteger.
+    inline static const uint32_t MaxCompressedSignatureUnsignedInteger { 0x1FFF'FFFF };
+
+    // Compresses the given signed value to the form
+    // that can be used in method signature blobs.
+    // @param signedValue : the value to compress,
+    //     should be between MinCompressedSignatureInteger
+    //     and MaxCompressedSignatureInteger.
+    std::vector<std::byte> CompressSignatureInteger(const int32_t signedValue);
+
+    // Compresses the given unsigned value to the form
+    // that can be used in method signature blobs.
+    // @param unsignedValue : the value to compress,
+    //     should less than MaxCompressedSignatureUnsignedInteger.
+    std::vector<std::byte> CompressSignatureInteger(const uint32_t unsignedValue);
+
+    // Stores the output produced by Parse methods.
+    template <typename T>
+    class ParseResult
+    {
+    public:
+        // The amount of bytes from the input raw bytes
+        // stream, which the Parse method has consumed.
+        size_t BytesTaken;
+
+        // The value formed by the Parse method.
+        T ParsedValue;
+    };
+
+    // Compares output produced by the Parse method.
+    // The outputs considered equal if both amount of used
+    // bytes and the extracted value are the same.
+    // Returns true, if the given values are the same.
+    // @param left : the first item to compare.
+    // @param right : the second item to compare.
+    template <typename T>
+    constexpr bool operator==(
+        const ParseResult<T> left,
+        const ParseResult<T> right)
+    {
+        return left.BytesTaken == right.BytesTaken
+            && left.ParsedValue == right.ParsedValue;
+    }
+
+    // Compares output produced by the Parse method.
+    // The outputs considered equal if both amount of used
+    // bytes and the extracted value are the same.
+    // Returns true, if the given values are not the same.
+    // @param left : the first item to compare.
+    // @param right : the second item to compare.
+    template <typename T>
+    constexpr bool operator!=(
+        const ParseResult<T> left,
+        const ParseResult<T> right)
+    {
+        return !(left == other);
+    }
+
+    // Parses a signed integer from the given position in
+    // a signature blob.
+    // Throws std::runtime_error if the input stream ends
+    // unexpectedly or the input data is invalid.
+    // @param integerPosition : iterator pointing to the position
+    //     in the signature blob, where the compressed value starts.
+    // @param sourceEnd : iterator pointing immediately after the
+    //     last byte of the method signature.
+    ParseResult<int32_t> DecompressSignatureSignedInteger(
+        const std::vector<std::byte>::const_iterator integerPosition,
+        const std::vector<std::byte>::const_iterator sourceEnd);
+
+    // Parses an unsigned integer from the given position in
+    // a signature blob.
+    // Throws std::runtime_error if the input stream ends
+    // unexpectedly or the input data is invalid.
+    // @param integerPosition : iterator pointing to the position
+    //     in the signature blob, where the compressed value starts.
+    // @param sourceEnd : iterator pointing immediately after the
+    //     last byte of the method signature.
+    ParseResult<uint32_t> DecompressSignatureUnsignedInteger(
+        const std::vector<std::byte>::const_iterator integerPosition,
+        const std::vector<std::byte>::const_iterator sourceEnd);
+
+    // Defines possible options for method calling convention in .net.
+    enum class MethodCallingConvention
+    {
+        // Managed code convention.
+        Default,
+
+        // Standard C unmanaged call convention.
+        C,
+
+        // Standard C++ unmanaged call convention.
+        StdCall,
+
+        // Unmanaged C++ call that passes a this pointer.
+        ThisCall,
+
+        // Optimized unmanaged C++ call convention.
+        FastCall
+    };
+
+    // Defines possible options how a .net method uses "this" object.
+    enum class MethodThisUsage
+    {
+        // The method is static, and not allowed to use "this".
+        NoThis,
+
+        // The method is a usual instance method, uses "this".
+        This,
+
+        // For unmanaged calls only.
+        ExplicitThis
+    };
+
+    // Defines possible variations of method signature syntax.
+    enum class MethodSignatureKind
+    {
+        // The signature describes a managed call, and
+        // if it is a vararg signature, information about
+        // optional parameters is not provided.
+        MethodInSameAssembly,
+
+        // The signature describes a managed call, and
+        // if it is a vararg signature, information about
+        // optional parameters is provided.
+        MethodInDifferentAssembly,
+
+        // Managed or unmanaged call.
+        FreeStandingSignature
+    };
+
+    // Represents a method signature, which is a
+    // combination of the return type, the parameter types,
+    // and the calling convention.
+    class MethodSignature;
+
+    // Represents an integral, floating point,
+    // object, or string type.
+    class PrimitiveType;
+
+    // Represents an array type as a combination of
+    // the element type and shape describing array dimensions.
+    class ArrayType;
+
+    // Represents a type which is a class.
+    class ClassType;
+
+    // Represents a type which is a struct.
+    class StructType;
+
+    // Represents a type of an unmanaged
+    // function pointer.
+    class FunctionPointerType;
+
+    // Represents a closed generic type.
+    class GenericInstanceType;
+
+    // Represents a type, which is specified as
+    // a generic method argument.
+    class MethodGenericArgument;
+
+    // Represents a type, which is specified as
+    // a generic type argument.
+    class TypeGenericArgument;
+
+    // Represents a type of an unmanaged pointer type.
+    class PointerType;
+
+    // Represents a single dimension zero-based array type.
+    class ZeroBasedArrayType;
+
+    // Represents a variable type in .net.
+    using Type = std::variant<
+        PrimitiveType,
+        ArrayType,
+        ClassType,
+        StructType,
+        FunctionPointerType,
+        GenericInstanceType,
+        MethodGenericArgument,
+        TypeGenericArgument,
+        PointerType,
+        ZeroBasedArrayType>;
+
+    // Describes array dimensions.
+    class ArrayShape
+    {
+    public:
+        // The number of the dimensions.
+        uint32_t Rank;
+
+        // Each element in this vector specifies
+        // length of the corresponding dimension.
+        // There could be less elements than Rank,
+        // in this case other dimensions are considered
+        // to be of unknown length. For example, if
+        // Rank is 2, and Sizes has 1 element equal to 4,
+        // the array will have two dimensions, the first
+        // will keep 4 elements, and the second will contain
+        // any amount of elements.
+        std::vector<uint32_t> Sizes;
+
+        // Each element in this vector specifies
+        // lower bound of the corresponding dimension.
+        // There could be less elements than Rank,
+        // in this case other dimensions are considered
+        // to be zero based. For example, if Rank is 2,
+        // and LowerBounds has 1 element equal to 1,
+        // the array will have two dimensions, the indexes
+        // of the first will start with 1, the indexes of
+        // the second one will start with 0.
+        std::vector<int32_t> LowerBounds;
+
+        // Parses an ArrayShape from the given position in
+        // a signature blob.
+        // Throws std::runtime_error if the input stream ends
+        // unexpectedly or the input data is invalid.
+        // @param position : iterator pointing to the position
+        //     in the signature blob, where the ArrayShape value starts.
+        // @param end : iterator pointing immediately after the
+        //     last byte of the method signature.
+        static ParseResult<ArrayShape> Parse(
+            const std::vector<std::byte>::const_iterator position,
+            const std::vector<std::byte>::const_iterator end);
+
+        // Serializes the value to the raw bytes form.
+        // @param target : the vector to store the serialized value in.
+        void AppendToBytes(std::vector<std::byte>& target) const;
+    };
+
+    // Parses a type token from a method signature blob.
+    // Returns a metadata token of type mdtTypeDef, mdtTypeRef, or mdtTypeSpec.
+    // @param position : iterator pointing to the position
+    //     in the signature blob, where the token value starts.
+    // @param end : iterator pointing immediately after the
+    //     last byte of the method signature.
+    ParseResult<mdToken> DecompressTypeDefOrRefOrSpecEncoded(
+        const std::vector<std::byte>::const_iterator position,
+        const std::vector<std::byte>::const_iterator end);
+
+    // Compresses a type token to a form that can be used in method signature blobs.
+    // @param typeToken : a metadata token of type mdtTypeDef, mdtTypeRef, or mdtTypeSpec.
+    // @param target : the vector to store the serialized value in.
+    void CompressTypeDefOrRefOrSpecEncoded(
+        const mdToken typeToken,
+        std::vector<std::byte>& target);
+
+    // Represents a custom modifier.
+    // Custom modifier is a reference to some
+    // tag type, which gives additional information
+    // about how the parameter is passed.
+    // Such tag types are typically located in the
+    // System.Runtime.CompilerServices namespace,
+    // for example, System.Runtime.CompilerServices.IsConst.
+    class CustomMod
+    {
+    public:
+        // The value indicating whether the caller
+        // must take the semantics of the custom modifier
+        // into account to make a successful call.
+        bool Required;
+
+        // The reference to the tag type.
+        mdToken TypeToken;
+
+        // Parses a custom modifier from the given position in
+        // a signature blob.
+        // Throws std::runtime_error if the input stream ends
+        // unexpectedly or the input data is invalid.
+        // If a custom modifier starts at the position, the
+        // modifier is extracted and returned. If there is no
+        // custom modifier at the position, std::nullopt is returned.
+        // @param position : iterator pointing to the position
+        //     in the signature blob, where the custom modifier value starts.
+        // @param end : iterator pointing immediately after the
+        //     last byte of the method signature.
+        static std::optional<ParseResult<CustomMod>> Parse(
+            const std::vector<std::byte>::const_iterator position,
+            const std::vector<std::byte>::const_iterator end);
+
+        // Serializes the value to the raw bytes form.
+        // @param target : the vector to store the serialized value in.
+        void AppendToBytes(std::vector<std::byte>& target) const;
+
+        // Parses as many adjacent custom modifiers as possible
+        // from the given position in a signature blob.
+        // Throws std::runtime_error if the input stream ends
+        // unexpectedly or the input data is invalid.
+        // If one or more custom modifiers start at the position, they
+        // are extracted and returned. If there is no
+        // custom modifier at the position, an empty vector is returned.
+        // @param position : iterator pointing to the position
+        //     in the signature blob, where the custom modifier value starts.
+        // @param end : iterator pointing immediately after the
+        //     last byte of the method signature.
+        static ParseResult<std::vector<CustomMod>> ParseSeveral(
+            const std::vector<std::byte>::const_iterator position,
+            const std::vector<std::byte>::const_iterator end);
+
+        // Serializes several custom modifiers to the raw bytes form.
+        // @param customMods : the collection of custom modifiers, can be empty.
+        // @param target : the vector to store the serialized value in.
+        static void AppendSeveral(
+            const std::vector<CustomMod> customMods,
+            std::vector<std::byte>& target);
+    };
+
+    // Represents an integral, floating point,
+    // object, or string type.
+    class PrimitiveType
+    {
+    private:
+        // The selected primitive type option.
+        CorElementType m_type;
+
+    public:
+        // Creates a primitive type with the given option.
+        // Throws std::logic_error if the given option is not primitive.
+        // Method PrimitiveType::IsPrimitiveType can be used to
+        // determine whether a type is primitive.
+        // @param primitiveType : one of primitive type options.
+        constexpr PrimitiveType(const CorElementType primitiveType)
+            : m_type{ primitiveType }
+        {
+            if (!IsPrimitiveType(primitiveType))
+            {
+                throw std::logic_error("The given type is not primitive");
+            }
+        }
+
+        // The selected primitive type option.
+        constexpr CorElementType Type() const noexcept
+        {
+            return m_type;
+        }
+
+        // Gets the value determining whether the given type option is primitive.
+        // Returns true, if the given option is an integral type, floating point
+        // type, object, or string.
+        // @param type : one of possible CorElementType options.
+        static constexpr bool IsPrimitiveType(const CorElementType type) noexcept
+        {
+            switch (type)
+            {
+            case ELEMENT_TYPE_BOOLEAN:
+            case ELEMENT_TYPE_CHAR:
+            case ELEMENT_TYPE_I1:
+            case ELEMENT_TYPE_U1:
+            case ELEMENT_TYPE_I2:
+            case ELEMENT_TYPE_U2:
+            case ELEMENT_TYPE_I4:
+            case ELEMENT_TYPE_U4:
+            case ELEMENT_TYPE_I8:
+            case ELEMENT_TYPE_U8:
+            case ELEMENT_TYPE_R4:
+            case ELEMENT_TYPE_R8:
+            case ELEMENT_TYPE_STRING:
+            case ELEMENT_TYPE_OBJECT:
+            case ELEMENT_TYPE_I:
+            case ELEMENT_TYPE_U:
+                return true;
+            default:
+                return false;
+            }
+        }
+    };
+
+    // Represents an array type as a combination of
+    // the element type and shape describing array dimensions.
+    class ArrayType
+    {
+    private:
+        // Copies the value from the given
+        // ArrayShape to this object.
+        // @param other : the source object.
+        void Assign(const ArrayType& other);
+
+        // Stores the type of array element.
+        // The std::unique_ptr is used, because
+        // otherwise, Type, which could be ArrayType,
+        // should have included other Type as
+        // a field, this is not allowed in C++ type system.
+        // sizeof(std::unique_ptr<Type>) does not depend on
+        // sizeof(Type), this allows to break the recursion.
+        // The pointer will never be nullptr.
+        std::unique_ptr<Type> m_elementType;
+
+    public:
+        // Describes array dimensions.
+        ArrayShape Shape;
+
+        // Creates ArrayType with the given parameters.
+        // @param type : the element type.
+        // @param shape : the description of array dimensions.
+        ArrayType(
+            const Type& type,
+            const ArrayShape& shape);
+
+        // Creates ArrayType with the given parameters.
+        // Both parameters will be in moved-from state after this constructor.
+        // @param type : the element type.
+        // @param shape : the description of array dimensions.
+        ArrayType(
+            Type&& type,
+            ArrayShape&& shape);
+
+        // Copy constructor.
+        ArrayType(const ArrayType& other)
+            : Shape(other.Shape)
+        {
+            Assign(other);
+        }
+
+        // Move constructor.
+        ArrayType(ArrayType&& other) = default;
+        // Move assignment operator.
+        ArrayType& operator=(ArrayType&& other) & = default;
+
+        // Copy assignment operator.
+        ArrayType& operator=(const ArrayType& other) &
+        {
+            Assign(other);
+            return *this;
+        }
+
+        // The type of an element in the array.
+        const Type& ElementType() const;
+
+        // The type of an element in the array.
+        Type& ElementType();
+
+        // Parses an ArrayType from the given position in
+        // a signature blob.
+        // Throws std::runtime_error if the input stream ends
+        // unexpectedly or the input data is invalid.
+        // @param position : iterator pointing to the position
+        //     in the signature blob, where the ArrayType value starts.
+        // @param end : iterator pointing immediately after the
+        //     last byte of the method signature.
+        static ParseResult<ArrayType> Parse(
+            const std::vector<std::byte>::const_iterator position,
+            const std::vector<std::byte>::const_iterator end);
+
+        // Serializes the value to the raw bytes form.
+        // @param target : the vector to store the serialized value in.
+        void AppendToBytes(std::vector<std::byte>& target) const;
+    };
+
+    // Represents a type which is a class.
+    class ClassType
+    {
+    public:
+        // The metadata token of a class.
+        mdToken Class;
+
+        // Parses a ClassType from the given position in
+        // a signature blob.
+        // Throws std::runtime_error if the input stream ends
+        // unexpectedly or the input data is invalid.
+        // @param position : iterator pointing to the position
+        //     in the signature blob, where the ClassType value starts.
+        // @param end : iterator pointing immediately after the
+        //     last byte of the method signature.
+        static ParseResult<ClassType> Parse(
+            const std::vector<std::byte>::const_iterator position,
+            const std::vector<std::byte>::const_iterator end);
+
+        // Serializes the value to the raw bytes form.
+        // @param target : the vector to store the serialized value in.
+        void AppendToBytes(std::vector<std::byte>& target) const;
+    };
+
+    // Represents a type which is a struct.
+    class StructType
+    {
+    public:
+        // The metadata token of a struct.
+        mdToken Struct;
+
+        // Parses a StructType from the given position in
+        // a signature blob.
+        // Throws std::runtime_error if the input stream ends
+        // unexpectedly or the input data is invalid.
+        // @param position : iterator pointing to the position
+        //     in the signature blob, where the StructType value starts.
+        // @param end : iterator pointing immediately after the
+        //     last byte of the method signature.
+        static ParseResult<StructType> Parse(
+            const std::vector<std::byte>::const_iterator position,
+            const std::vector<std::byte>::const_iterator end);
+
+        // Serializes the value to the raw bytes form.
+        // @param target : the vector to store the serialized value in.
+        void AppendToBytes(std::vector<std::byte>& target) const;
+    };
+
+    // Represents a type of an unmanaged
+    // function pointer.
+    class FunctionPointerType
+    {
+    private:
+        // Copies the value from the given
+        // FunctionPointerType to this object.
+        // @param other : the source object.
+        void Assign(const FunctionPointerType& other);
+
+        // Stores the signature of the target function.
+        // The std::unique_ptr is used, because
+        // otherwise, Type, which could be FunctionPointerType,
+        // should have included other Type as
+        // a parameter type, this is not allowed in C++ type system.
+        // sizeof(std::unique_ptr<Type>) does not depend on
+        // sizeof(Type), this allows to break the recursion.
+        // The pointer will never be nullptr.
+        std::unique_ptr<MethodSignature> m_targetSignature;
+
+    public:
+
+        // Creates FunctionPointerType with the given target signature.
+        // @param signature : the signature of the target function.
+        FunctionPointerType(const MethodSignature& signature);
+
+        // Creates FunctionPointerType with the given target signature.
+        // @param signature : the signature of the target function.
+        //     Will be in moved-from state after this constructor.
+        FunctionPointerType(MethodSignature&& signature);
+
+        // Copy constructor.
+        FunctionPointerType(const FunctionPointerType& other)
+        {
+            Assign(other);
+        }
+
+        // Move constructor.
+        FunctionPointerType(FunctionPointerType&& other) = default;
+
+        // Move assignment operator.
+        FunctionPointerType& operator=(FunctionPointerType&& other) & = default;
+
+        // Copy assignment operator.
+        FunctionPointerType& operator=(const FunctionPointerType& other) &
+        {
+            Assign(other);
+            return *this;
+        }
+
+        // The signature of the target function.
+        const MethodSignature& TargetSignature() const;
+
+        // The signature of the target function.
+        MethodSignature& TargetSignature();
+
+        // Parses a FunctionPointerType from the given position in
+        // a signature blob.
+        // Throws std::runtime_error if the input stream ends
+        // unexpectedly or the input data is invalid.
+        // @param position : iterator pointing to the position
+        //     in the signature blob, where the FunctionPointerType value starts.
+        // @param end : iterator pointing immediately after the
+        //     last byte of the method signature.
+        static ParseResult<FunctionPointerType> Parse(
+            const std::vector<std::byte>::const_iterator position,
+            const std::vector<std::byte>::const_iterator end);
+
+        // Serializes the value to the raw bytes form.
+        // @param target : the vector to store the serialized value in.
+        void AppendToBytes(std::vector<std::byte>& target) const;
+    };
+
+    // Represents a closed generic type.
+    class GenericInstanceType
+    {
+    private:
+        // Copies the value from the given
+        // GenericInstanceType to this object.
+        // @param other : the source object.
+        void Assign(const GenericInstanceType& other);
+
+    public:
+        // Value indicating whether
+        // GenericType is a class or a struct.
+        // True corresponds to struct.
+        bool IsValueType;
+
+        // The metadata token of open generic type.
+        mdToken GenericType;
+
+        // The types used as parameters to construct
+        // a closed generic type from GenericType.
+        std::vector<Type> GenericParameters;
+
+        // Creates GenericInstanceType with the given parameters.
+        // @param isValueType : value indicating whether
+        //     genericType is a class or a struct.
+        //     True corresponds to struct.
+        // @param genericType : the metadata token of
+        //     an open generic type.
+        // @param genericParameters : The types used as
+        //     parameters to construct a closed generic type
+        //     from genericType.
+        GenericInstanceType(
+            const bool isValueType,
+            const mdToken genericType,
+            const std::vector<Type>& genericParameters);
+
+        // Creates GenericInstanceType with the given parameters.
+        // @param isValueType : value indicating whether
+        //     genericType is a class or a struct.
+        //     True corresponds to struct.
+        // @param genericType : the metadata token of
+        //     an open generic type.
+        // @param genericParameters : The types used as
+        //     parameters to construct a closed generic type
+        //     from genericType. Will be in moved-from
+        //     state after this constructor.
+        GenericInstanceType(
+            const bool isValueType,
+            const mdToken genericType,
+            std::vector<Type>&& genericParameters);
+
+        // Copy constructor.
+        GenericInstanceType(const GenericInstanceType& other)
+        {
+            Assign(other);
+        }
+
+        // Move constructor.
+        GenericInstanceType(GenericInstanceType&& other) = default;
+
+        // Move assignment operator.
+        GenericInstanceType& operator=(GenericInstanceType&& other) & = default;
+
+        // Copy assignment operator.
+        GenericInstanceType& operator=(const GenericInstanceType& other) &
+        {
+            Assign(other);
+            return *this;
+        }
+
+        // Parses a GenericInstanceType from the given position in
+        // a signature blob.
+        // Throws std::runtime_error if the input stream ends
+        // unexpectedly or the input data is invalid.
+        // @param position : iterator pointing to the position
+        //     in the signature blob, where the GenericInstanceType value starts.
+        // @param end : iterator pointing immediately after the
+        //     last byte of the method signature.
+        static ParseResult<GenericInstanceType> Parse(
+            const std::vector<std::byte>::const_iterator position,
+            const std::vector<std::byte>::const_iterator end);
+
+        // Serializes the value to the raw bytes form.
+        // @param target : the vector to store the serialized value in.
+        void AppendToBytes(std::vector<std::byte>& target) const;
+    };
+
+    // Represents a type, which is specified as
+    // a generic method argument.
+    class MethodGenericArgument
+    {
+    public:
+        // Number of generic parameter of this method,
+        // which this type equal to.
+        // Example 1 [C#]:
+        // class MyClass
+        // {
+        //     public void MyFunction<TFirst, TSecond>(TFirst first, TSecond second)
+        //     {
+        //     }
+        // }
+        // In this case, in signature blob, MyFunction will be represented as
+        // void`2(MethodGenericArguments[0] first, MethodGenericArguments[1] second)
+        // For the first parameter, type will be MethodGenericArgument with Index == 0,
+        // and for the second parameter, type will be MethodGenericArgument with Index == 1.
+        //
+        // Example 2 [C#]:
+        // class MyClass
+        // {
+        //     public List<T> Merge<T>(List<T> first, List<T> second)
+        //     {
+        //         // ...
+        //     }
+        // }
+        // In this case, in signature blob, MyFunction will be represented as
+        // GenericInstanceType { ClassType { List`1 }, MethodGenericArguments[0] }`1(
+        //     GenericInstanceType { ClassType { List`1 }, MethodGenericArguments[0] } first,
+        //     GenericInstanceType { ClassType { List`1 }, MethodGenericArguments[0] } second)
+        // In this case, return type and both parameters types will be represented as a closed
+        // generic type, constructed from generic type System.Collections.Generic.List, and
+        // and the element type of the List will be the same as the generic parameter
+        // of the Merge method.
+        uint32_t Index;
+
+        // Parses a MethodGenericArgument from the given position in
+        // a signature blob.
+        // Throws std::runtime_error if the input stream ends
+        // unexpectedly or the input data is invalid.
+        // @param position : iterator pointing to the position
+        //     in the signature blob, where the MethodGenericArgument value starts.
+        // @param end : iterator pointing immediately after the
+        //     last byte of the method signature.
+        static ParseResult<MethodGenericArgument> Parse(
+            const std::vector<std::byte>::const_iterator position,
+            const std::vector<std::byte>::const_iterator end);
+
+        // Serializes the value to the raw bytes form.
+        // @param target : the vector to store the serialized value in.
+        void AppendToBytes(std::vector<std::byte>& target) const;
+    };
+
+    // Represents a type, which is specified as
+    // a generic type argument.
+    class TypeGenericArgument
+    {
+    public:
+        // Number of generic parameter of the type this method belongs to,
+        // which this type equal to.
+        // Example 1 [C#]:
+        // class MyClass<TFirst, TSecond>
+        // {
+        //     public void MyFunction(TFirst first, TSecond second)
+        //     {
+        //     }
+        // }
+        // In this case, in signature blob, MyFunction will be represented as
+        // void(TypeGenericArguments[0] first, TypeGenericArguments[1] second)
+        // For the first parameter, type will be TypeGenericArgument with Index == 0,
+        // and for the second parameter, type will be TypeGenericArgument with Index == 1.
+        //
+        // Example 2 [C#]:
+        // class MyClass<T>
+        // {
+        //     public List<T> Merge(List<T> first, List<T> second)
+        //     {
+        //         // ...
+        //     }
+        // }
+        // In this case, in signature blob, MyFunction will be represented as
+        // GenericInstanceType { ClassType { List`1 }, TypeGenericArguments[0] }`1(
+        //     GenericInstanceType { ClassType { List`1 }, TypeGenericArguments[0] } first,
+        //     GenericInstanceType { ClassType { List`1 }, TypeGenericArguments[0] } second)
+        // In this case, return type and both parameters types will be represented as a closed
+        // generic type, constructed from generic type System.Collections.Generic.List, and
+        // and the element type of the List will be the same as the generic parameter
+        // of the myClass class.
+        uint32_t Index;
+
+        // Parses a TypeGenericArgument from the given position in
+        // a signature blob.
+        // Throws std::runtime_error if the input stream ends
+        // unexpectedly or the input data is invalid.
+        // @param position : iterator pointing to the position
+        //     in the signature blob, where the TypeGenericArgument value starts.
+        // @param end : iterator pointing immediately after the
+        //     last byte of the method signature.
+        static ParseResult<TypeGenericArgument> Parse(
+            const std::vector<std::byte>::const_iterator position,
+            const std::vector<std::byte>::const_iterator end);
+
+        // Serializes the value to the raw bytes form.
+        // @param target : the vector to store the serialized value in.
+        void AppendToBytes(std::vector<std::byte>& target) const;
+    };
+
+    // Represents a type of an unmanaged pointer type.
+    class PointerType
+    {
+    private:
+        // Copies the value from the given
+        // PointerType to this object.
+        // @param other : the source object.
+        void Assign(const PointerType& other);
+
+    public:
+        // If the pointer is typed, this should
+        // hold the description of the value type.
+        // If the pointer is not typed, i. e. void*,
+        // this is equal to nullptr.
+        std::unique_ptr<Type> ValueType;
+
+        // Custom modifiers providing additional
+        // details on the semantics of the pointer.
+        std::vector<CustomMod> CustomMods;
+
+        // Creates the PointerType with the given parameters.
+        // @param valueType : if the pointer is typed, this
+        //     should hold the description of the value type.
+        //     If the pointer is not typed, i. e. void*,
+        //     this is equal to nullptr.
+        // @param customMods : custom modifiers providing
+        //     additional details on the semantics of the pointer.
+        PointerType(
+            const std::unique_ptr<Type>& valueType,
+            const std::vector<CustomMod>& customMods);
+
+        // Creates the PointerType with the given parameters.
+        // Both parameters will be in moved-from state after this constructor.
+        // @param valueType : if the pointer is typed, this
+        //     should hold the description of the value type.
+        //     If the pointer is not typed, i. e. void*,
+        //     this is equal to nullptr.
+        // @param customMods : custom modifiers providing
+        //     additional details on the semantics of the pointer.
+        PointerType(
+            std::unique_ptr<Type>&& valueType,
+            std::vector<CustomMod>&& customMods);
+
+        // Copy constructor.
+        PointerType(const PointerType& other)
+        {
+            Assign(other);
+        }
+
+        // Move constructor.
+        PointerType(PointerType&& other) = default;
+
+        // Move assignment operator.
+        PointerType& operator=(PointerType&& other) & = default;
+
+        // Copy assignment operator.
+        PointerType& operator=(const PointerType& other) &
+        {
+            Assign(other);
+            return *this;
+        }
+
+        // Parses a PointerType from the given position in
+        // a signature blob.
+        // Throws std::runtime_error if the input stream ends
+        // unexpectedly or the input data is invalid.
+        // @param position : iterator pointing to the position
+        //     in the signature blob, where the PointerType value starts.
+        // @param end : iterator pointing immediately after the
+        //     last byte of the method signature.
+        static ParseResult<PointerType> Parse(
+            const std::vector<std::byte>::const_iterator position,
+            const std::vector<std::byte>::const_iterator end);
+
+        // Serializes the value to the raw bytes form.
+        // @param target : the vector to store the serialized value in.
+        void AppendToBytes(std::vector<std::byte>& target) const;
+    };
+
+    // Represents a single dimension zero-based array type.
+    class ZeroBasedArrayType
+    {
+    private:
+        // Copies the value from the given
+        // ArrayShape to this object.
+        // @param other : the source object.
+        void Assign(const ZeroBasedArrayType& other);
+
+        // Stores the type of array element.
+        // The std::unique_ptr is used, because
+        // otherwise, Type, which could be ZeroBasedArrayType,
+        // should have included other Type as
+        // a field, this is not allowed in C++ type system.
+        // sizeof(std::unique_ptr<Type>) does not depend on
+        // sizeof(Type), this allows to break the recursion.
+        // The pointer will never be nullptr.
+        std::unique_ptr<Type> m_elementType;
+
+    public:
+        // Custom modifiers providing additional
+        // details on the semantics of array.
+        std::vector<CustomMod> CustomMods;
+
+        // Creates ZeroBasedArrayType with the given parameters.
+        // @param type : the element type.
+        // @param customMods : custom modifiers providing
+        //     additional details on the semantics of array.
+        ZeroBasedArrayType(
+            const Type& elementType,
+            const std::vector<CustomMod>& customMods);
+
+        // Creates ZeroBasedArrayType with the given parameters.
+        // Both parameters will be in moved-from state after this constructor.
+        // @param type : the element type.
+        // @param customMods : custom modifiers providing
+        //     additional details on the semantics of array.
+        ZeroBasedArrayType(
+            Type&& elementType,
+            std::vector<CustomMod>&& customMods);
+
+        // Copy constructor.
+        ZeroBasedArrayType(const ZeroBasedArrayType& other)
+        {
+            Assign(other);
+        }
+
+        // Move constructor.
+        ZeroBasedArrayType(ZeroBasedArrayType&& other) = default;
+
+        // Move assignment operator.
+        ZeroBasedArrayType& operator=(ZeroBasedArrayType&& other) & = default;
+
+        // Copy assignment operator.
+        ZeroBasedArrayType& operator=(const ZeroBasedArrayType& other) &
+        {
+            Assign(other);
+            return *this;
+        }
+
+        // The type of an element in the array.
+        const Type& ElementType() const;
+
+        // The type of an element in the array.
+        Type& ElementType();
+
+        // Parses a ZeroBasedArrayType from the given position in
+        // a signature blob.
+        // Throws std::runtime_error if the input stream ends
+        // unexpectedly or the input data is invalid.
+        // @param position : iterator pointing to the position
+        //     in the signature blob, where the ZeroBasedArrayType value starts.
+        // @param end : iterator pointing immediately after the
+        //     last byte of the method signature.
+        static ParseResult<ZeroBasedArrayType> Parse(
+            const std::vector<std::byte>::const_iterator position,
+            const std::vector<std::byte>::const_iterator end);
+
+        // Serializes the value to the raw bytes form.
+        // @param target : the vector to store the serialized value in.
+        void AppendToBytes(std::vector<std::byte>& target) const;
+    };
+
+    // Parses a Type from the given position in
+    // a signature blob.
+    // Throws std::runtime_error if the input stream ends
+    // unexpectedly or the input data is invalid.
+    // @param position : iterator pointing to the position
+    //     in the signature blob, where the Type value starts.
+    // @param end : iterator pointing immediately after the
+    //     last byte of the method signature.
+    static ParseResult<Type> ParseType(
+        const std::vector<std::byte>::const_iterator position,
+        const std::vector<std::byte>::const_iterator end);
+
+    // Serializes the Type value to the raw bytes form.
+    // @param type : the Type value to serialize.
+    // @param target : the vector to store the serialized value in.
+    void AppendTypeToBytes(const Type& type, std::vector<std::byte>& target);
+
+    // Represents parameter of type System.TypedReference.
+    class ObsoleteParameterPassed
+    {
+    };
+
+    // Represents parameter of type other than System.TypedReference.
+    class ModernParameterPassed
+    {
+    public:
+        // The type of the parameter.
+        Type ParameterType;
+
+        // True, if the parameter is passed by reference.
+        bool IsPassedByReference;
+    };
+
+    // Represents parameter passed in a method.
+    class ParameterType
+    {
+    public:
+        // Custom modifiers providing additional information
+        // on the parameter pass semantics.
+        std::vector<CustomMod> CustomMods;
+
+        // The type of the parameter, and whether it is
+        // passed by reference.
+        std::variant<ModernParameterPassed, ObsoleteParameterPassed> PassDescription;
+
+        // Parses a ParameterType from the given position in
+        // a signature blob.
+        // Throws std::runtime_error if the input stream ends
+        // unexpectedly or the input data is invalid.
+        // @param position : iterator pointing to the position
+        //     in the signature blob, where the ParameterType value starts.
+        // @param end : iterator pointing immediately after the
+        //     last byte of the method signature.
+        static ParseResult<ParameterType> Parse(
+            const std::vector<std::byte>::const_iterator position,
+            const std::vector<std::byte>::const_iterator end);
+
+        // Serializes the value to the raw bytes form.
+        // @param target : the vector to store the serialized value in.
+        void AppendToBytes(std::vector<std::byte>& target) const;
+    };
+
+    // Description of the value returned from a method.
+    class ReturnType
+    {
+    public:
+        // Custom modifiers providing additional information
+        // on the value pass semantics.
+        std::vector<CustomMod> CustomMods;
+
+        // If this equal to std::nullopt, the method does not
+        // return any value, i. e. void.
+        // Otherwise, describes the return type and pass semantics.
+        std::optional<std::variant<ModernParameterPassed, ObsoleteParameterPassed>> PassDescription;
+
+        // Parses a ReturnType from the given position in
+        // a signature blob.
+        // Throws std::runtime_error if the input stream ends
+        // unexpectedly or the input data is invalid.
+        // @param position : iterator pointing to the position
+        //     in the signature blob, where the ReturnType value starts.
+        // @param end : iterator pointing immediately after the
+        //     last byte of the method signature.
+        static ParseResult<ReturnType> Parse(
+            const std::vector<std::byte>::const_iterator position,
+            const std::vector<std::byte>::const_iterator end);
+
+        // Serializes the value to the raw bytes form.
+        // @param target : the vector to store the serialized value in.
+        void AppendToBytes(std::vector<std::byte>& target) const;
+    };
+
+    // For methods accepting variable amount of
+    // parameters, describes how many required and
+    // optional parameters are passed.
+    class VarArgDescription
+    {
+    public:
+        // How many required parameters were passed.
+        size_t RequiredParametersCount;
+
+        // How many additional parameters were passed.
+        size_t OptionalParametersCount;
+    };
+
+    // Represents a method signature, which is a
+    // combination of the return type, the parameter types,
+    // and the calling convention.
+    class MethodSignature
+    {
+    private:
+        // The syntax variation of this signature.
+        MethodSignatureKind m_kind;
+
+        // How this method uses "this" object.
+        MethodThisUsage m_thisUsage;
+
+        // Calling convention of the method.
+        MethodCallingConvention m_callingConvention;
+
+        // Types of the method parameters.
+        std::vector<ParameterType> m_parameterTypes;
+
+        // The type of the method's return value.
+        ReturnType m_returnType;
+
+        // For generic methods, the number of generic parameters.
+        std::optional<size_t> m_genericParameters;
+
+        // For methods accepting variable amount of
+        // parameters, describes how many required and
+        // optional parameters are passed.
+        std::optional<VarArgDescription> m_varArg;
+
+        // Object capable of outputting method calling convention
+        // and return type to standard streams.
+        class WritePreambleHolder
+        {
+        private:
+            // The method signature which details should be outputted.
+            const MethodSignature& m_value;
+
+        public:
+            // Creates a new instance.
+            // @param value : the method signature which
+            //     details should be outputted.
+            WritePreambleHolder(const MethodSignature& value)
+                : m_value(value)
+            {
+            }
+
+            // Outputs method calling convention
+            // and return type to standard streams.
+            // @param target : the strem to output to.
+            // @param holder : stores the value to output.
+            template <typename TChar>
+            friend std::basic_ostream<TChar>& operator<<(
+                std::basic_ostream<TChar>& target,
+                const WritePreambleHolder& holder)
+            {
+                const MethodSignature& self { holder.m_value };
+                return target
+                    << self.CallingConvention()
+                    << " "
+                    << self.ThisUsage()
+                    << " "
+                    << self.ReturnType();
+            }
+
+        };
+
+        // Object capable of outputting method
+        // parameters to standard streams.
+        class WriteParametersHolder
+        {
+        private:
+            // The method signature which details should be outputted.
+            const MethodSignature& m_value;
+
+        public:
+            // Creates a new instance.
+            // @param value : the method signature which
+            //     details should be outputted.
+            WriteParametersHolder(const MethodSignature& value)
+                : m_value(value)
+            {
+            }
+
+            // Outputs method parameters types to standard streams.
+            // @param target : the strem to output to.
+            // @param holder : stores the value to output.
+            template <typename TChar>
+            friend std::basic_ostream<TChar>& operator<<(
+                std::basic_ostream<TChar>& target,
+                const WriteParametersHolder& holder)
+            {
+                const MethodSignature& self { holder.m_value };
+                if (self.GenericParameters().has_value())
+                {
+                    target << '`' << *self.GenericParameters();
+                }
+
+                target << '(';
+                bool first { true };
+                for (size_t i { 0 }; i != self.ParameterTypes().size(); ++i)
+                {
+                    if (self.VarArg().has_value() && i == self.VarArg()->RequiredParametersCount)
+                    {
+                        if (!first)
+                        {
+                            target << ", ";
+                        }
+                        else
+                        {
+                            first = false;
+                        }
+
+                        target << "... ";
+                    }
+
+                    if (!first)
+                    {
+                        target << ", ";
+                    }
+
+                    target << self.ParameterTypes()[i];
+                    first = false;
+                };
+
+                if (self.VarArg().has_value() && self.VarArg()->OptionalParametersCount == 0)
+                {
+                    target << (first ? "..." : ", ...");
+                }
+
+                return target << ')';
+            }
+        };
+
+    public:
+        // Creates an instance of MethodSignature with the given values.
+        // @param kind : the syntax variation of this signature.
+        // @param thisUsage : how this method uses "this" object.
+        // @param callingConvention : calling convention of the method.
+        // @param parameterTypes : types of the method parameters.
+        // @param returnType : the type of the method's return value.
+        // @param genericParameters : for generic methods, the number of
+        //     generic parameters.
+        // @param varArg : for methods accepting variable amount of
+        // parameters, describes how many required and
+        // optional parameters are passed.
+        MethodSignature(
+            const MethodSignatureKind kind,
+            const MethodThisUsage thisUsage,
+            const MethodCallingConvention callingConvention,
+            std::vector<ParameterType> parameterTypes,
+            ReturnType returnType,
+            std::optional<size_t> genericParameters,
+            std::optional<VarArgDescription> varArg);
+
+        // Parses a MethodSignature from the given position in
+        // a signature blob.
+        // Throws std::runtime_error if the input stream ends
+        // unexpectedly or the input data is invalid.
+        // @param position : iterator pointing to the position
+        //     in the signature blob, where the MethodSignature value starts.
+        // @param end : iterator pointing immediately after the
+        //     last byte of the method signature.
+        static ParseResult<MethodSignature> Parse(
+            const std::vector<std::byte>::const_iterator position,
+            const std::vector<std::byte>::const_iterator end);
+
+        // Serializes the value to the raw bytes form.
+        // @param target : the vector to store the serialized value in.
+        void AppendToBytes(std::vector<std::byte>& target) const;
+
+        // How this method uses "this" object.
+        MethodThisUsage ThisUsage() const
+        {
+            return m_thisUsage;
+        }
+
+        // Calling convention of the method.
+        MethodCallingConvention CallingConvention() const
+        {
+            return m_callingConvention;
+        }
+
+        // Types of the method parameters.
+        const std::vector<ParameterType>& ParameterTypes() const&
+        {
+            return m_parameterTypes;
+        }
+
+        // The type of the method's return value.
+        const ReturnType& ReturnType() const&
+        {
+            return m_returnType;
+        }
+
+        // For generic methods, the number of generic parameters.
+        std::optional<size_t> GenericParameters() const
+        {
+            return m_genericParameters;
+        }
+
+        // The syntax variation of this signature.
+        MethodSignatureKind Kind() const
+        {
+            return m_kind;
+        }
+
+        // For methods accepting variable amount of
+        // parameters, describes how many required and
+        // optional parameters are passed.
+        std::optional<VarArgDescription> VarArg() const
+        {
+            return m_varArg;
+        }
+
+        // Returns an object capable of outputting method calling
+        // convention and return type to standard streams.
+        auto WritePreamble() const
+        {
+            return WritePreambleHolder(*this);
+        }
+
+        // Returns an object capable of outputting
+        // method parameters to standard streams.
+        auto WriteParameters() const
+        {
+            return WriteParametersHolder(*this);
+        }
+    };
+
+    // Provides ability to output method calling convention
+    // to standard streams.
+    // @param target : the stream to output to.
+    // @param callingConvention : the value to output.
+    template <typename TChar>
+    std::basic_ostream<TChar>& operator<<(
+        std::basic_ostream<TChar>& target,
+        const MethodCallingConvention callingConvention)
+    {
+        switch (callingConvention)
+        {
+        case MethodCallingConvention::C:
+            target << "c";
+            break;
+        case MethodCallingConvention::FastCall:
+            target << "fastcall";
+            break;
+        case MethodCallingConvention::StdCall:
+            target << "stdcall";
+            break;
+        case MethodCallingConvention::ThisCall:
+            target << "thiscall";
+        }
+
+        return target;
+    }
+
+    // Provides ability to output usage of "this"
+    // by a method to standard streams.
+    // @param target : the stream to output to.
+    // @param thisUsage : the value to output.
+    template <typename TChar>
+    std::basic_ostream<TChar>& operator<<(
+        std::basic_ostream<TChar>& target,
+        const MethodThisUsage thisUsage)
+    {
+        switch (thisUsage)
+        {
+        case MethodThisUsage::ExplicitThis:
+            target << "explicit this";
+            break;
+        case MethodThisUsage::NoThis:
+            target << "static";
+            break;
+        }
+
+        return target;
+    }
+
+    // Provides ability to output one custom modifier
+    // to standard streams.
+    // @param target : the stream to output to.
+    // @param customMod : the value to output.
+    template <typename TChar>
+    std::basic_ostream<TChar>& operator<<(
+        std::basic_ostream<TChar>& target,
+        const CustomMod& customMod)
+    {
+        target
+            << "["
+            << (customMod.Required ? "required" : "optional")
+            << " custom modifier: "
+            << HexOutput(customMod.TypeToken)
+            << "]";
+        return target;
+    }
+
+    // Provides ability to output several custom modifiers
+    // to standard streams.
+    // @param target : the stream to output to.
+    // @param customMods : the value to output.
+    template <typename TChar>
+    std::basic_ostream<TChar>& operator<<(
+        std::basic_ostream<TChar>& target,
+        const std::vector<CustomMod>& customMods)
+    {
+        for (const auto& customMod : customMods)
+        {
+            target << customMod;
+        }
+
+        if (!customMods.empty())
+        {
+            target << " ";
+        }
+
+        return target;
+    }
+
+    // Provides ability to output PrimitiveType
+    // to standard streams.
+    // @param target : the stream to output to.
+    // @param type : the value to output.
+    template <typename TChar>
+    std::basic_ostream<TChar>& operator<<(
+        std::basic_ostream<TChar>& target,
+        const PrimitiveType& type)
+    {
+        switch (type.Type())
+        {
+        case CorElementType::ELEMENT_TYPE_BOOLEAN:
+            target << "bool";
+            break;
+        case CorElementType::ELEMENT_TYPE_CHAR:
+            target << "char";
+            break;
+        case CorElementType::ELEMENT_TYPE_I1:
+            target << "sbyte";
+            break;
+        case CorElementType::ELEMENT_TYPE_U1:
+            target << "byte";
+            break;
+        case CorElementType::ELEMENT_TYPE_I2:
+            target << "short";
+            break;
+        case CorElementType::ELEMENT_TYPE_U2:
+            target << "ushort";
+            break;
+        case CorElementType::ELEMENT_TYPE_I4:
+            target << "int";
+            break;
+        case CorElementType::ELEMENT_TYPE_U4:
+            target << "uint";
+            break;
+        case CorElementType::ELEMENT_TYPE_I8:
+            target << "long";
+            break;
+        case CorElementType::ELEMENT_TYPE_U8:
+            target << "ulong";
+            break;
+        case CorElementType::ELEMENT_TYPE_R4:
+            target << "float";
+            break;
+        case CorElementType::ELEMENT_TYPE_R8:
+            target << "double";
+            break;
+        case CorElementType::ELEMENT_TYPE_STRING:
+            target << "string";
+            break;
+        case CorElementType::ELEMENT_TYPE_OBJECT:
+            target << "object";
+            break;
+        case CorElementType::ELEMENT_TYPE_I:
+            target << "System.IntPtr";
+            break;
+        case CorElementType::ELEMENT_TYPE_U:
+            target << "System.UIntPtr";
+            break;
+        }
+
+        return target;
+    }
+
+    // Provides ability to output ArrayShape
+    // to standard streams.
+    // @param target : the stream to output to.
+    // @param shape : the value to output.
+    template <typename TChar>
+    std::basic_ostream<TChar>& operator<<(
+        std::basic_ostream<TChar>& target,
+        const ArrayShape& shape)
+    {
+        target << "[";
+        bool first { true };
+        for (decltype(shape.Rank) i { 0 }; i != shape.Rank; ++i)
+        {
+            if (!first)
+            {
+                target << ", ";
+            }
+
+            const bool hasLowerBound { i < shape.LowerBounds.size() };
+            const bool hasSize { i < shape.Sizes.size() };
+
+            if (hasLowerBound)
+            {
+                const auto lowerBound { shape.LowerBounds[i] };
+                target << lowerBound << " ...";
+                if (hasSize)
+                {
+                    target << ' ' << (lowerBound + static_cast<int32_t>(shape.Sizes[i]));
+                }
+            }
+            else if (hasSize)
+            {
+                target << shape.Sizes[i];
+            }
+
+            first = false;
+        }
+
+        target << "]";
+
+        return target;
+    }
+
+    // Provides ability to output ArrayType
+    // to standard streams.
+    // @param target : the stream to output to.
+    // @param arrayType : the value to output.
+    template <typename TChar>
+    std::basic_ostream<TChar>& operator<<(
+        std::basic_ostream<TChar>& target,
+        const ArrayType& arrayType)
+    {
+        return target << arrayType.ElementType() << arrayType.Shape;
+    }
+
+    // Provides ability to output ClassType
+    // to standard streams.
+    // @param target : the stream to output to.
+    // @param classType : the value to output.
+    template <typename TChar>
+    std::basic_ostream<TChar>& operator<<(
+        std::basic_ostream<TChar>& target,
+        const ClassType classType)
+    {
+        return target
+            << "{ class "
+            << HexOutput(classType.Class)
+            << " }";
+    }
+
+    // Provides ability to output StructType
+    // to standard streams.
+    // @param target : the stream to output to.
+    // @param structType : the value to output.
+    template <typename TChar>
+    std::basic_ostream<TChar>& operator<<(
+        std::basic_ostream<TChar>& target,
+        const StructType structType)
+    {
+        return target
+            << "{ struct "
+            << HexOutput(structType.Struct)
+            << " }";
+    }
+
+    // Provides ability to output FunctionPointerType
+    // to standard streams.
+    // @param target : the stream to output to.
+    // @param functionPointer : the value to output.
+    template <typename TChar>
+    std::basic_ostream<TChar>& operator<<(
+        std::basic_ostream<TChar>& target,
+        const FunctionPointerType& functionPointer)
+    {
+        return target
+            << InRoundBrackets(functionPointer.TargetSignature())
+            << "*";
+    }
+
+    // Provides ability to output GenericInstanceType
+    // to standard streams.
+    // @param target : the stream to output to.
+    // @param closedGenericType : the value to output.
+    template <typename TChar>
+    std::basic_ostream<TChar>& operator<<(
+        std::basic_ostream<TChar>& target,
+        const GenericInstanceType& closedGenericType)
+    {
+        if (closedGenericType.IsValueType)
+        {
+            target << StructType { closedGenericType.GenericType };
+        }
+        else
+        {
+            target << ClassType { closedGenericType.GenericType };
+        }
+
+        return target << '<' << Delimitered(closedGenericType.GenericParameters, ", ") << '>';
+    }
+
+    // Provides ability to output MethodGenericArgument
+    // to standard streams.
+    // @param target : the stream to output to.
+    // @param genericArgument : the value to output.
+    template <typename TChar>
+    std::basic_ostream<TChar>& operator<<(
+        std::basic_ostream<TChar>& target,
+        const MethodGenericArgument genericArgument)
+    {
+        return target << "MethodGenericArguments" << InSquareBrackets(genericArgument.Index);
+    }
+
+    // Provides ability to output TypeGenericArgument
+    // to standard streams.
+    // @param target : the stream to output to.
+    // @param genericArgument : the value to output.
+    template <typename TChar>
+    std::basic_ostream<TChar>& operator<<(
+        std::basic_ostream<TChar>& target,
+        const TypeGenericArgument genericArgument)
+    {
+        return target << "TypeGenericArguments" << InSquareBrackets(genericArgument.Index);
+    }
+
+    // Provides ability to output PointerType
+    // to standard streams.
+    // @param target : the stream to output to.
+    // @param pointer : the value to output.
+    template <typename TChar>
+    std::basic_ostream<TChar>& operator<<(
+        std::basic_ostream<TChar>& target,
+        const PointerType& pointer)
+    {
+        target << pointer.CustomMods;
+        if (pointer.ValueType == nullptr)
+        {
+            target << "void";
+        }
+        else
+        {
+            target << *pointer.ValueType;
+        }
+
+        return target << "*";
+    }
+
+    // Provides ability to output ZeroBasedArrayType
+    // to standard streams.
+    // @param target : the stream to output to.
+    // @param zeroBasedArray : the value to output.
+    template <typename TChar>
+    std::basic_ostream<TChar>& operator<<(
+        std::basic_ostream<TChar>& target,
+        const ZeroBasedArrayType& zeroBasedArray)
+    {
+        return target
+            << zeroBasedArray.CustomMods
+            << zeroBasedArray.ElementType()
+            << "[]";
+    }
+
+    // Provides ability to output variable Type
+    // to standard streams.
+    // @param target : the stream to output to.
+    // @param type : the value to output.
+    template <typename TChar>
+    std::basic_ostream<TChar>& operator<<(
+        std::basic_ostream<TChar>& target,
+        const Type& type)
+    {
+        std::visit(
+            [&target](const auto& typeOption)
+            {
+                target << typeOption;
+            },
+            type);
+
+        return target;
+    }
+
+    // Provides ability to output ObsoleteParameterPassed
+    // to standard streams.
+    // @param target : the stream to output to.
+    // @param obsoleteParameter : the value to output.
+    template <typename TChar>
+    std::basic_ostream<TChar>& operator<<(
+        std::basic_ostream<TChar>& target,
+        const ObsoleteParameterPassed obsoleteParameter)
+    {
+        return target << "System.TypedReference";
+    }
+
+    // Provides ability to output ModernParameterPassed
+    // to standard streams.
+    // @param target : the stream to output to.
+    // @param modernParameter : the value to output.
+    template <typename TChar>
+    std::basic_ostream<TChar>& operator<<(
+        std::basic_ostream<TChar>& target,
+        const ModernParameterPassed& modernParameter)
+    {
+        if (modernParameter.IsPassedByReference)
+        {
+            target << "ref ";
+        }
+
+        return target << modernParameter.ParameterType;
+    }
+
+    // Provides ability to output ParameterType
+    // to standard streams.
+    // @param target : the stream to output to.
+    // @param parameter : the value to output.
+    template <typename TChar>
+    std::basic_ostream<TChar>& operator<<(
+        std::basic_ostream<TChar>& target,
+        const ParameterType& parameter)
+    {
+        target << parameter.CustomMods;
+
+        std::visit(
+            [&target](const auto& pass)
+            {
+                target << pass;
+            },
+            parameter.PassDescription);
+
+        return target;
+    }
+
+    // Provides ability to output ReturnType
+    // to standard streams.
+    // @param target : the stream to output to.
+    // @param returnType : the value to output.
+    template <typename TChar>
+    std::basic_ostream<TChar>& operator<<(
+        std::basic_ostream<TChar>& target,
+        const ReturnType& returnType)
+    {
+        target << returnType.CustomMods;
+        if (!returnType.PassDescription.has_value())
+        {
+            return target << "void";
+        }
+
+        std::visit(
+            [&target](const auto& pass)
+            {
+                target << pass;
+            },
+            *returnType.PassDescription);
+
+        return target;
+    }
+
+    // Provides ability to output MethodSignature
+    // to standard streams.
+    // @param target : the stream to output to.
+    // @param signature : the value to output.
+    template <typename TChar>
+    std::basic_ostream<TChar>& operator<<(
+        std::basic_ostream<TChar>& target,
+        const MethodSignature& signature)
+    {
+        return target
+            << signature.WritePreamble()
+            << signature.WriteParameters();
+    }
 }


### PR DESCRIPTION
Work under EPMDJ-2316

- Fix `HexOutput` for non-Unicode streams.
- Create `Signature.h` and related files as a place for further changes.
- Parsing binary signature blobs to `MethodSignature`, which also supports serialization back to blob and output to standard streams.
- Update `ICoreInteract` and implementations to retrieve signature blobs of methods.
- Output method signature when decompiling.