### PR TITLE
Send mock coverage data

### DIFF
--- a/Drill4dotNet/Connector/Connector.h
+++ b/Drill4dotNet/Connector/Connector.h
@@ -59,6 +59,52 @@ namespace Drill4dotNet
         std::vector<std::wstring> packagesPrefixes;
     };
 
+    class StartPayload
+    {
+    public:
+        std::wstring testType { L"AUTO" };
+
+        std::wstring sessionId;
+    };
+
+    class StartSessionHttpRequest
+    {
+    public:
+        std::string type { "START" };
+
+        StartPayload payload;
+
+        StartSessionHttpRequest() = default;
+
+        StartSessionHttpRequest(StartPayload payload)
+            : payload { payload }
+        {
+        }
+    };
+
+    class SessionPayload
+    {
+    public:
+        std::wstring sessionId;
+    };
+
+    class StopSession
+    {
+    public:
+        inline static const std::string Discriminator { "STOP" };
+
+        std::string type { Discriminator };
+
+        SessionPayload payload;
+
+        StopSession() = default;
+
+        StopSession(SessionPayload payload)
+            : payload { payload }
+        {
+        }
+    };
+
     // Determines whether the given functor can be
     // used as a source of classes tree.
     template <typename F>

--- a/Drill4dotNet/Connector/Connector.h
+++ b/Drill4dotNet/Connector/Connector.h
@@ -273,6 +273,59 @@ namespace Drill4dotNet
         std::wstring message;
     };
 
+    class ScopeInitialized
+    {
+    public:
+        std::string type { "SCOPE_INITIALIZED" };
+
+        std::wstring id;
+
+        std::wstring name;
+
+        std::wstring prevId;
+
+        int64_t ts;
+
+        ScopeInitialized() = default;
+
+        ScopeInitialized(
+            std::wstring id,
+            std::wstring name,
+            std::wstring prevId,
+            int64_t ts)
+            : id { id },
+            name { name },
+            prevId { prevId },
+            ts { ts }
+        {
+        }
+    };
+
+    class InitScopePayload
+    {
+    public:
+        std::wstring id;
+        std::wstring name;
+        std::wstring prevId;
+    };
+
+    class InitActiveScope
+    {
+    public:
+        inline static const std::string Discriminator { "INIT_ACTIVE_SCOPE" };
+
+        std::string type { Discriminator };
+
+        InitScopePayload payload;
+
+        InitActiveScope() = default;
+
+        InitActiveScope(InitScopePayload payload)
+            : payload { payload }
+        {
+        }
+    };
+
     // Determines whether the given functor can be
     // used as a source of classes tree.
     template <typename F>

--- a/Drill4dotNet/Connector/Connector.h
+++ b/Drill4dotNet/Connector/Connector.h
@@ -105,6 +105,174 @@ namespace Drill4dotNet
         }
     };
 
