### PR TITLE
EPMDJ-2299/EPMDJ-2430: Various follow-up fixes

### DIFF
--- a/Drill4dotNet/Drill4dotNet-Tests/CProfilerCallbackTest.cpp
+++ b/Drill4dotNet/Drill4dotNet-Tests/CProfilerCallbackTest.cpp
@@ -15,8 +15,7 @@ class CProfilerCallbackTest : public Test
 public:
     void SetUp()
     {
-        connectorMock.emplace();
-        proClient.emplace(*connectorMock);
+        proClient.emplace();
         profilerCallback.emplace(*proClient);
         WCHAR injectionFileName[_MAX_PATH];
         ::GetModuleFileName(NULL, injectionFileName, _MAX_PATH);
@@ -27,13 +26,9 @@ public:
     {
         profilerCallback.reset();
         proClient.reset();
-        // Dirty hack to workaround leaked mock objects GTest bug when using shared_ptr
-        // Refer to https://github.com/google/googletest/issues/1310
-        connectorMock.reset();
     }
 
     std::optional<ProClient<ConnectorMock>> proClient;
-    std::optional<ConnectorMock> connectorMock;
     std::optional<CProfilerCallback<
         ConnectorMock,
         CoreInteractMock,
@@ -46,11 +41,6 @@ public:
 TEST_F(CProfilerCallbackTest, GetClient)
 {
     EXPECT_EQ(&*proClient, &profilerCallback->GetClient());
-}
-
-TEST_F(CProfilerCallbackTest, Client_GetConnector)
-{
-    EXPECT_EQ(&(connectorMock.value()), &(proClient->GetConnector()));
 }
 
 TEST_F(CProfilerCallbackTest, Initialize_Shutdown)
@@ -86,7 +76,7 @@ TEST_F(CProfilerCallbackTest, Initialize_Shutdown)
         EXPECT_CALL(metaDataImportMock, EnumMethodsWithName(expectedInjection.Class, injectionMethodName)).WillOnce(Return(std::vector { expectedInjection.Function }));
     }) };
 
-    EXPECT_CALL(*connectorMock, SendMessage1("ready")).WillOnce(Return());
+    EXPECT_CALL(proClient->GetConnector(), SendMessage1("ready")).WillOnce(Return());
 
     IUnknown* p = reinterpret_cast<IUnknown*>(this);
     EXPECT_HRESULT_SUCCEEDED(profilerCallback->Initialize(p));

--- a/Drill4dotNet/Drill4dotNet/CDrillProfiler.cpp
+++ b/Drill4dotNet/Drill4dotNet/CDrillProfiler.cpp
@@ -7,7 +7,7 @@ namespace Drill4dotNet
 
     CDrillProfiler::CDrillProfiler()
         : CProfilerCallback(dynamic_cast<ProClient<Connector>&>(*this))
-        , ProClient(Connector{})
+        , ProClient()
     {
     }
 

--- a/Drill4dotNet/Drill4dotNet/CProfilerCallback.h
+++ b/Drill4dotNet/Drill4dotNet/CProfilerCallback.h
@@ -29,9 +29,10 @@ namespace Drill4dotNet
         result.moduleId = functionInfo.moduleId;
         result.classId = functionInfo.classId;
         result.token = functionInfo.token;
+        MethodProps methodProps { metadataImport.GetMethodProps(functionInfo.token) };
         result.name = FunctionName {
-            metadataImport.GetMethodProps(functionInfo.token).Name,
-            metadataImport.GetTypeDefProps(functionInfo.classId).Name };
+            methodProps.Name,
+            metadataImport.GetTypeDefProps(methodProps.EnclosingClass).Name };
         return result;
     }
 
@@ -658,10 +659,16 @@ namespace Drill4dotNet
                 // NOPs will be added to show ability to turn short branching instructions
                 // into long ones.
 
