### PR TITLE
Allow filtering of assemblies being profiled

### DIFF
--- a/Drill4dotNet/Connector/Connector.h
+++ b/Drill4dotNet/Connector/Connector.h
@@ -53,12 +53,26 @@ namespace Drill4dotNet
         std::vector<AstMethod> methods;
     };
 
+    class PackagesPrefixes
+    {
+    public:
+        std::vector<std::wstring> packagesPrefixes;
+    };
+
     // Determines whether the given functor can be
     // used as a source of classes tree.
     template <typename F>
     concept IsTreeProvider = requires (const F& f)
     {
         { f() } -> std::same_as<std::vector<AstEntity>>;
+    };
+
+    // Determines whether the given functor can be
+    // used as a handler of assembly filter.
+    template <typename F>
+    concept IsPackagesPrefixesHandler = requires (F f, PackagesPrefixes prefixes)
+    {
+        { f(prefixes) } -> std::same_as<void>;
     };
 
     // Determines whether the given type can be used for
@@ -85,5 +99,6 @@ namespace Drill4dotNet
         { x.WaitForNextMessage(std::declval<const DWORD>()) } -> std::same_as<void>;
 
         { x.TreeProvider() } -> IsTreeProvider;
+        { x.PackagesPrefixesHandler() } -> IsPackagesPrefixesHandler;
     };
 }