+    class SessionStarted
+    {
+    public:
+        std::string type { "SESSION_STARTED" };
+
+        std::wstring sessionId;
+
+        std::wstring testType;
+
+        int64_t ts;
+
+        SessionStarted() = default;
+
+        SessionStarted(
+            std::wstring sessionId,
+            std::wstring testType,
+            int64_t ts)
+            : sessionId { sessionId },
+            testType { testType },
+            ts { ts }
+        {
+        }
+    };
+
+    class SessionCancelled
+    {
+    public:
+        std::string type { "SESSION_CANCELLED" };
+
+        std::wstring sessionId;
+
+        int64_t ts;
+
+        SessionCancelled() = default;
+
+        SessionCancelled(
+            std::wstring sessionId,
+            int64_t ts)
+            : sessionId { sessionId },
+            ts { ts }
+        {
+        }
+    };
+
+    class AllSessionsCancelled
+    {
+    public:
+        std::string type { "ALL_SESSIONS_CANCELLED" };
+
+        std::vector<std::wstring> ids;
+
+        int64_t ts;
+
+        AllSessionsCancelled() = default;
+
+        AllSessionsCancelled(
+            std::vector<std::wstring> ids,
+            int64_t ts)
+            : ids { ids },
+            ts { ts }
+        {
+        }
+    };
+
+    class ExecClassData
+    {
+    public:
+        int64_t id { 0 };
+
+        std::wstring className;
+
+        std::vector<bool> probes;
+
+        std::wstring testName { L"" };
+    };
+
+    class CoverDataPart
+    {
+    public:
+        std::string type { "COVERAGE_DATA_PART" };
+
+        std::wstring sessionId;
+
+        std::vector<ExecClassData> data;
+
+        CoverDataPart() = default;
+
+        CoverDataPart(
+            std::wstring sessionId,
+            std::vector<ExecClassData> data)
+            : sessionId { sessionId },
+            data { data }
+        {
+        }
+    };
+
+    class SessionChanged
+    {
+    public:
+        std::string type { "SESSION_CHANGED" };
+
+        std::wstring sessionId;
+
+        int32_t probeCount;
+
+        SessionChanged() = default;
+
+        SessionChanged(
+            std::wstring sessionId,
+            int32_t probeCount)
+            : sessionId { sessionId },
+            probeCount { probeCount }
+        {
+        }
+    };
+
+    class SessionFinished
+    {
+    public:
+        std::string type { "SESSION_FINISHED" };
+
+        std::wstring sessionId;
+
+        int64_t ts;
+
+        SessionFinished() = default;
+
+        SessionFinished(
+            std::wstring sessionId,
+            int64_t ts)
+            : sessionId { sessionId },
+            ts { ts }
+        {
+        }
+    };
+
+    class StartSessionPayload
+    {
+    public:
+        std::wstring sessionId;
+
+        StartPayload startPayload;
+    };
+
+    class StartSession
+    {
+    public:
+        inline static const std::string Discriminator { "START_AGENT_SESSION" };
+
+        std::string type { Discriminator };
+
+        StartSessionPayload payload;
+
+        StartSession() = default;
+
+        StartSession(StartSessionPayload payload)
+            : payload { payload }
+        {
+        }
+    };
+
+    class PluginAction
+    {
+    public:
+        std::wstring id;
+        std::wstring message;
+    };
+
     // Determines whether the given functor can be
     // used as a source of classes tree.
     template <typename F>

--- a/Drill4dotNet/Connector/ConnectorImplementation.h
+++ b/Drill4dotNet/Connector/ConnectorImplementation.h
@@ -427,6 +427,66 @@ namespace Drill4dotNet
         }
     }
 
+    // Converts a SessionPayload object to json format.
+    static void to_json(nlohmann::json& target, const SessionPayload& data)
+    {
+        target = nlohmann::json { { "sessionId", EncodeUtf8(data.sessionId) } };
+    }
+
+    // Gets a SessionPayload object from json.
+    static void from_json(const nlohmann::json& source, SessionPayload& target)
+    {
+        target.sessionId = DecodeUtf8(source.at("sessionId").get<std::string>());
+    }
+
+    // Converts a StopSession object to json format.
+    static void to_json(nlohmann::json& target, const StopSession& data)
+    {
+        target = nlohmann::json {
+            { "type", data.type },
+            { "payload", data.payload }
+        };
+    }
+
+    // Gets a StopSession object from json.
+    static void from_json(const nlohmann::json& source, StopSession& target)
+    {
+        source.at("type").get_to(target.type);
+        source.at("payload").get_to(target.payload);
+    }
+
+    // Converts a StartPayload object to json format.
+    static void to_json(nlohmann::json& target, const StartPayload& data)
+    {
+        target = nlohmann::json {
+            { "testType", EncodeUtf8(data.testType) },
+            { "sessionId", EncodeUtf8(data.sessionId) }
+        };
+    }
+
+    // Gets a StartPayload object from json.
+    static void from_json(const nlohmann::json& source, StartPayload& target)
+    {
+        target.testType = DecodeUtf8(source.at("testType").get<std::string>());
+        target.sessionId = DecodeUtf8(source.at("sessionId").get<std::string>());
+    }
+
+    // Converts a StartSessionHttpRequest object to json format.
+    static void to_json(nlohmann::json& target, const StartSessionHttpRequest& data)
+    {
+        target = nlohmann::json {
+            { "type", data.type },
+            { "payload", data.payload }
+        };
+    }
+
+    // Gets a StartSessionHttpRequest object from json.
+    static void from_json(const nlohmann::json& source, StartSessionHttpRequest& target)
+    {
+        source.at("type").get_to(target.type);
+        source.at("payload").get_to(target.payload);
+    }
+
     template <
         IsTreeProvider TreeProvider,
         IsPackagesPrefixesHandler PackagesPrefixesHandler>