-                const FunctionInfo functionInfo{
+                const FunctionInfoWithoutName functionInfoWithoutName {
                     m_corProfilerInfo->GetFunctionInfo(functionId) };
 
-                const std::vector<std::byte> functionBytes{
+                const auto moduleMetaData { m_corProfilerInfo->GetModuleMetadata(
+                    functionInfoWithoutName.moduleId,
+                    LogToProClient(m_pImplClient)) };
+
+                const FunctionInfo functionInfo { GetFunctionInfo(moduleMetaData, functionInfoWithoutName) };
+
+                const std::vector<std::byte> functionBytes {
                     m_corProfilerInfo->GetMethodIntermediateLanguageBody(functionInfo) };
 
                 GetClient().Log()

--- a/Drill4dotNet/Drill4dotNet/ComInitializer.h
+++ b/Drill4dotNet/Drill4dotNet/ComInitializer.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include "ComWrapperBase.h"
+
+namespace Drill4dotNet
+{
+    // RAII-style wrapper for CoInitialize / CoUninitialize.
+    // with logging and error handling capability.
+    template <Logger TLogger>
+    class ComInitializer : protected ComWrapperBase<TLogger>
+    {
+    private:
+        bool m_initialized{ false };
+
+        void UnInitialize() const noexcept
+        {
+            CoUninitialize();
+        }
+
+        auto CoInitializeCallable() const
+        {
+            return []()
+            {
+                return ::CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+            };
+        }
+
+    public:
+        // Creates a new instance.
+        // @param logger : the tool to log errors.
+        ComInitializer(TLogger logger)
+            : ComWrapperBase(logger)
+        {
+        }
+
+        // Wraps CoInitialize. Throws _com_error in case of an error.
+        void Initialize()
+        {
+            CallComOrThrow(
+                CoInitializeCallable(),
+                L"ComInitializer::Initialize: failed to call CoInitializeEx.");
+            m_initialized = true;
+        }
+
+        // Wraps CoInitialize. Returns false in case of an error.
+        bool TryInitialize()
+        {
+            m_initialized = this->TryCallCom(
+                CoInitializeCallable(),
+                L"ComInitializer::TryInitialize: failed to call CoInitializeEx.");
+            return m_initialized;
+        }
+
+        // Wraps CoUninitialize.
+        ~ComInitializer()
+        {
+            if (m_initialized)
+            {
+                UnInitialize();
+            }
+        }
+
+        ComInitializer(const ComInitializer&) = delete;
+        ComInitializer& operator=(const ComInitializer&) & = delete;
+
+        // Move constructor.
+        ComInitializer(ComInitializer&& other)
+            : m_initialized{ std::exchange(other.m_initialized, false) }
+        {
+        }
+
+        // Move assignment operator.
+        ComInitializer& operator=(ComInitializer&& other) &
+        {
+            if (m_initialized)
+            {
+                UnInitialize();
+            }
+
+            m_initialized = std::exchange(other.m_initialized, false);
+            return *this;
+        }
+    };
+}

--- a/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj
+++ b/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj
@@ -87,7 +87,6 @@
       <ModuleDefinitionFile>.\Drill4dotNet.def</ModuleDefinitionFile>
       <RegisterOutput>false</RegisterOutput>
       <AdditionalOptions>/ignore:4099 %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalDependencies>Rometadata.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -124,12 +123,12 @@
       <OptimizeReferences>true</OptimizeReferences>
       <RegisterOutput>false</RegisterOutput>
       <AdditionalOptions>/ignore:4099 %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalDependencies>Rometadata.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="ByteUtils.h" />
     <ClInclude Include="..\Connector\Connector.h" />
+    <ClInclude Include="ComInitializer.h" />
     <ClInclude Include="CProfilerCallbackBase.h" />
     <ClInclude Include="ICorProfilerInfo.h" />
     <ClInclude Include="IMetaDataAssemblyImport.h" />

--- a/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj.filters
+++ b/Drill4dotNet/Drill4dotNet/Drill4dotNet.vcxproj.filters
@@ -121,6 +121,9 @@
     <ClInclude Include="MetaDataDispenser.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="ComInitializer.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Drill4dotNet.cpp">

--- a/Drill4dotNet/Drill4dotNet/MetaDataImport.h
+++ b/Drill4dotNet/Drill4dotNet/MetaDataImport.h
@@ -370,9 +370,9 @@ namespace Drill4dotNet
             const std::wstring& name) const
         {
             MetaDataEnum enumeration { *this };
-            mdMethodDef chunk[16];
+            constexpr ULONG chunkLength { 16 };
+            std::array<mdMethodDef, chunkLength> chunk;
             std::vector<mdMethodDef> result{};
-            constexpr ULONG chunkLength { std::extent_v<decltype(chunk)> };
             while (true)
             {
                 ULONG methodsRetrieved;
@@ -381,7 +381,7 @@ namespace Drill4dotNet
                     EnumMethodsWithNameCallable(
                         enclosingType,
                         name,
-                        chunk,
+                        chunk.data(),
                         chunkLength,
                         methodsRetrieved,
                         enumeration.Value,
@@ -395,8 +395,8 @@ namespace Drill4dotNet
 
                 result.insert(
                     result.cend(),
-                    std::cbegin(chunk),
-                    std::cend(chunk) + methodsRetrieved);
+                    chunk.cbegin(),
+                    chunk.cbegin() + methodsRetrieved);
 
                 if (methodsRetrieved < chunkLength)
                 {
@@ -414,9 +414,9 @@ namespace Drill4dotNet
             const std::wstring& name) const
         {
             MetaDataEnum enumeration { *this };
-            mdMethodDef chunk[16];
+            constexpr ULONG chunkLength{ 16 };
+            std::array<mdMethodDef, chunkLength> chunk;
             std::vector<mdMethodDef> result{};
-            constexpr ULONG chunkLength{ std::extent_v<decltype(chunk)> };
             while (true)
             {
                 HRESULT peekResult;
@@ -425,7 +425,7 @@ namespace Drill4dotNet
                         EnumMethodsWithNameCallable(
                             enclosingType,
                             name,
-                            chunk,
+                            chunk.data(),
                             chunkLength,
                             methodsRetrieved,
                             enumeration.Value,
@@ -439,8 +439,8 @@ namespace Drill4dotNet
 
                     result.insert(
                         result.cend(),
-                        std::cbegin(chunk),
-                        std::cend(chunk) + methodsRetrieved);
+                        chunk.cbegin(),
+                        chunk.cend() + methodsRetrieved);
 
                     if (methodsRetrieved < chunkLength)
                     {

--- a/Drill4dotNet/Drill4dotNet/ProClient.h
+++ b/Drill4dotNet/Drill4dotNet/ProClient.h
@@ -15,14 +15,13 @@ namespace Drill4dotNet
         std::wostream& m_ostream;
         std::wistream& m_istream;
         InfoHandler m_infoHandler;
-        TConnector& m_connector;
+        TConnector m_connector{};
 
     public:
-        ProClient(TConnector& connector)
+        ProClient()
             : m_ostream(std::wcout),
             m_istream(std::wcin),
-            m_infoHandler(m_ostream),
-            m_connector(connector)
+            m_infoHandler(m_ostream)
         {
         }
 


### PR DESCRIPTION
Fix issues found after #38 :
- Stop using `MetaDataGetDispenser` function from `rometadata.dll`.
Previously, we were using `MetaDataGetDispenser` function from WinRT API.
This function is not a part of .NET API, and the usage caused a lot of runtime conflicts and issues.
Now, we use `CoCreateInstance` with the required GUIDs directly.
- Fix early disposal of `Connector`: create it directly in `ProClient`.
- Fix array handling in `MetaDataImport::EnumMethodsWithName` and `MetaDataImport::TryEnumMethodsWithName`.
- Fix `GetFunctionInfo` method for `JitCompilationStarted` - wrong Id was used for `GetMethodProps`.