--- a/Drill4dotNet/Connector/ConnectorImplementation.h
+++ b/Drill4dotNet/Connector/ConnectorImplementation.h
@@ -199,7 +199,7 @@ namespace Drill4dotNet
         std::wstring result(
             MultiByteToWideChar(
                 CP_UTF8,
-                WC_ERR_INVALID_CHARS,
+                MB_ERR_INVALID_CHARS,
                 string.c_str(),
                 string.size(),
                 nullptr,
@@ -208,7 +208,7 @@ namespace Drill4dotNet
 
         if (MultiByteToWideChar(
             CP_UTF8,
-            WC_ERR_INVALID_CHARS,
+            MB_ERR_INVALID_CHARS,
             string.c_str(),
             string.size(),
             result.data(),

--- a/Drill4dotNet/Connector/main.cpp
+++ b/Drill4dotNet/Connector/main.cpp
@@ -24,18 +24,30 @@ int main(int argc, char** argv)
 
     try
     {
-        Connector connector{ []() {
-            return std::vector {
-                AstEntity {
-                    L"my_path",
-                    L"my_name",
-                    std::vector {
-                        AstMethod {
-                            std::wstring { L"my_method" },
-                            std::vector { std::wstring { L"my_param" } },
-                            L"my_return_type",
-                            1,
-                            std::vector { uint32_t { 42 } } } } } }; } };
+        Connector connector {
+            []()
+            {
+                return std::vector {
+                    AstEntity {
+                        L"my_path",
+                        L"my_name",
+                        std::vector {
+                            AstMethod {
+                                std::wstring { L"my_method" },
+                                std::vector { std::wstring { L"my_param" } },
+                                L"my_return_type",
+                                1,
+                                std::vector { uint32_t { 42 } } } } } };
+            },
+            [](const PackagesPrefixes& prefixes)
+            {
+                std::wcout << L"Received packages prefixes settings:" << std::endl;
+                for (const auto& item : prefixes.packagesPrefixes)
+                {
+                    std::wcout << L'\t' << item << std::endl;
+                }
+            }
+        };
 
         connector.InitializeAgent();
         int x;

--- a/Drill4dotNet/Drill4dotNet-Tests/ConnectorMock.h
+++ b/Drill4dotNet/Drill4dotNet-Tests/ConnectorMock.h
@@ -10,6 +10,7 @@ namespace Drill4dotNet
     {
     public:
         MOCK_METHOD(std::function<std::vector<AstEntity>()>&, TreeProvider, ());
+        MOCK_METHOD(std::function<void(const PackagesPrefixes&)>&, PackagesPrefixesHandler, ());
         MOCK_METHOD(void, InitializeAgent, ());
         MOCK_METHOD(void, SendAgentMessage, (const std::string&, const std::string&, const std::string&));
         MOCK_METHOD(void, SendPluginMessage, (const std::string&, const std::string&));
@@ -21,7 +22,9 @@ namespace Drill4dotNet
         {
         }
 
-        ConnectorMock(const std::function<std::vector<AstEntity>()>&)
+        ConnectorMock(
+            const std::function<std::vector<AstEntity>()>&,
+            const std::function<void(const PackagesPrefixes&)>&)
             : ConnectorMock()
         {
         }

--- a/Drill4dotNet/Drill4dotNet/CDrillProfiler.cpp
+++ b/Drill4dotNet/Drill4dotNet/CDrillProfiler.cpp
@@ -6,7 +6,7 @@ namespace Drill4dotNet
 {
 
     CDrillProfiler::CDrillProfiler()
-        : CProfilerCallback(dynamic_cast<ProClient<Connector<std::function<std::vector<AstEntity>()>>>&>(*this))
+        : CProfilerCallback(dynamic_cast<ProClient<TConnector>&>(*this))
         , ProClient()
     {
     }

--- a/Drill4dotNet/Drill4dotNet/CDrillProfiler.h
+++ b/Drill4dotNet/Drill4dotNet/CDrillProfiler.h
@@ -9,17 +9,19 @@
 
 namespace Drill4dotNet
 {
+    using TConnector = Connector<std::function<std::vector<AstEntity>()>>;
+    using TLogger = LogToProClient<TConnector>;
     class ATL_NO_VTABLE CDrillProfiler
         : public ATL::CComObjectRootEx<ATL::CComSingleThreadModel>
         , public ATL::CComCoClass<CDrillProfiler, &CLSID_DrillProfiler>
-        , public ProClient<Connector<std::function<std::vector<AstEntity>()>>>
+        , public ProClient<TConnector>
         , public CProfilerCallback<
-            Connector<std::function<std::vector<AstEntity>()>>,
-            CorProfilerInfo<LogToProClient<Connector<std::function<std::vector<AstEntity>()>>>>,
-            MetaDataDispenser<LogToProClient<Connector<std::function<std::vector<AstEntity>()>>>>,
-            MetaDataAssemblyImport<LogToProClient<Connector<std::function<std::vector<AstEntity>()>>>>,
-            MetaDataImport<LogToProClient<Connector<std::function<std::vector<AstEntity>()>>>>,
-            LogToProClient<Connector<std::function<std::vector<AstEntity>()>>>>
+            TConnector,
+            CorProfilerInfo<TLogger>,
+            MetaDataDispenser<TLogger>,
+            MetaDataAssemblyImport<TLogger>,
+            MetaDataImport<TLogger>,
+            TLogger>
     {
     public:
         CDrillProfiler();

--- a/Drill4dotNet/Drill4dotNet/CDrillProfiler.h
+++ b/Drill4dotNet/Drill4dotNet/CDrillProfiler.h
@@ -9,7 +9,7 @@
 
 namespace Drill4dotNet
 {
-    using TConnector = Connector<std::function<std::vector<AstEntity>()>>;
+    using TConnector = Connector<std::function<std::vector<AstEntity>()>, std::function<void(const PackagesPrefixes&)>>;
     using TLogger = LogToProClient<TConnector>;
     class ATL_NO_VTABLE CDrillProfiler
         : public ATL::CComObjectRootEx<ATL::CComSingleThreadModel>

--- a/Drill4dotNet/Drill4dotNet/CProfilerCallback.h
+++ b/Drill4dotNet/Drill4dotNet/CProfilerCallback.h
@@ -750,6 +750,8 @@ namespace Drill4dotNet
                     << functionInfo.fullName()
                     << L" "
                     << signature.ParsedValue.WriteParameters()
+                    << L" RVA: "
+                    << HexOutput(moduleMetaData.GetMethodProps(functionInfo.token).CodeRelativeVirtualAddress)
                     << L" IL Body size: "
                     << functionBytes.size()
                     << L" bytes";

--- a/Drill4dotNet/Drill4dotNet/OutputUtils.h
+++ b/Drill4dotNet/Drill4dotNet/OutputUtils.h
@@ -343,4 +343,50 @@ namespace Drill4dotNet
         }
         return target;
     }
+
+    template<typename TChar>
+    int CompareIgnoreCase(
+        std::basic_string<TChar> left,
+        std::basic_string<TChar> right,
+        size_t partToCompare)
+    {
+        for (ptrdiff_t i { 0 }; i != partToCompare; ++i)
+        {
+            if (left.size() == i)
+            {
+                if (right.size() == i)
+                {
+                    return true;
+                }
+                else
+                {
+                    return -1;
+                }
+            }
+            else if (right.size() == i)
+            {
+                return +1;
+            }
+            else
+            {
+                TChar leftLower { std::tolower(left[i], std::locale::classic()) };
+                TChar rightLower { std::tolower(right[i], std::locale::classic()) };
+                if (leftLower != rightLower)
+                {
+                    return leftLower - rightLower;
+                }
+            }
+        }
+
+        return 0;
+    }
+
+    template<typename TChar>
+    bool StartsWithIgnoreCase(std::basic_string<TChar> stringToTest, std::basic_string<TChar> prefix)
+    {
+        return CompareIgnoreCase(
+            stringToTest,
+            prefix,
+            prefix.size()) == 0;
+    }
 }

--- a/Drill4dotNet/Drill4dotNet/ProClient.h
+++ b/Drill4dotNet/Drill4dotNet/ProClient.h
@@ -15,7 +15,9 @@ namespace Drill4dotNet
         std::wostream& m_ostream;
         std::wistream& m_istream;
         InfoHandler m_infoHandler;
-        TConnector m_connector { std::function<std::vector<AstEntity>()>{} };
+        TConnector m_connector {
+            std::function<std::vector<AstEntity>()>{},
+            std::function<void(const PackagesPrefixes&)>{} };
 
     public:
         ProClient()

--- a/HelloWorld/Calculator/Calculator.csproj
+++ b/HelloWorld/Calculator/Calculator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <OutputType>WinExe</OutputType>
+    <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWPF>true</UseWPF>
     <Platforms>x64</Platforms>


### PR DESCRIPTION
Work under EPMDJ-2305

### Output RVA for methods being decompiled

### Fix the `DecodeUtf8` function

Previously, wrong flags were used for `MultiBytToWideChar` function.
As a result, the `DecodeUtf8` function returned empty string.

Now, the right flags are used, and the function is working properly.

### Initialize agent in a separate thread

This is required to work with Windows applications.

### Make the Calculator a console application

Currently, there is a limitation in the native agent connector - it can only work with console applications.
Until this issue is fixed, the Calculator application will spawn a console.

### Refactor `CDrillProfiler` declarations

### Introduce `PackagesPrefixesHandler` to allow filtering of assemblies