--- a/Drill4dotNet/Connector/ConnectorImplementation.h
+++ b/Drill4dotNet/Connector/ConnectorImplementation.h
@@ -280,12 +280,9 @@ namespace Drill4dotNet
     // Gets an AstMethod object from json.
     static void from_json(const nlohmann::json& source, AstMethod& target)
     {
-        std::string string;
-        source.at("name").get_to(string);
-        target.name = DecodeUtf8(string);
+        target.name = DecodeUtf8(source.at("name").get<std::string>());
 
-        std::vector<std::string> params{};
-        source.at("params").get_to(params);
+        std::vector<std::string> params { source.at("params").get<std::vector<std::string>>() };
         target.params.clear();
         target.params.reserve(params.size());
         for (const auto& param : params)
@@ -293,8 +290,7 @@ namespace Drill4dotNet
             target.params.push_back(DecodeUtf8(param));
         }
 
-        source.at("returnType").get_to(string);
-        target.returnType = DecodeUtf8(string);
+        target.returnType = DecodeUtf8(source.at("returnType").get<std::string>());
 
         source.at("count").get_to(target.count);
         source.at("probes").get_to(target.probes);
@@ -313,13 +309,8 @@ namespace Drill4dotNet
     // Gets an AstEntity object from json.
     static void from_json(const nlohmann::json& source, AstEntity& target)
     {
-        std::string string;
-        source.at("path").get_to(string);
-        target.path = DecodeUtf8(string);
-
-        source.at("name").get_to(string);
-        target.name = DecodeUtf8(string);
-
+        target.path = DecodeUtf8(source.at("path").get<std::string>());
+        target.name = DecodeUtf8(source.at("name").get<std::string>());
         source.at("methods").get_to(target.methods);
     }
 
@@ -427,8 +418,7 @@ namespace Drill4dotNet
     // Gets a PackagesPrefixes object from json.
     static void from_json(const nlohmann::json& source, PackagesPrefixes& target)
     {
-        std::vector<std::string> packagesPrefixes{};
-        source.at("packagesPrefixes").get_to(packagesPrefixes);
+        std::vector<std::string> packagesPrefixes { source.at("packagesPrefixes").get<std::vector<std::string>>() };
         target.packagesPrefixes.clear();
         target.packagesPrefixes.reserve(packagesPrefixes.size());
         for (const auto& item : packagesPrefixes)

--- a/Drill4dotNet/Connector/ConnectorImplementation.h
+++ b/Drill4dotNet/Connector/ConnectorImplementation.h
@@ -679,6 +679,62 @@ namespace Drill4dotNet
         source.at("ts").get_to(target.ts);
     }
 
+    // Converts a ScopeInitialized object to json format.
+    static void to_json(nlohmann::json& target, const ScopeInitialized& data)
+    {
+        target = nlohmann::json {
+            { "type", data.type },
+            { "id", EncodeUtf8(data.id) },
+            { "name", EncodeUtf8(data.name) },
+            { "prevId", EncodeUtf8(data.prevId) },
+            { "ts", data.ts }
+        };
+    }
+
+    // Gets a ScopeInitialized object from json.
+    static void from_json(const nlohmann::json& source, ScopeInitialized& target)
+    {
+        source.at("type").get_to(target.type);
+        target.id = DecodeUtf8(source.at("id").get<std::string>());
+        target.name = DecodeUtf8(source.at("name").get<std::string>());
+        target.prevId = DecodeUtf8(source.at("prevId").get<std::string>());
+        source.at("ts").get_to(target.ts);
+    }
+
+    // Converts a InitScopePayload object to json format.
+    static void to_json(nlohmann::json& target, const InitScopePayload& data)
+    {
+        target = nlohmann::json {
+            { "id", EncodeUtf8(data.id) },
+            { "name", EncodeUtf8(data.name) },
+            { "prevId", EncodeUtf8(data.prevId) }
+        };
+    }
+
+    // Gets a InitScopePayload object from json.
+    static void from_json(const nlohmann::json& source, InitScopePayload& target)
+    {
+        target.id = DecodeUtf8(source.at("id").get<std::string>());
+        target.name = DecodeUtf8(source.at("name").get<std::string>());
+        target.prevId = DecodeUtf8(source.at("prevId").get<std::string>());
+    }
+
+    // Converts a InitActiveScope object to json format.
+    static void to_json(nlohmann::json& target, const InitActiveScope& data)
+    {
+        target = nlohmann::json {
+            { "type", data.type },
+            { "payload", data.payload }
+        };
+    }
+
+    // Gets a InitActiveScope object from json.
+    static void from_json(const nlohmann::json& source, InitActiveScope& target)
+    {
+        source.at("type").get_to(target.type);
+        source.at("payload").get_to(target.payload);
+    }
+
     static int64_t GetCurrentTimeMillis()
     {
         const std::chrono::system_clock::time_point now {
@@ -795,6 +851,19 @@ namespace Drill4dotNet
                         s_connector->SendPluginMessage(
                             "test2code",
                             stopMessage.dump());
+                    }
+                    else if (discriminator == InitActiveScope::Discriminator)
+                    {
+                        InitActiveScope init { messageText.get<decltype(init)>() };
+                        nlohmann::json initMessage = ScopeInitialized {
+                            init.payload.id,
+                            init.payload.name,
+                            init.payload.prevId,
+                            GetCurrentTimeMillis() };
+
+                        s_connector->SendPluginMessage(
+                            "test2code",
+                            initMessage.dump());
                     }
                 }
             }

--- a/Drill4dotNet/Connector/ConnectorImplementation.h
+++ b/Drill4dotNet/Connector/ConnectorImplementation.h
@@ -427,6 +427,22 @@ namespace Drill4dotNet
         }
     }
 
+    // Converts a PluginAction object to json format.
+    static void to_json(nlohmann::json& target, const PluginAction& data)
+    {
+        target = nlohmann::json {
+            { "id", EncodeUtf8(data.id) },
+            { "message", EncodeUtf8(data.message) }
+        };
+    }
+
+    // Gets a PluginAction object from json.
+    static void from_json(const nlohmann::json& source, PluginAction& target)
+    {
+        target.id = DecodeUtf8(source.at("id").get<std::string>());
+        target.message = DecodeUtf8(source.at("message").get<std::string>());
+    }
+
     // Converts a SessionPayload object to json format.
     static void to_json(nlohmann::json& target, const SessionPayload& data)
     {
@@ -487,6 +503,202 @@ namespace Drill4dotNet
         source.at("payload").get_to(target.payload);
     }
 
+    // Converts a StartSessionPayload object to json format.
+    static void to_json(nlohmann::json& target, const StartSessionPayload& data)
+    {
+        target = nlohmann::json {
+            { "sessionId", EncodeUtf8(data.sessionId) },
+            { "startPayload", data.startPayload }
+        };
+    }
+
+    // Gets a StartSessionPayload object from json.
+    static void from_json(const nlohmann::json& source, StartSessionPayload& target)
+    {
+        target.sessionId = DecodeUtf8(source.at("sessionId").get<std::string>());
+        source.at("startPayload").get_to(target.startPayload);
+    }
+
+    // Converts a StartSession object to json format.
+    static void to_json(nlohmann::json& target, const StartSession& data)
+    {
+        target = nlohmann::json {
+            { "type", data.type },
+            { "payload", data.payload }
+        };
+    }
+
+    // Gets a StartSession object from json.
+    static void from_json(const nlohmann::json& source, StartSession& target)
+    {
+        source.at("type").get_to(target.type);
+        source.at("payload").get_to(target.payload);
+    }
+
+    // Converts a SessionStarted object to json format.
+    static void to_json(nlohmann::json& target, const SessionStarted& data)
+    {
+        target = nlohmann::json {
+            { "type", data.type },
+            { "sessionId", EncodeUtf8(data.sessionId) },
+            { "testType", EncodeUtf8(data.testType) },
+            { "ts", data.ts }
+        };
+    }
+
+    // Gets a SessionStarted object from json.
+    static void from_json(const nlohmann::json& source, SessionStarted& target)
+    {
+        source.at("type").get_to(target.type);
+        target.sessionId = DecodeUtf8(source.at("sessionId").get<std::string>());
+        target.testType = DecodeUtf8(source.at("testType").get<std::string>());
+        source.at("ts").get_to(target.ts);
+    }
+
+    // Converts a SessionCancelled object to json format.
+    static void to_json(nlohmann::json& target, const SessionCancelled& data)
+    {
+        target = nlohmann::json {
+            { "type", data.type },
+            { "sessionId", EncodeUtf8(data.sessionId) },
+            { "ts", data.ts}
+        };
+    }
+
+    // Gets a SessionCancelled object from json.
+    static void from_json(const nlohmann::json& source, SessionCancelled& target)
+    {
+        source.at("type").get_to(target.type);
+        target.sessionId = DecodeUtf8(source.at("sessionId").get<std::string>());
+        source.at("ts").get_to(target.ts);
+    }
+
+    // Converts a AllSessionsCancelled object to json format.
+    static void to_json(nlohmann::json& target, const AllSessionsCancelled& data)
+    {
+        std::vector<std::string> ids{};
+        ids.reserve(data.ids.size());
+        for (const auto& id : data.ids)
+        {
+            ids.push_back(EncodeUtf8(id));
+        }
+
+        target = nlohmann::json {
+            { "type", data.type },
+            { "ids", ids },
+            { "ts", data.ts}
+        };
+    }
+
+    // Gets a AllSessionsCancelled object from json.
+    static void from_json(const nlohmann::json& source, AllSessionsCancelled& target)
+    {
+        source.at("type").get_to(target.type);
+        std::vector<std::string> ids { source.at("ids").get<decltype(ids)>() };
+        target.ids.clear();
+        target.ids.reserve(ids.size());
+        for (const auto& id : ids)
+        {
+            target.ids.push_back(DecodeUtf8(id));
+        }
+
+        source.at("ts").get_to(target.ts);
+    }
+
+    // Converts a ExecClassData object to json format.
+    static void to_json(nlohmann::json& target, const ExecClassData& data)
+    {
+        target = nlohmann::json {
+            { "id", data.id },
+            { "className", EncodeUtf8(data.className) },
+            { "probes", data.probes },
+            { "testName", EncodeUtf8(data.testName) }
+        };
+    }
+
+    // Gets a ExecClassData object from json.
+    static void from_json(const nlohmann::json& source, ExecClassData& target)
+    {
+        source.at("id").get_to(target.id);
+        target.className = DecodeUtf8(source.at("className").get<std::string>());
+        source.at("probes").get_to(target.probes);
+        target.testName = DecodeUtf8(source.at("testName").get<std::string>());
+    }
+
+    // Converts a CoverDataPart object to json format.
+    static void to_json(nlohmann::json& target, const CoverDataPart& data)
+    {
+        target = nlohmann::json {
+            { "type", data.type },
+            { "sessionId", EncodeUtf8(data.sessionId) },
+            { "data", data.data }
+        };
+    }
+
+    // Gets a CoverDataPart object from json.
+    static void from_json(const nlohmann::json& source, CoverDataPart& target)
+    {
+        source.at("type").get_to(target.type);
+        target.sessionId = DecodeUtf8(source.at("sessionId").get<std::string>());
+        source.at("data").get_to(target.data);
+    }
+
+    // Converts a SessionChanged object to json format.
+    static void to_json(nlohmann::json& target, const SessionChanged& data)
+    {
+        target = nlohmann::json {
+            { "type", data.type },
+            { "sessionId", EncodeUtf8(data.sessionId) },
+            { "probeCount", data.probeCount }
+        };
+    }
+
+    // Gets a SessionChanged object from json.
+    static void from_json(const nlohmann::json& source, SessionChanged& target)
+    {
+        source.at("type").get_to(target.type);
+        target.sessionId = DecodeUtf8(source.at("sessionId").get<std::string>());
+        source.at("probeCount").get_to(target.probeCount);
+    }
+
+    // Converts a SessionFinished object to json format.
+    static void to_json(nlohmann::json& target, const SessionFinished& data)
+    {
+        target = nlohmann::json {
+            { "type", data.type },
+            { "sessionId", EncodeUtf8(data.sessionId) },
+            { "ts", data.ts }
+        };
+    }
+
+    // Gets a SessionFinished object from json.
+    static void from_json(const nlohmann::json& source, SessionFinished& target)
+    {
+        source.at("type").get_to(target.type);
+        target.sessionId = DecodeUtf8(source.at("sessionId").get<std::string>());
+        source.at("ts").get_to(target.ts);
+    }
+
+    static int64_t GetCurrentTimeMillis()
+    {
+        const std::chrono::system_clock::time_point now {
+            std::chrono::system_clock::now() };
+
+        std::tm zero {
+           .tm_sec = 0,
+           .tm_min = 0,
+           .tm_hour = 0,
+           .tm_mday = 1,
+           .tm_mon = 0,
+           .tm_year = 1970 - 1900 };
+
+        std::chrono::system_clock::time_point zeroPoint {
+            std::chrono::system_clock::from_time_t(
+                mktime(&zero)) };
+        return std::chrono::duration_cast<std::chrono::milliseconds>(
+            now - zeroPoint).count();
+    }
+
     template <
         IsTreeProvider TreeProvider,
         IsPackagesPrefixesHandler PackagesPrefixesHandler>
@@ -540,6 +752,50 @@ namespace Drill4dotNet
                 else if (std::string { "/agent/set-packages-prefixes" } == destination)
                 {
                     s_connector->m_packagesPrefixesHandler(nlohmann::json::parse(message).get<PackagesPrefixes>());
+                }
+                else if (std::string { "/plugin/action" } == destination)
+                {
+                    PluginAction wrapper { nlohmann::json::parse(message).get<PluginAction>() };
+                    nlohmann::json messageText { nlohmann::json::parse(wrapper.message) };
+                    std::string discriminator { messageText.at("type").get<std::string>() };
+                    if (discriminator == StartSession::Discriminator)
+                    {
+                        StartSession startSession { messageText.get<StartSession>() };
+                        nlohmann::json startMessage = SessionStarted {
+                            startSession.payload.startPayload.sessionId,
+                            startSession.payload.startPayload.testType,
+                            GetCurrentTimeMillis() };
+                        s_connector->SendPluginMessage(
+                            "test2code",
+                            startMessage.dump());
+                    }
+                    else if (discriminator == StopSession::Discriminator)
+                    {
+                        StopSession stopSession{ messageText.get<StopSession>() };
+                        nlohmann::json coverageDataPart = CoverDataPart{
+                            stopSession.payload.sessionId,
+                            std::vector{
+                                ExecClassData{
+                                    .id = 0,
+                                    .className = L"my_path/my_name",
+                                    .probes = { true },
+                                    .testName = L"my_test"
+                                }
+                            }
+                        };
+
+                        s_connector->SendPluginMessage(
+                            "test2code",
+                            coverageDataPart.dump());
+
+                        nlohmann::json stopMessage = SessionFinished {
+                            stopSession.payload.sessionId,
+                            GetCurrentTimeMillis() };
+
+                        s_connector->SendPluginMessage(
+                            "test2code",
+                            stopMessage.dump());
+                    }
                 }
             }
         }

--- a/Drill4dotNet/Connector/main.cpp
+++ b/Drill4dotNet/Connector/main.cpp
@@ -6,6 +6,24 @@
 #include <thread>
 #include <atomic>
 
+#include <curl/curl.h>
+
+size_t curlWriteFunc(
+    char* data,
+    size_t size,
+    size_t nmemb,
+    void* buffer)
+{
+    const size_t result { size * nmemb };
+    if (std::string* const output { static_cast<decltype(output)>(buffer) }
+        ; output != nullptr)
+    {
+        output->append(data, result);
+    }
+
+    return result;
+}
+
 int main(int argc, char** argv)
 {
     using namespace Drill4dotNet;
@@ -50,6 +68,218 @@ int main(int argc, char** argv)
         };
 
         connector.InitializeAgent();
+        std::this_thread::sleep_for(std::chrono::seconds(16));
+
+        {
+            curl_global_init(CURL_GLOBAL_ALL);
+
+            {
+                if (CURL* curl { curl_easy_init() }
+                    ; curl != nullptr)
+                {
+                    std::array<char, CURL_ERROR_SIZE> errorBuffer{};
+                    curl_easy_setopt(
+                        curl,
+                        CURLOPT_ERRORBUFFER,
+                        errorBuffer.data());
+
+                    curl_easy_setopt(
+                        curl,
+                        CURLOPT_USERAGENT,
+                        "Drill");
+
+                    curl_easy_setopt(
+                        curl,
+                        CURLOPT_FOLLOWLOCATION,
+                        true);
+
+                    curl_easy_setopt(
+                        curl,
+                        CURLOPT_NOPROGRESS,
+                        true);
+
+                    curl_easy_setopt(
+                        curl,
+                        CURLOPT_MAXREDIRS,
+                        50L);
+
+                    curl_easy_setopt(
+                        curl,
+                        CURLOPT_COOKIEFILE,
+                        "");
+
+                    curl_easy_setopt(
+                        curl,
+                        CURLOPT_NOSIGNAL,
+                        true);
+
+                    curl_easy_setopt(
+                        curl,
+                        CURLOPT_TCP_KEEPALIVE,
+                        true);
+
+                    curl_easy_setopt(
+                        curl,
+                        CURLOPT_ACCEPT_ENCODING,
+                        "");
+
+                    curl_easy_setopt(
+                        curl,
+                        CURLOPT_POST,
+                        true);
+
+                    curl_easy_setopt(
+                        curl,
+                        CURLOPT_URL,
+                        "http://localhost:8090/api/login");
+
+                    curl_easy_setopt(
+                        curl,
+                        CURLOPT_POSTFIELDS,
+                        "");
+
+                    curl_easy_setopt(
+                        curl,
+                        CURLOPT_WRITEDATA,
+                        nullptr);
+
+                    std::string header;
+                    curl_easy_setopt(
+                        curl,
+                        CURLOPT_HEADERDATA,
+                        &header);
+
+                    curl_easy_setopt(
+                        curl,
+                        CURLOPT_WRITEFUNCTION,
+                        curlWriteFunc);
+
+                    CURLcode curlResult = curl_easy_perform(curl);
+
+                    if (curlResult == CURLcode::CURLE_OK)
+                    {
+                        long responseCode;
+                        curl_easy_getinfo(
+                            curl,
+                            CURLINFO_RESPONSE_CODE,
+                            &responseCode);
+
+                        std::wcout
+                            << responseCode
+                            << std::endl;
+
+                        std::optional<std::string> authentication;
+                        if (responseCode == 200)
+                        {
+                            std::istringstream headerData(std::move(header));
+                            std::string line{};
+                            const char authorizationKey[] { "Authorization: " };
+                            while (std::getline(headerData, line))
+                            {
+                                if (line.starts_with(authorizationKey))
+                                {
+                                    authentication.emplace(std::move(line));
+                                    authentication->insert(
+                                        std::extent_v<decltype(authorizationKey)> - 1,
+                                        "Bearer ");
+                                    break;
+                                }
+                            }
+
+                            std::cout << *authentication;
+                            if (authentication.has_value())
+                            {
+                                curl_easy_setopt(
+                                    curl,
+                                    CURLOPT_URL,
+                                    "http://localhost:8090/api/agents/mysuperAgent/plugins/test2code/dispatch-action");
+
+                                curl_slist* headerList { curl_slist_append(
+                                    curl_slist_append(nullptr, authentication->c_str()),
+                                    "Content-Type: application/json") };
+
+                                curl_easy_setopt(
+                                    curl,
+                                    CURLOPT_HTTPHEADER,
+                                    headerList);
+
+                                const nlohmann::json body = StartSessionHttpRequest {
+                                    StartPayload {
+                                        .testType = L"AUTO",
+                                        .sessionId = L"{6D2831ED-6A9D-42FB-9375-1ABFAAF81933}",
+                                    }
+                                };
+
+                                const std::string bodyMock { body.dump() };
+
+                                curl_easy_setopt(
+                                    curl,
+                                    CURLOPT_POSTFIELDSIZE_LARGE,
+                                    bodyMock.size());
+
+                                curl_easy_setopt(
+                                    curl,
+                                    CURLOPT_COPYPOSTFIELDS,
+                                    bodyMock.c_str());
+
+                                CURLcode curlResult2 = curl_easy_perform(curl);
+
+                                if (curlResult2 == CURLcode::CURLE_OK)
+                                {
+                                    long responseCode2;
+                                    curl_easy_getinfo(
+                                        curl,
+                                        CURLINFO_RESPONSE_CODE,
+                                        &responseCode2);
+
+                                    std::wcout
+                                        << responseCode2
+                                        << std::endl;
+
+                                    std::this_thread::sleep_for(std::chrono::seconds(32));
+
+                                    const nlohmann::json stopBody = StopSession {
+                                        SessionPayload {
+                                            L"{6D2831ED-6A9D-42FB-9375-1ABFAAF81933}" } };
+                                    const std::string stopBodyMock { stopBody.dump() };
+
+                                    curl_easy_setopt(
+                                        curl,
+                                        CURLOPT_POSTFIELDSIZE_LARGE,
+                                        stopBodyMock.size());
+
+                                    curl_easy_setopt(
+                                        curl,
+                                        CURLOPT_COPYPOSTFIELDS,
+                                        stopBodyMock.c_str());
+
+                                    CURLcode curlResult3 = curl_easy_perform(curl);
+
+                                    long responseCode3;
+                                    curl_easy_getinfo(
+                                        curl,
+                                        CURLINFO_RESPONSE_CODE,
+                                        &responseCode3);
+
+                                    std::wcout
+                                        << responseCode3
+                                        << std::endl;
+
+
+                                    curl_slist_free_all(headerList);
+                                }
+                            }
+                        }
+                    }
+
+                    curl_easy_cleanup(curl);
+                }
+            }
+
+            curl_global_cleanup();
+        }
+
+        std::this_thread::sleep_for(std::chrono::seconds(16));
         int x;
         std::cin >> x;
     }

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Note: You can run HelloWorld.csproj (set As StartUp Project) from the IDE and un
 Before the first build, run the following commands in the `dependencies\vcpkg` directory:
 ```
 bootstrap-vcpkg.bat
-vcpkg install nlohmann-json:x64-windows
+vcpkg install nlohmann-json:x64-windows curl:x64-windows
 ```
 
 # Running Drill dotNet agent


### PR DESCRIPTION
Work under EMPDJ-2793

- Refactor conversion from json to data objects related to tree passing
- Introduce HTTP requests to `dispatch-action` for session start and stop
- Handling of session start and stop requests
- Handling of `InitActiveScope`